### PR TITLE
CLDR-9980 update numericSeparators to link to failing item

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -743,17 +743,11 @@ public class CheckDates extends FactoryCheckCLDR {
                     && element.isNumeric()) {
                 if (HMS.contains(preLast.getType()) && HMS.contains(element.getType())
                         || YMD.contains(preLast.getType()) && YMD.contains(element.getType())) {
-
-                    // Make an abbreviated header+code string to indicate the origin.
-                    // Ideally we would have a link on it to the path.
-                    PathHeader ph = PathHeader.getFactory().fromPath(xpath);
-                    String header = ph.getHeader();
-                    int lastHyphen = header.lastIndexOf('-');
-                    header = lastHyphen < 0 ? header : header.substring(lastHyphen + 1).trim();
-                    header += " | " + ph.getCode();
+                    final String link =
+                            FactoryCheckCLDR.getPathReferenceForMessage(getLocaleID(), xpath);
 
                     separatorToPathValue.put(
-                            last.toString().trim(), header + " → «" + winningValue + "»");
+                            last.toString().trim(), link + " → «" + winningValue + "»");
                 }
             }
             preLast = last;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/FactoryCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/FactoryCheckCLDR.java
@@ -63,22 +63,96 @@ abstract class FactoryCheckCLDR extends CheckCLDR {
         return factory;
     }
 
+    /**
+     * Return a reference for {@link #getMessage} that refers to an item.
+     *
+     * @param path the XPath
+     */
+    public String getPathReferenceForMessage(String path) {
+        return getPathReferenceForMessage(path, true);
+    }
+
+    /**
+     * Return a reference for {@link #getMessage} that refers to a header.
+     *
+     * @param path the XPath to any item in that header
+     */
+    public String getPathReferenceToHeaderForMessage(String path) {
+        return getPathReferenceForMessage(path, false);
+    }
+
+    /**
+     * Return a reference for {@link #getMessage} that refers to an item.
+     *
+     * <p>TODO CLDR-15428 this would be better handled as structured data in the CheckStatus.
+     *
+     * @param path the XPath
+     * @param codeOnly if true, refer to an item. If false, refer to the enclosing header.
+     */
     public String getPathReferenceForMessage(String path, boolean codeOnly) {
-        PathHeader pathHeader = getPathHeaderFactory().fromPath(path);
-        String referenceToOther;
-        String code = codeOnly ? pathHeader.getCode() : pathHeader.getHeaderCode();
-        if (getPhase() == Phase.FINAL_TESTING) {
-            referenceToOther = code; // later make this more readable.
-        } else {
-            referenceToOther =
-                    "<a href=\""
-                            + CLDRConfig.getInstance()
-                                    .urls()
-                                    .forPathHeader(getCldrFileToCheck().getLocaleID(), pathHeader)
-                            + "\">"
-                            + code
-                            + "</a>";
+        return renderPathReference(
+                getCldrFileToCheck().getLocaleID(), path, codeOnly, getPathHeaderFactory());
+    }
+
+    /**
+     * Return a reference for {@link #getMessage} that refers to an item.
+     *
+     * @param locale locale in question
+     * @param path the XPath
+     */
+    public static String getPathReferenceForMessage(String locale, String path) {
+        return getPathReferenceForMessage(locale, path, false);
+    }
+
+    /**
+     * Return a reference for {@link #getMessage} that refers to an enclosing header.
+     *
+     * @param locale locale in question
+     * @param path the XPath to an item
+     */
+    public static String getPathReferenceToHeaderForMessage(String locale, String path) {
+        return getPathReferenceForMessage(locale, path, true);
+    }
+
+    /**
+     * Return a reference for {@link #getMessage} that refers to an item.
+     *
+     * <p>Private, call this from {@link #getPathReferenceForMessage(String, String)} or {@link
+     * #getPathReferenceToHeaderForMessage(String, String)} instead.
+     *
+     * @param path the XPath
+     * @param codeOnly if true, refer to an item. If false, refer to the enclosing header.
+     */
+    private static String getPathReferenceForMessage(String locale, String path, boolean codeOnly) {
+        final PathHeader.Factory phf = PathHeader.getFactory();
+        return renderPathReference(locale, path, codeOnly, phf);
+    }
+
+    // TODO CLDR-15428: FINAL_TESTING may not be the right check.
+    /** true if to render pathReference as code (vs URL) */
+    private static final boolean renderPathReferenceAsCode =
+            CLDRConfig.getInstance().getPhase() == Phase.FINAL_TESTING;
+
+    /**
+     * Internal function to render, see {@link #getPathReferenceForMessage(String)} etc. TODO
+     * CLDR-15428 this would be better handled as structured data in the CheckStatus.
+     */
+    private static String renderPathReference(
+            String locale, String path, boolean codeOnly, final PathHeader.Factory phf) {
+        final PathHeader ph = phf.fromPath(path);
+        final String disp = codeOnly ? ph.getCode() : ph.getHeaderCode();
+
+        if (renderPathReferenceAsCode) {
+            return disp;
         }
-        return referenceToOther;
+
+        if (!ph.getSurveyToolStatus().visible()) {
+            // not visible, so don't show it as a URL.
+            return String.format(
+                    "<span class=\"pathReference deactivated\" title='Not Visible: %s'>%s</span>",
+                    path, disp);
+        }
+        final String url = CLDRConfig.getInstance().urls().forPathHeader(locale, ph);
+        return "<a class=\"pathReference\" href=\"" + url + "\">" + disp + "</a>";
     }
 }


### PR DESCRIPTION
- also, update FactoryCheckCLDR getPathReference machinery with better error checking and availability -  See CLDR-15428 for TODOs there.

CLDR-9980

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Example: (the dark unlinked item is suppressed)

<img width="367" height="116" alt="image" src="https://github.com/user-attachments/assets/d0cd35c2-327c-4844-9ec5-a84c3222f510" />


ALLOW_MANY_COMMITS=true
