### PR TITLE
CLDR-19394 Off/On: suppress 'ss/core'

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -175,7 +175,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageVariable key="%variantTypes" value="([A-Z0-9]++)"/>
 		<coverageVariable key="%wideAbbr" value="(wide|abbreviated)"/>
+		<!-- for typeValue -->
 		<coverageVariable key="%yesNo" value="(yes|no)"/>
+		<!-- keys that are applied to yesNo for core values. TODO CLDR-19394 should come from structure to be spec’d -->
+		<coverageVariable key="%yesNoKeys" value="(colAlternate|colBackwards|colCaseLevel|colNormalization|colNumeric|ss)" />
 
 		<coverageVariable key="%anyAttribute" value='([^\x{22}]++)'/>
 		<coverageVariable key="%A" value='([^\x{22}]++)'/>
@@ -1093,6 +1096,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="localeDisplayNames/scripts/script[@type='%script80'][@alt='%anyAttribute']"/>
 		<coverageLevel value="modern" match="localeDisplayNames/keys/key[@type='%anyAttribute']"/>
 		<coverageLevel inLanguage="pt" value="modern" match="localeDisplayNames/variants/variant[@type='%ptVariants']"/>
+		<!-- all of the %yesNoKeys are actually hidden, they will be constructed from typeValues. -->
+		<coverageLevel value="comprehensive" match="localeDisplayNames/types/type[@key='%yesNoKeys'][@type='%A'][@scope='core']"/>
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='collation'][@type='%collationType80'][@scope='%A']"/>
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='collation'][@type='%collationType80']"/>
 		<coverageLevel inLanguage="%collationType80TopLangs" value="modern" match="localeDisplayNames/types/type[@key='collation'][@type='%collationType80ForTopLangs'][@scope='%A']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -4206,7 +4206,7 @@ public class ExampleGenerator {
      * @param args
      * @return result or null
      */
-    final String getStringValue(final CLDRFile file, final String path, final String... args) {
+    final String getStringValue(final CLDRFile file, final String path, final Object... args) {
         return getStringValue(file, String.format(path, args));
     }
 
@@ -4219,7 +4219,7 @@ public class ExampleGenerator {
      * @param args
      * @return result or null
      */
-    final String getStringValue(final String path, final String... args) {
+    final String getStringValue(final String path, final Object... args) {
         return getStringValue(getCldrFile(), String.format(path, args));
     }
 
@@ -4232,12 +4232,17 @@ public class ExampleGenerator {
      * @param args
      * @return result or null
      */
-    final String getStringValueOrEnglish(final String path, final String... args) {
+    final String getStringValueOrEnglish(final String path, final Object... args) {
         final String currentVal = getStringValue(getCldrFile(), String.format(path, args));
         if (currentVal != null && !currentVal.isEmpty()) {
             return currentVal;
         }
-        return getEnglishStringValue(path, args);
+        final String eng = getEnglishStringValue(path, args);
+        if (eng != null) {
+            return "⟨" + eng + "⟩";
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -4248,7 +4253,7 @@ public class ExampleGenerator {
      * @param args
      * @return result or null
      */
-    final String getEnglishStringValue(final String path, String... args) {
+    final String getEnglishStringValue(final String path, Object... args) {
         return getStringValue(englishFile, String.format(path, args));
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -3840,32 +3841,42 @@ public class ExampleGenerator {
                 examples.add(combined);
             }
         } else if (parts.getElement(-1).equals("typeValue")) {
-            final String COL_ALTERNATE =
-                    "//ldml/localeDisplayNames/keys/key[@type=\"colAlternate\"]";
             String type = parts.getAttributeValue(-1, "type");
-            String exampleValue = getCldrFile().getStringValue(COL_ALTERNATE);
-            if (exampleValue == null || exampleValue.isEmpty()) {
-                exampleValue = englishFile.getStringValue(COL_ALTERNATE);
-            }
             if (YES_NO.contains(type)) {
+                final Collection<String> typeValueKeyStrings = getTypeValueKeyStrings();
                 for (final String t : YES_NO) {
-                    if (type.equals(t)) {
-                        examples.add(exampleValue + ": " + setBackground(value));
-                    } else {
-                        // show all others that are present
-                        String otherValue =
-                                getCldrFile()
-                                        .getStringValue(
-                                                "//ldml/localeDisplayNames/typeValues/typeValue[@type=\""
-                                                        + t
-                                                        + "\"]");
-                        if (otherValue != null && !otherValue.isEmpty()) {
-                            examples.add(exampleValue + ": " + otherValue);
+                    final String yesNo =
+                            type.equals(t)
+                                    ? setBackground(value)
+                                    : getStringValue(
+                                            "//ldml/localeDisplayNames/typeValues/typeValue[@type=\"%s\"]",
+                                            t);
+                    if (yesNo != null) {
+                        for (final String exampleValue : typeValueKeyStrings) {
+                            // SomeValue:  Off
+                            // SomeOtherValue: On
+                            examples.add(String.format("%s: %s", exampleValue, yesNo));
                         }
                     }
                 }
             }
         }
+    }
+
+    private static final String[] typeValueSampleTypes = {"colAlternate", "ss"};
+
+    /** Get some example strings to use with On/Off strings, such as "Ignore Symbols Sorting" */
+    private Collection<String> getTypeValueKeyStrings() {
+        final Set<String> strings = new TreeSet<>();
+        for (final String type : typeValueSampleTypes) {
+            String exampleValue =
+                    getStringValueOrEnglish(
+                            "//ldml/localeDisplayNames/keys/key[@type=\"%s\"]", type);
+            if (exampleValue != null) {
+                strings.add(exampleValue);
+            }
+        }
+        return strings;
     }
 
     private String formatExampleList(String[] examples) {
@@ -4179,5 +4190,65 @@ public class ExampleGenerator {
                 .replace("</div>", "〗")
                 .replace("<span class='cldr_substituted'>", "❬")
                 .replace("</span>", "❭");
+    }
+
+    /** Convenience function for getting a path from some file */
+    final String getStringValue(final CLDRFile file, final String path) {
+        return file.getStringValue(path);
+    }
+
+    /**
+     * Convenience function for getting a formatted path from some file. Example use:
+     * getStringValue("//ldml/%s", "localeDisplayNames")
+     *
+     * @param file CLDRFile to use
+     * @param path Example: "//ldml/%s"
+     * @param args
+     * @return result or null
+     */
+    final String getStringValue(final CLDRFile file, final String path, final String... args) {
+        return getStringValue(file, String.format(path, args));
+    }
+
+    /**
+     * Convenience function for getting a formatted path from the current file. Example use:
+     * getStringValue("//ldml/%s", "localeDisplayNames")
+     *
+     * @param file CLDRFile to use
+     * @param path Example: "//ldml/%s"
+     * @param args
+     * @return result or null
+     */
+    final String getStringValue(final String path, final String... args) {
+        return getStringValue(getCldrFile(), String.format(path, args));
+    }
+
+    /**
+     * Convenience function for getting a formatted path from the current file, fallign back to
+     * English Example use: getStringValue("//ldml/%s", "localeDisplayNames")
+     *
+     * @param file CLDRFile to use
+     * @param path Example: "//ldml/%s"
+     * @param args
+     * @return result or null
+     */
+    final String getStringValueOrEnglish(final String path, final String... args) {
+        final String currentVal = getStringValue(getCldrFile(), String.format(path, args));
+        if (currentVal != null && !currentVal.isEmpty()) {
+            return currentVal;
+        }
+        return getEnglishStringValue(path, args);
+    }
+
+    /**
+     * Convenience function for getting a formatted path from the English file. Example use:
+     * getStringValue("//ldml/%s", "localeDisplayNames")
+     *
+     * @param path Example: "//ldml/%s"
+     * @param args
+     * @return result or null
+     */
+    final String getEnglishStringValue(final String path, String... args) {
+        return getStringValue(englishFile, String.format(path, args));
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -385,7 +385,7 @@ public class ExtraPaths {
                         "colCaseLevel", // On/Off
                         "colNormalization", // On/Off
                         "colNumeric", // On/Off
-
+                        "ss", // On/Off
                         // all of the transforms
                         "d0",
                         "h0",

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -71,6 +71,8 @@
 //ldml/localeDisplayNames/subdivisions/subdivision[@type="%A"]    ; Locale Display Names ; &territorySection($1) ; &categoryFromTerritory($1)-Subdivisions ; $1
 //ldml/localeDisplayNames/variants/variant[@type="%A"]         ; Locale Display Names ; Locale Variants ; null ; $1
 //ldml/localeDisplayNames/keys/key[@type="%A"]                 ; Locale Display Names ; Keys ; &categoryFromKey($1) ; $1
+# ss/core became the beginning of Off/On, so don't show it anymore.
+//ldml/localeDisplayNames/types/type[@key="ss"][@type="(none|standard)"][@scope="core"]    ; Special ; Suppress ; *&categoryFromKey($1) ; onoff ; HIDE
 //ldml/localeDisplayNames/types/type[@key="%A"][@type="%A"][@scope="%A"]    ; Locale Display Names ; Keys ; *&categoryFromKey($1) ; $1-$2-$3
 //ldml/localeDisplayNames/types/type[@key="%A"][@type="%A"]    ; Locale Display Names ; Keys ; *&categoryFromKey($1) ; *$1-$2
 //ldml/localeDisplayNames/typeValues/typeValue[@type="%A"]     ; Locale Display Names ; Keys ; Type Values ; $1

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -625,6 +625,16 @@ public class TestCoverageLevel extends TestFmwkPlus {
                         continue;
                     }
                 }
+                if (path.equals(
+                                "//ldml/localeDisplayNames/types/type[@key=\"t0\"][@type=\"und\"][@scope=\"core\"]")
+                        && logKnownIssue("CLDR-19252", "comprehensive path: " + path)) {
+                    continue;
+                } else if (path.startsWith("//ldml/localeDisplayNames/types/type[@key=\"ss\"]")
+                        && path.endsWith("[@scope=\"core\"]")) {
+                    // ss core
+                    continue;
+                }
+
             } else if (xpp.containsElement("variant")) {
                 // All variant names are comprehensive coverage
                 continue;
@@ -698,16 +708,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 }
             } else if (xpp.contains("posix")) {
                 continue;
-            } else if (path.equals(
-                            "//ldml/localeDisplayNames/types/type[@key=\"t0\"][@type=\"und\"][@scope=\"core\"]")
-                    && logKnownIssue("CLDR-19252", "comprehensive path: " + path)) {
-                continue;
-            } else if (path.startsWith("//ldml/localeDisplayNames/types/type[@key=\"ss\"]")
-                    && path.endsWith("[@scope=\"core\"]")) {
-                // ss core
-                continue;
             }
-
             errln("Comprehensive & no exception for path =>\t" + path);
         }
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -702,6 +702,10 @@ public class TestCoverageLevel extends TestFmwkPlus {
                             "//ldml/localeDisplayNames/types/type[@key=\"t0\"][@type=\"und\"][@scope=\"core\"]")
                     && logKnownIssue("CLDR-19252", "comprehensive path: " + path)) {
                 continue;
+            } else if (path.startsWith("//ldml/localeDisplayNames/types/type[@key=\"ss\"]")
+                    && path.endsWith("[@scope=\"core\"]")) {
+                // ss core
+                continue;
             }
 
             errln("Comprehensive & no exception for path =>\t" + path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
@@ -40,7 +40,7 @@ public class TestExtraPaths {
             "lw",
             "ms",
             "numbers",
-            "ss",
+            // "ss", Removed in CLDR-19394
             // New keys of interest
             "colAlternate",
             "colBackwards",
@@ -129,8 +129,8 @@ public class TestExtraPaths {
                 "//ldml/localeDisplayNames/types/type[@key=\"ms\"][@type=\"metric\"][@scope=\"core\"]",
                 "//ldml/localeDisplayNames/types/type[@key=\"ms\"][@type=\"uksystem\"][@scope=\"core\"]",
                 "//ldml/localeDisplayNames/types/type[@key=\"ms\"][@type=\"ussystem\"][@scope=\"core\"]",
-                "//ldml/localeDisplayNames/types/type[@key=\"ss\"][@type=\"none\"][@scope=\"core\"]",
-                "//ldml/localeDisplayNames/types/type[@key=\"ss\"][@type=\"standard\"][@scope=\"core\"]"
+                // "//ldml/localeDisplayNames/types/type[@key=\"ss\"][@type=\"none\"][@scope=\"core\"]", Removed, CLDR-19394
+                // "//ldml/localeDisplayNames/types/type[@key=\"ss\"][@type=\"standard\"][@scope=\"core\"]", Removed, CLDR-19394
             };
 
             for (final String path : typeKeys) {
@@ -162,6 +162,17 @@ public class TestExtraPaths {
         assertTrue(missing.isEmpty(), () -> "In XML but not in extraPaths: " + missing);
     }
 
+    // skip these
+    // - skip 4-letter script codes
+    // - skip ss (deprecated in CLDR-19394)
+    private static final Pattern IGNORE_KEY_TYPES =
+            Pattern.compile(
+                    "^.*(\\[@key=\"numbers\"\\]\\[@type=\"[a-z]{4}\"\\]|types/type\\[@key=\"ss\"\\]\\[@type=\"(standard|none)\"\\]\\[@scope=\"core\"\\])$");
+
+    private static final boolean isIgnoredKeyType(final String path) {
+        return IGNORE_KEY_TYPES.matcher(path).matches();
+    }
+
     @ParameterizedTest(name = "{index} locale={0}.xml")
     @ValueSource(strings = {"de", "ru"})
     public void testMissingKeyTypes(final String localeId) {
@@ -170,14 +181,11 @@ public class TestExtraPaths {
         final Set<String> paths = getExtraPathsFor(localeId);
         final Set<String> missing = new TreeSet<>();
         final CLDRFile f = CLDRConfig.getInstance().getCLDRFile(localeId, true);
-        // skip these
-        final Pattern skipNumbers =
-                Pattern.compile("^.*\\[@key=\"numbers\"\\]\\[@type=\"[a-z]{4}\"\\]$");
         for (Iterator<String> i =
                         f.iteratorWithoutExtras("//ldml/localeDisplayNames/types/type", null);
                 i.hasNext(); ) {
             final String path = i.next();
-            if (!paths.contains(path) && !skipNumbers.matcher(path).matches()) {
+            if (!paths.contains(path) && !isIgnoredKeyType(path)) {
                 missing.add(path);
             }
         }
@@ -195,7 +203,7 @@ public class TestExtraPaths {
                 i.hasNext(); ) {
             final String path = i.next();
             final Level l = cov.getLevel(path);
-            if (path.endsWith("[@scope=\"core\"]")) {
+            if (path.endsWith("[@scope=\"core\"]") && !isIgnoredKeyType(path)) {
                 // should be modern or lower. Some were already lower.
                 assertTrue(Level.MODERN.isAtLeast(l), () -> l + "=" + localeId + ":" + path);
             }
@@ -252,7 +260,7 @@ public class TestExtraPaths {
                             l,
                             () -> localeId + ":" + path + " - expect comprehensive");
                 }
-            } else {
+            } else if (!isIgnoredKeyType(path)) {
                 // CORE
                 if (l48 != null && l48 != Level.COMPREHENSIVE) {
                     // present in v48


### PR DESCRIPTION
- The old Off/On should now be suppressed in SurveyTool
- also, update examples for off/on as follows. (Did not add every type, so it's not unwieldy. All of the other sorting types end with Sorting.) 
  - 〖Ignore Symbols Sorting: On〗〖Sentence Break After Abbr.: On〗
  - 〖Ignore Symbols Sorting: ❬Off❭〗〖Sentence Break After Abbr.: ❬Off❭〗

CLDR-19394

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
