### PR TITLE
CLDR-9980 Examples/checks for numericDateSeparator, timeSeparator

### DIFF
--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -2399,7 +2399,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -2088,7 +2088,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">‏/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -1602,7 +1602,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">-</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -1866,7 +1866,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -1963,7 +1963,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -2162,7 +2162,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -5238,7 +5238,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -2445,7 +2445,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -998,7 +998,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -4431,7 +4431,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -1831,7 +1831,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<numericSeparators>
 						<numericDateSeparator draft="provisional">/</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
+						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -2112,7 +2112,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<numericSeparators>
 						<numericDateSeparator draft="provisional">.</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
+						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -1870,7 +1870,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/doi.xml
+++ b/common/main/doi.xml
@@ -473,7 +473,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ee.xml
+++ b/common/main/ee.xml
@@ -1580,7 +1580,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -2290,7 +2290,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -2121,7 +2121,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">-</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -1795,7 +1795,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -1802,7 +1802,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -2236,7 +2236,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -2188,8 +2188,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -2605,8 +2605,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -3258,7 +3258,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -2140,7 +2140,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">-</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -2102,7 +2102,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -1739,7 +1739,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -2131,7 +2131,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -2819,7 +2819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/hi_Latn.xml
+++ b/common/main/hi_Latn.xml
@@ -2188,7 +2188,7 @@ annotations.
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -1744,8 +1744,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -3101,8 +3101,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -2712,7 +2712,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -3110,7 +3110,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -2205,7 +2205,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -1718,7 +1718,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -3078,7 +3078,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -1505,7 +1505,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ks_Deva.xml
+++ b/common/main/ks_Deva.xml
@@ -468,7 +468,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -2397,7 +2397,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -2045,7 +2045,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -1459,7 +1459,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/mi.xml
+++ b/common/main/mi.xml
@@ -1519,7 +1519,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">-</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -2443,7 +2443,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -2557,7 +2557,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -2203,7 +2203,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/mni.xml
+++ b/common/main/mni.xml
@@ -437,7 +437,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -2151,7 +2151,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -2708,7 +2708,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -1713,7 +1713,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -5346,7 +5346,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">-</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -4899,7 +4899,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/om.xml
+++ b/common/main/om.xml
@@ -1139,7 +1139,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -1952,7 +1952,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -1581,7 +1581,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -2252,7 +2252,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -2018,7 +2018,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/raj.xml
+++ b/common/main/raj.xml
@@ -119,7 +119,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">-</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<availableFormats>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -2420,7 +2420,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/sa.xml
+++ b/common/main/sa.xml
@@ -534,7 +534,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/sd_Deva.xml
+++ b/common/main/sd_Deva.xml
@@ -430,7 +430,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -1691,7 +1691,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<numericSeparators>
 						<numericDateSeparator draft="provisional">-</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
+						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -2212,7 +2212,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -3602,7 +3602,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -2010,7 +2010,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/su.xml
+++ b/common/main/su.xml
@@ -459,8 +459,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
-						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericTimeSeparator draft="provisional">.</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -2980,7 +2980,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">-</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -1764,7 +1764,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -2232,7 +2232,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -2987,7 +2987,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -1817,7 +1817,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">.</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -1642,7 +1642,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -2320,7 +2320,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -1345,7 +1345,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -2236,7 +2236,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">/</numericDateSeparator>
+						<numericDateSeparator draft="provisional">.</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -1884,7 +1884,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -3079,7 +3079,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -5116,7 +5116,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<numericDateSeparator draft="provisional">-</numericDateSeparator>
+						<numericDateSeparator draft="provisional">/</numericDateSeparator>
 						<numericTimeSeparator draft="provisional">:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -933,7 +933,8 @@ public abstract class CheckCLDR implements CheckAccessor {
             inconsistentCoreDatePattern,
             inconsistentCurrencyPattern,
             inconsistentCompactPattern,
-            inconsistentPositiveAndNegativePatterns;
+            inconsistentPositiveAndNegativePatterns,
+            dateTimeSeparatorMismatch;
 
             @Override
             public String toString() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -601,7 +601,8 @@ public class CheckDates extends FactoryCheckCLDR {
                                     .setMainType(CheckStatus.errorType)
                                     .setSubtype(Subtype.dateTimeSeparatorMismatch)
                                     .setMessage(
-                                            "{0}\tmismatch with\t{1}",
+                                            "@{0}@ {1}\tmismatch with\t{2}",
+                                            separatorToPaths.keySet().iterator().next(),
                                             separatorToPaths.keySet().size(),
                                             separatorToPaths.toString()));
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -54,7 +54,6 @@ import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LogicalGrouping;
-import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.PreferredAndAllowedHour;
@@ -584,8 +583,9 @@ public class CheckDates extends FactoryCheckCLDR {
             DateTimePatternType dateTypePatternType = DateTimePatternType.fromPath(path);
             if (dateTypePatternType == DateTimePatternType.SEPARATOR) {
                 String calendar = parts.getAttributeValue(3, "type");
-                Multimap<String, Pair<String, String>> separatorToPaths = TreeMultimap.create();
-                if (parts.containsElement("numericDateSeparator")) {
+                Multimap<String, String> separatorToPaths = TreeMultimap.create();
+                boolean isDate = parts.containsElement("numericDateSeparator");
+                if (isDate) {
                     getNumericSeparator(separatorToPaths, calendar, "date-short");
                     getNumericSeparator(separatorToPaths, calendar, "yMd");
                 } else { //  (parts.containsElement("numericTimeSeparator"))
@@ -593,18 +593,21 @@ public class CheckDates extends FactoryCheckCLDR {
                     getNumericSeparator(separatorToPaths, calendar, "Hms");
                     getNumericSeparator(separatorToPaths, calendar, "hms");
                 }
-                Collection<Pair<String, String>> pairs = separatorToPaths.get(value);
+                Collection<String> pairs = separatorToPaths.get(value);
                 if (pairs.isEmpty()) {
+                    CheckStatus.Type errorType =
+                            !isDate && getLocaleID().equals("fr_CA")
+                                    ? CheckStatus.warningType
+                                    : CheckStatus.errorType;
                     result.add(
                             new CheckStatus()
                                     .setCause(this)
-                                    .setMainType(CheckStatus.errorType)
+                                    .setMainType(errorType)
                                     .setSubtype(Subtype.dateTimeSeparatorMismatch)
                                     .setMessage(
-                                            "@{0}@ {1}\tmismatch with\t{2}",
-                                            separatorToPaths.keySet().iterator().next(),
-                                            separatorToPaths.keySet().size(),
-                                            separatorToPaths.toString()));
+                                            "Mismatch with {0}, see: {1}",
+                                            separatorToPaths.keySet().toString(),
+                                            Set.copyOf(separatorToPaths.values())));
                 }
             } else if (DateTimePatternType.STOCK_AVAILABLE_INTERVAL_PATTERNS.contains(
                     dateTypePatternType)) {
@@ -722,9 +725,7 @@ public class CheckDates extends FactoryCheckCLDR {
             ImmutableSet.of(FieldType.HOUR, FieldType.MINUTE, FieldType.SECOND);
 
     private void getNumericSeparator(
-            Multimap<String, Pair<String, String>> separatorToPathValue,
-            String calendar,
-            String idOrStock) {
+            Multimap<String, String> separatorToPathValue, String calendar, String idOrStock) {
         String xpath = CldrPathUtilities.dateTypePattern(calendar, idOrStock);
         String winningValue = getCldrFileToCheck().getWinningValue(xpath);
         if (winningValue == null) {
@@ -742,8 +743,17 @@ public class CheckDates extends FactoryCheckCLDR {
                     && element.isNumeric()) {
                 if (HMS.contains(preLast.getType()) && HMS.contains(element.getType())
                         || YMD.contains(preLast.getType()) && YMD.contains(element.getType())) {
+
+                    // Make an abbreviated header+code string to indicate the origin.
+                    // Ideally we would have a link on it to the path.
+                    PathHeader ph = PathHeader.getFactory().fromPath(xpath);
+                    String header = ph.getHeader();
+                    int lastHyphen = header.lastIndexOf('-');
+                    header = lastHyphen < 0 ? header : header.substring(lastHyphen + 1).trim();
+                    header += " | " + ph.getCode();
+
                     separatorToPathValue.put(
-                            last.toString(), Pair.of(winningValue, calendar + ":" + idOrStock));
+                            last.toString().trim(), header + " → «" + winningValue + "»");
                 }
             }
             preLast = last;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -3,6 +3,8 @@ package org.unicode.cldr.test;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.text.DateIntervalInfo;
@@ -37,8 +39,12 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRURLS;
+import org.unicode.cldr.util.CldrPathUtilities;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.DateTimeCanonicalizer.DateTimePatternType;
+import org.unicode.cldr.util.DatetimeUtilities;
+import org.unicode.cldr.util.DatetimeUtilities.FieldType;
+import org.unicode.cldr.util.DatetimeUtilities.PatternElement;
 import org.unicode.cldr.util.DayPeriodInfo;
 import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
 import org.unicode.cldr.util.DayPeriodInfo.Type;
@@ -48,6 +54,7 @@ import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LogicalGrouping;
+import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.PreferredAndAllowedHour;
@@ -575,7 +582,30 @@ public class CheckDates extends FactoryCheckCLDR {
                 result.add(checkStatus);
             }
             DateTimePatternType dateTypePatternType = DateTimePatternType.fromPath(path);
-            if (DateTimePatternType.STOCK_AVAILABLE_INTERVAL_PATTERNS.contains(
+            if (dateTypePatternType == DateTimePatternType.SEPARATOR) {
+                String calendar = parts.getAttributeValue(3, "type");
+                Multimap<String, Pair<String, String>> separatorToPaths = TreeMultimap.create();
+                if (parts.containsElement("numericDateSeparator")) {
+                    getNumericSeparator(separatorToPaths, calendar, "date-short");
+                    getNumericSeparator(separatorToPaths, calendar, "yMd");
+                } else { //  (parts.containsElement("numericTimeSeparator"))
+                    getNumericSeparator(separatorToPaths, calendar, "time-short");
+                    getNumericSeparator(separatorToPaths, calendar, "Hms");
+                    getNumericSeparator(separatorToPaths, calendar, "hms");
+                }
+                Collection<Pair<String, String>> pairs = separatorToPaths.get(value);
+                if (pairs.isEmpty()) {
+                    result.add(
+                            new CheckStatus()
+                                    .setCause(this)
+                                    .setMainType(CheckStatus.errorType)
+                                    .setSubtype(Subtype.dateTimeSeparatorMismatch)
+                                    .setMessage(
+                                            "{0}\tmismatch with\t{1}",
+                                            separatorToPaths.keySet().size(),
+                                            separatorToPaths.toString()));
+                }
+            } else if (DateTimePatternType.STOCK_AVAILABLE_INTERVAL_PATTERNS.contains(
                     dateTypePatternType)) {
                 boolean patternBasicallyOk = false;
                 try {
@@ -683,6 +713,41 @@ public class CheckDates extends FactoryCheckCLDR {
             }
         }
         return this;
+    }
+
+    static final Set<FieldType> YMD =
+            ImmutableSet.of(FieldType.YEAR, FieldType.MONTH, FieldType.DAY_OF_MONTH);
+    static final Set<FieldType> HMS =
+            ImmutableSet.of(FieldType.HOUR, FieldType.MINUTE, FieldType.SECOND);
+
+    private void getNumericSeparator(
+            Multimap<String, Pair<String, String>> separatorToPathValue,
+            String calendar,
+            String idOrStock) {
+        String xpath = CldrPathUtilities.dateTypePattern(calendar, idOrStock);
+        String winningValue = getCldrFileToCheck().getWinningValue(xpath);
+        if (winningValue == null) {
+            return;
+        }
+        List<PatternElement> elements =
+                DatetimeUtilities.getPatternElementsWithLiterals(winningValue);
+        PatternElement preLast = null;
+        PatternElement last = null;
+        for (PatternElement element : elements) {
+            if (preLast != null
+                    && last != null
+                    && preLast.isNumeric()
+                    && last.getType() == FieldType.LITERAL
+                    && element.isNumeric()) {
+                if (HMS.contains(preLast.getType()) && HMS.contains(element.getType())
+                        || YMD.contains(preLast.getType()) && YMD.contains(element.getType())) {
+                    separatorToPathValue.put(
+                            last.toString(), Pair.of(winningValue, calendar + ":" + idOrStock));
+                }
+            }
+            preLast = last;
+            last = element;
+        }
     }
 
     private static final Pattern datePatternDoesntEndsWithDigits =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrPathUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrPathUtilities.java
@@ -16,4 +16,39 @@ public class CldrPathUtilities {
                 + ordinal
                 + "\"]";
     }
+
+    public static String stockDatetime(String calendar, String dateVsTime, String width) {
+        return "//ldml/dates/calendars/calendar[@type=\""
+                + calendar
+                + "\"]/"
+                + dateVsTime
+                + "Formats/"
+                + dateVsTime
+                + "FormatLength[@type=\""
+                + width
+                + "\"]/"
+                + dateVsTime
+                + "Format[@type=\"standard\"]/pattern[@type=\"standard\"]";
+    }
+
+    public static String availableFormat(String calendar, String id) {
+        return "//ldml/dates/calendars/calendar[@type=\""
+                + calendar
+                + "\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\""
+                + id
+                + "\"]";
+    }
+
+    /**
+     * Return a pattern; if the id is like date-width, it is a stock pattern. Otherwise it is an
+     * available ID.
+     */
+    public static String dateTypePattern(String calendar, String id) {
+        int stock = id.indexOf('-');
+        if (stock < 0) {
+            return availableFormat(calendar, id);
+        } else {
+            return stockDatetime(calendar, id.substring(0, stock), id.substring(stock + 1));
+        }
+    }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeCanonicalizer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeCanonicalizer.java
@@ -14,7 +14,10 @@ public class DateTimeCanonicalizer {
         STOCK,
         AVAILABLE,
         INTERVAL,
-        GMT;
+        GMT,
+        SEPARATOR;
+
+        // //ldml/dates/calendars/calendar[@type="generic"]/dateTimeFormats/numericSeparators/numericDateSeparator
 
         public static final Set<DateTimePatternType> STOCK_AVAILABLE_INTERVAL_PATTERNS =
                 Collections.unmodifiableSet(
@@ -26,18 +29,20 @@ public class DateTimeCanonicalizer {
         public static DateTimePatternType fromPath(String path) {
             return !path.contains("/dates")
                     ? DateTimePatternType.NA
-                    : path.contains("/pattern")
-                                    && (path.contains("/dateFormats")
-                                            || path.contains("/timeFormats")
-                                            || path.contains("/dateTimeFormatLength"))
-                            ? DateTimePatternType.STOCK
-                            : path.contains("/dateFormatItem")
-                                    ? DateTimePatternType.AVAILABLE
-                                    : path.contains("/intervalFormatItem")
-                                            ? DateTimePatternType.INTERVAL
-                                            : path.contains("/timeZoneNames/hourFormat")
-                                                    ? DateTimePatternType.GMT
-                                                    : DateTimePatternType.NA;
+                    : path.contains("/numericSeparators")
+                            ? DateTimePatternType.SEPARATOR
+                            : path.contains("/pattern")
+                                            && (path.contains("/dateFormats")
+                                                    || path.contains("/timeFormats")
+                                                    || path.contains("/dateTimeFormatLength"))
+                                    ? DateTimePatternType.STOCK
+                                    : path.contains("/dateFormatItem")
+                                            ? DateTimePatternType.AVAILABLE
+                                            : path.contains("/intervalFormatItem")
+                                                    ? DateTimePatternType.INTERVAL
+                                                    : path.contains("/timeZoneNames/hourFormat")
+                                                            ? DateTimePatternType.GMT
+                                                            : DateTimePatternType.NA;
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DatetimeUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DatetimeUtilities.java
@@ -740,21 +740,59 @@ public class DatetimeUtilities extends TestFmwk {
         return result;
     }
 
-    /** Clean replacement for VariableField */
+    public enum FieldType {
+        ERA,
+        YEAR,
+        QUARTER,
+        MONTH,
+        WEEK_OF_YEAR,
+        WEEK_OF_MONTH,
+        WEEKDAY,
+        DAY_OF_MONTH,
+        DAY_OF_YEAR,
+        DAY_OF_WEEK_IN_MONTH,
+        DAYPERIOD,
+        HOUR,
+        MINUTE,
+        SECOND,
+        FRACTIONAL_SECOND,
+        ZONE,
+        LITERAL;
+        public static final List<FieldType> ALL = List.copyOf(Arrays.asList(values()));
+
+        public static FieldType fromVariableFieldType(int type) {
+            return ALL.get(type);
+        }
+    }
+
+    /** Cleaner replacement for VariableField */
     public static final class PatternElement implements Comparable<PatternElement> {
         private final String element;
-        private final int type;
+        private final FieldType type;
         private final boolean numeric;
 
-        private PatternElement(String element, int type, boolean numeric) {
+        public FieldType getType() {
+            return type;
+        }
+
+        public boolean isNumeric() {
+            return numeric;
+        }
+
+        private PatternElement(String element, FieldType type, boolean numeric) {
             this.element = element;
             this.type = type; // determined by the element
             this.numeric = numeric; // determined by the element
         }
 
         @SuppressWarnings("deprecation")
-        public static PatternElement from(VariableField vf) {
-            return new PatternElement(vf.toString(), vf.getType(), vf.isNumeric());
+        public static PatternElement from(Object stringOrVf) {
+            if (stringOrVf instanceof String) {
+                return new PatternElement((String) stringOrVf, FieldType.LITERAL, false);
+            }
+            VariableField vf = (VariableField) stringOrVf;
+            return new PatternElement(
+                    vf.toString(), FieldType.fromVariableFieldType(vf.getType()), vf.isNumeric());
         }
 
         @SuppressWarnings("deprecation")
@@ -807,7 +845,7 @@ public class DatetimeUtilities extends TestFmwk {
                         Set<PatternElement> patternElements = getPatternElements(y);
                         List<Integer> sortKey = new ArrayList<>();
                         // We ensure that all of the integers are between 1..127 inclusive
-                        patternElements.stream().forEach(x -> sortKey.add(x.type + 1));
+                        patternElements.stream().forEach(x -> sortKey.add(x.type.ordinal() + 1));
                         sortKey.add(0);
                         patternElements.stream().forEach(x -> sortKey.add(x.numeric ? 1 : 2));
                         sortKey.add(0);
@@ -873,11 +911,19 @@ public class DatetimeUtilities extends TestFmwk {
                     FormatParser fp = new DateTimePatternGenerator.FormatParser();
                     fp.set(y);
                     return fp.getItems().stream()
-                            .map(x -> PatternElement.from((VariableField) x))
+                            .map(x -> PatternElement.from(x))
                             .collect(
                                     ImmutableSortedSet.toImmutableSortedSet(
                                             Comparator.naturalOrder()));
                 });
+    }
+
+    public static final List<PatternElement> getPatternElementsWithLiterals(String pattern) {
+        FormatParser fp = new DateTimePatternGenerator.FormatParser();
+        fp.set(pattern);
+        return fp.getItems().stream()
+                .map(x -> PatternElement.from(x))
+                .collect(Collectors.toUnmodifiableList());
     }
 
     // temporary for quick testing; needs to be removed and a test added

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,55 +1,87 @@
 #locale;	action	path	new_value
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtau"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtau"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtau"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtobe"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtobe"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtobe"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Almaty"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Almaty"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Almaty"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Guam"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Guam"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Guam"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Kizilorda"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Kizilorda"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Kizilorda"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Lanka"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Lanka"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Lanka"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Macau"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Macau"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Macau"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="North_Mariana"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="North_Mariana"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="North_Mariana"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Qyzylorda"]/long/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Qyzylorda"]/long/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Qyzylorda"]/long/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtau"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtau"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtau"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtobe"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtobe"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Aqtobe"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Almaty"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Almaty"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Almaty"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Guam"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Guam"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Guam"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Kizilorda"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Kizilorda"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Kizilorda"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Lanka"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Lanka"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Lanka"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Macau"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Macau"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Macau"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="North_Mariana"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="North_Mariana"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="North_Mariana"]/short/daylight
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Qyzylorda"]/short/generic
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Qyzylorda"]/short/standard
-locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Qyzylorda"]/short/daylight
+locale=am;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ar;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=‏/
+locale=as;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=-
+locale=az;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=bg;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=bn;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=bs;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=ca;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ceb;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=cs;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=cy;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=:
+locale=da;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=.
+locale=de_CH;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=doi;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ee;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=en_AU;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=en_CA;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=-
+locale=es_MX;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=es_US;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=et;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=fa;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=fa;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=:
+locale=fi;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=fi;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=.
+locale=fr_CA;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=-
+locale=fr;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ga;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=gl;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=gu;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=he;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=hi_Latn;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=hr;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=hu;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=hy;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=hy;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=:
+locale=id;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=id;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=.
+locale=is;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=ja;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=kk;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=km;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ko;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=ks_Deva;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ks;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=lo;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=lv;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=mai;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=mi;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=-
+locale=mk;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=ml;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=mn;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=mni;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=mr;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ms;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=my;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=nl;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=-
+locale=no;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=om;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=pa;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=pcm;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=pl;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=pt_PT;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=raj;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=-
+locale=ru;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=sa;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=sd_Deva;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=si;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=.
+locale=sk;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=sl;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=so;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=sr_Latn;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=sr;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=. 
+locale=su;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=su;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericTimeSeparator[@draft='provisional'];	new_value=.
+locale=sv;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=-
+locale=sw;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ta;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=th;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=ti;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=tk;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=tr;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=tt;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=uk;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=.
+locale=ur;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=vi;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/
+locale=zh_Hant_HK;	action=add;	new_path=//ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/numericSeparators/numericDateSeparator[@draft='provisional'];	new_value=/


### PR DESCRIPTION
CLDR-9980

The code for the test 
1. pulls in 'core' values: the short date and yMd patterns, and the short time, Hms, and hms patterns
2. Extracts numeric separators, looking for them in the patterns between certain numeric fields (eg only considers M or MM, not MMM or MMMM). 
    * yM, My, Md, dM, yd, dy for dates
    * hm, ms, Hm for times (those are monotonic-decreasing in all our data.
4. this is done with some updates to the DatetimeUtilities (a step towards modernization)
5. checks to see that the value for the corresponding numeric separator (date or time) is in the set of extracted separators
6. Emits an Check error if not.
    * Special exception for fr_CA time; that is a warning not an errorl.
7. This is run using ConsoleCheck, extracting the errors, and using those (with some modification) to create a modify_config file:
    * https://docs.google.com/spreadsheets/d/194TD8od1y7DZdnkNMESfkVT_L0bHSVu401Sg_seLeK0/edit?gid=409625540#gid=409625540
9. That is used to make changes in the data (still provisional) so that vetters don't have to deal with a batch of errors.
    * https://docs.google.com/spreadsheets/d/194TD8od1y7DZdnkNMESfkVT_L0bHSVu401Sg_seLeK0/edit?gid=2026585233#gid=2026585233

Note the error message provide an abbreviated reference to the source paths and their values, like
    * Warning: Mismatch with [h, min], see: [**Time Formats | short** → «HH 'h' mm», **24 Hour Time Formats | Hms** → «HH 'h' mm 'min' ss 's'», **12 Hour Time Formats | hms** → «h 'h' mm 'min' ss 's' a»]

I'd like to put html links on those, but have forgotten whether we can do HTML that in the generated messages or not.

Note: next step after this PR will be to modify ExampleGenerator to add examples. My idea is to use those same patterns, and substitute a character for the separator to show what effect a user option could have. Maybe ➖, to make it obvious.

I'm also thinking that we can use some of this code to check short numeric dates and times use consistent separators (maybe a warning on them).

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
10. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
11. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
