### PR TITLE
CLDR-19272 CheckExemplars should detect and report empty string {}

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
@@ -12,6 +12,7 @@ import java.util.BitSet;
 import java.util.Comparator;
 import java.util.List;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Type;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.ComparatorUtilities;
 import org.unicode.cldr.util.ExemplarSets;
@@ -277,6 +278,16 @@ public class CheckExemplars extends FactoryCheckCLDR {
     private void checkMixedScripts(String title, UnicodeSet set, List<CheckStatus> result) {
         BitSet s = new BitSet();
         for (String item : set) {
+            if (item.isEmpty()) {
+                result.add(
+                        new CheckStatus()
+                                .setCause(this)
+                                .setMainType(Type.Error)
+                                .setSubtype(Subtype.illegalCharactersInExemplars)
+                                .setMessage(
+                                        "Exemplar has an empty string: {}. Ensure that any curly braces are quoted: \\{ \\}"));
+                continue; // skip this string
+            }
             int script = UScript.getScript(item.codePointAt(0));
             if (script != UScript.COMMON && script != UScript.INHERITED) {
                 s.set(script);


### PR DESCRIPTION
CLDR-19272 (but can add a new one if needed)

#5708 failed exemplar checks with a crash (stack trace). 

This changes that to:

> `xdq [Kaitag]    error   ▸Core_Data|Alphabetic_Information|Characters_in_Use|Others:_punctuation◂        〈[\- ‐‑ – — , ; \: ! ? . … '‘’ "“” ( ) \[ \] § @ * / \& # † ‡ ′ ″]〉       【】    〈[\- – — , ; \: ! ? . … ' ‚ " „ « » ( ) \[ \] { } @ * / \& # №]〉  «=»     【】    ⁅illegal characters in exemplars⁆       ❮Error: Exemplar has an empty string: {}. Ensure that any curly braces are quoted: \{ \}❯   https://st.unicode.org/cldr-apps/v#/xdq//6cf943e652b01478`

Note that the issue was: `{ }` which normalized to `{}` which should instead have been `\{ \}`.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
