### PR TITLE
CLDR-19440 Keyboards: use UnicodeSet notation for test repertoire

### DIFF
--- a/keyboards/test/README.md
+++ b/keyboards/test/README.md
@@ -129,10 +129,12 @@ _Attribute:_ `chars` (required)
 
 This attribute value specifies a list of characters in UnicodeSet format, which is specified in [UTS #35 Part One](tr35.md#Unicode_Sets).
 
+**Note** The use of UnicodeSet format here means that Unicode character escapes differ from how they are represented in other attributes in the file; `chars` uses `\u####` format (4 digits required), instead of `\u{####}`.
+
 **Example**
 
 ```xml
-<repertoire chars="[a b c d e \u{22}]" type="default" />
+<repertoire chars="[a b c d e \u0022]" type="default" />
 
 <!-- taken from CLDR's common/main/fr.xml main exemplars - indicates that all of these characters should be reachable without requiring a gesture.
 Note that the 'name' is arbitrary. -->

--- a/keyboards/test/fr-t-k0-test-test.xml
+++ b/keyboards/test/fr-t-k0-test-test.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
 <keyboardTest3 conformsTo="techpreview">
     <info keyboard="fr-t-k0-test.xml" author="Team Keyboard" name="fr-test" />
-    <repertoire name="simple-repertoire" chars="[a b c d e \u{22}]" type="simple" /> <!-- verify that these outputs are all available from simple keys on any layer, for all form factors -->
+    <repertoire name="simple-repertoire" chars="[a b c d e \u0022]" type="simple" /> <!-- verify that these outputs are all available from simple keys on any layer, for all form factors -->
     <repertoire name="chars-repertoire" chars="[á é ó]" type="gesture" /> <!-- verify that these outputs are all available from simple or gesture keys on any layer, for touch -->
     <tests name="key-tests">
         <test name="key-test">

--- a/keyboards/test/ja-Latn-test.xml
+++ b/keyboards/test/ja-Latn-test.xml
@@ -3,7 +3,7 @@
 <keyboardTest3 conformsTo="techpreview">
 	<info keyboard="ja-Latn.xml" author="Team Keyboard" name="ja-Latn-test" />
 	<repertoire name="latn-repertoire"
-		chars="[a-z A-Z 0-9 !\u{0022}#$%\u{0026}\[\]\{\}=\-|¥~\^_\u{0020}\u{003c}>,./?`@\+\*]" type="simple" />
+		chars="[a-z A-Z 0-9 !\u0022#$%\u0026\[\]\{\}=\-|¥~\^_\u0020\u003c>,./?`@\+\*]" type="simple" />
 	<tests name="tests">
 		<test name="test1">
 			<startContext to="" /> <!-- empty startContext -->

--- a/keyboards/test/pt-t-k0-abnt2-test.xml
+++ b/keyboards/test/pt-t-k0-abnt2-test.xml
@@ -3,7 +3,7 @@
 <keyboardTest3 conformsTo="techpreview">
     <info keyboard="pt-t-k0-abnt2.xml" author="Team Keyboard" name="pt-test" />
     <repertoire name="latn-repertoire"
-        chars="[a-z A-Z 0-9 !\u{0022}#$%\u{0026}\[\]\{\}=\-|~_\u{0020}\u{003c}>,./?`@\+\*çÇ]"
+        chars="[a-z A-Z 0-9 !\u0022#$%\u0026\[\]\{\}=\-|~_\u0020\u003c>,./?`@\+\*çÇ]"
         type="simple" />
     <repertoire name="currency-and-symbols"
         chars="[₢ ° ¹²³ § ¬ ªº]" />


### PR DESCRIPTION
- Test repertoire.chars, unlike other elements and attributes, use UnicodeSet notation, per draft spec.
- Update README.md to highlight difference in Unicode character escapes.

CLDR-19440

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
