### PR TITLE
CLDR-19464 docker: improve cache further, fix version check

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -301,14 +301,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-servertest-
           servertest-
-    - name: Cache local npm repository
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-          node-
     - name: Setup Docker
       uses: docker/setup-buildx-action@v4.0.0
     - name: Pull Containers

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -309,13 +309,29 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
           node-
-    - uses: docker/setup-buildx-action@v4.0.0
-    - name: Pull Images
+    - name: Setup Docker
+      uses: docker/setup-buildx-action@v4.0.0
+    - name: Pull Containers
       run: docker compose pull -q
       working-directory: tools/cldr-apps
+    - name: Cache Docker layers
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-step1-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
     - name: Build Containers
-      run: docker compose build
-      working-directory: tools/cldr-apps
+      uses: docker/bake-action@v7
+      with:
+        push: false
+        source: tools/cldr-apps
+        set: |
+          *.tags=unicode-org/cldr-apps-cache:latest
+    # - name: Build Containers (should be already cached)
+    #   run: docker compose build
+    #   working-directory: tools/cldr-apps
     - name: Bringup Containers
       run: docker compose up -d cldr-apps selenium
       working-directory: tools/cldr-apps

--- a/tools/cldr-apps/docker/setup-config.sh
+++ b/tools/cldr-apps/docker/setup-config.sh
@@ -2,7 +2,7 @@
 
 echo "Trying to determine CLDR version"
 java -jar /tmp/cldr-code.jar > /dev/null || exit 1
-CLDR_VERSION=$($(java -jar /tmp/cldr-code.jar) | fgrep GEN_VERSION | cut -d= -f2 | cut -d. -f1)
+CLDR_VERSION=$(java -jar /tmp/cldr-code.jar | fgrep GEN_VERSION | cut -d= -f2 | cut -d. -f1)
 rm -f /tmp/cldr-code.jar
 echo "CLDR_VERSION=${CLDR_VERSION}"
 CLDR_OLDVERSION=$(expr ${CLDR_VERSION} - 1)


### PR DESCRIPTION
CLDR-19464

Lower priority, but improvements.
Actually caches so that we can hopefully remove the maven workaround in the future.

(Docker build goes from 1.5 to 0.5 minutes on a rebuild and doesn't hit Maven at all) 

ALLOW_MANY_COMMITS=true