### PR TITLE
CLDR-19464 deps: work around maven issue, improve docker caching

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -309,6 +309,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
           node-
+    - uses: docker/setup-buildx-action@v4.0.0
     - name: Pull Images
       run: docker compose pull -q
       working-directory: tools/cldr-apps

--- a/tools/cldr-apps/Dockerfile
+++ b/tools/cldr-apps/Dockerfile
@@ -3,22 +3,30 @@ COPY target/cldr-apps.zip /tmp
 RUN mkdir -p /opt/ol
 WORKDIR /opt/ol
 # we don't want the bootstrap.properties or server.env from the workspace
-RUN unzip /tmp/cldr-apps.zip -x "*/bootstrap.properties" "*/server.env" 
+RUN unzip /tmp/cldr-apps.zip -x "*/bootstrap.properties" "*/server.env"
 WORKDIR /tmp
 RUN unzip -j cldr-apps.zip wlp/usr/servers/cldr/apps/cldr-apps.war
 RUN unzip -j cldr-apps.war 'WEB-INF/lib/cldr-code-*'
 RUN mv -v cldr-code-*-SNAPSHOT.jar cldr-code.jar
 
-FROM icr.io/appcafe/open-liberty:kernel-slim-java17-openj9-ubi-minimal AS server
+FROM icr.io/appcafe/open-liberty:26.0.0.4-kernel-slim-java17-openj9-ubi AS server
 # copy just the server file so we get config
 COPY --from=setup /opt/ol/wlp/usr/servers/cldr/server.xml /opt/ol/wlp/usr/servers/defaultServer/server.xml
 USER root
-RUN chown default /config/server.xml
+RUN mkdir /home/default
+RUN chown default /config/server.xml /home/default
 RUN mkdir -p /srv/st/config  /srv/st/src && chown -R default /srv/st
-USER default
 # fix local configuration
 COPY docker/bootstrap-docker.properties /opt/ol/wlp/usr/servers/defaultServer/bootstrap.properties
 COPY docker/server-docker.env /opt/ol/wlp/usr/servers/defaultServer/server.env
+## CLDR-19464 workaround maven issue:
+COPY docker/featureUtility.properties /opt/ol/wlp/etc/featureUtility.properties
+### - check settings
+RUN featureUtility viewSettings
+# RUN mkdir -p /home/default/.m2/repository/io/
+# COPY docker/io/ /home/default/.m2/repository/io/
+### - verify (this is what features.sh ought to do)
+# RUN featureUtility viewSettings && featureUtility installServerFeatures --acceptLicense defaultServer --verbose
 # setup features needed
 RUN features.sh
 # setup configuration

--- a/tools/cldr-apps/docker-compose.yml
+++ b/tools/cldr-apps/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   cldr-apps:
-    build: .
+    build:
+      context: .
+      cache_from:
+      - type=gha
+      cache_to:
+      - type=gha
     ports:
       - 9080  # web
     volumes:
@@ -17,7 +22,8 @@ services:
       MYSQL_PASSWORD: surveytoolpw
       MYSQL_DATABASE: cldrdb
   webdriver:
-    build: ../cldr-apps-webdriver
+    build:
+      context: ../cldr-apps-webdriver
     depends_on:
       - cldr-apps
       - selenium

--- a/tools/cldr-apps/docker/featureUtility.properties
+++ b/tools/cldr-apps/docker/featureUtility.properties
@@ -1,0 +1,7 @@
+# CLDR-19464
+## attempt to work around maven issue
+#mavenCentralMirror.url=https://repo1.maven.org/maven2/
+#mavenCentralMirror.url=https://maven-central.storage-download.googleapis.com/maven2/
+mavenCentralMirror.url=https://cldr-staging.unicode.org/repository/maven-central/
+#
+


### PR DESCRIPTION
- use an alternate repo
- improve caching in Docker
- bump (and pin) version of openliberty image

CLDR-19464