### PR TITLE
CLDR-13465 TestAll should run all tests

### DIFF
--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -38,6 +38,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- this is for tests, but we want cldr-apps to use it too. -->
+		<dependency>
+			<groupId>io.github.classgraph</groupId>
+			<artifactId>classgraph</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
@@ -1,10 +1,16 @@
 package org.unicode.cldr.util;
 
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.icu.dev.test.TestFmwk.TestGroup;
 
 /**
@@ -72,6 +78,26 @@ public class ShimmedMain {
                 | IllegalArgumentException
                 | InvocationTargetException nsm) {
             throw new RuntimeException("Could not invoke main for " + clazz, nsm);
+        }
+    }
+
+    /** Go fishing and find all TestFmwk subclasses in the package. */
+    public static String[] findAllTests(final Package inPackage) {
+        // keep these in lexical order
+        final Set<String> allTestClasses = new TreeSet<String>();
+        // use ClassGraph to look for all subclasses of TestFmwk
+        try (ScanResult scanResult =
+                new ClassGraph()
+                        .verbose()
+                        .acceptPackages(inPackage.getName())
+                        .enableAnnotationInfo()
+                        .enableClassInfo()
+                        .scan()) {
+            for (ClassInfo info : scanResult.getSubclasses(TestFmwk.class)) {
+                System.out.println(info.toString());
+                allTestClasses.add(info.getName());
+            }
+            return allTestClasses.toArray(new String[allTestClasses.size()]);
         }
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
@@ -93,10 +93,13 @@ public class ShimmedMain {
                         .enableClassInfo()
                         .scan()) {
             for (ClassInfo info : scanResult.getSubclasses(TestFmwk.class)) {
-                if (info.getPackageName().equals(inPackage.getName())) {
-                    if (!info.getSuperclass()
-                            .getName()
-                            .equals(TestFmwk.TestGroup.class.getName())) {
+                if (info.getPackageName().equals(inPackage.getName())
+                        && !info.getSuperclass()
+                                .getName()
+                                .equals(TestFmwk.TestGroup.class.getName())) {
+                    if (info.hasAnnotation("org.junit.jupiter.api.Disabled")) {
+                        System.err.println("Skipping, @Disabled: " + info.getName());
+                    } else {
                         allTestClasses.add(info.getName());
                     }
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
@@ -88,14 +88,18 @@ public class ShimmedMain {
         // use ClassGraph to look for all subclasses of TestFmwk
         try (ScanResult scanResult =
                 new ClassGraph()
-                        .verbose()
                         .acceptPackages(inPackage.getName())
                         .enableAnnotationInfo()
                         .enableClassInfo()
                         .scan()) {
             for (ClassInfo info : scanResult.getSubclasses(TestFmwk.class)) {
-                System.out.println(info.toString());
-                allTestClasses.add(info.getName());
+                if (info.getPackageName().equals(inPackage.getName())) {
+                    if (!info.getSuperclass()
+                            .getName()
+                            .equals(TestFmwk.TestGroup.class.getName())) {
+                        allTestClasses.add(info.getName());
+                    }
+                }
             }
             return allTestClasses.toArray(new String[allTestClasses.size()]);
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/api/AllTests.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/api/AllTests.java
@@ -1,34 +1,18 @@
 package org.unicode.cldr.api;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
-import com.google.common.collect.ImmutableList;
 import java.io.PrintWriter;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.icu.dev.test.TestFmwk.TestGroup;
 import org.unicode.cldr.util.ShimmedMain;
 
 public class AllTests extends TestGroup {
-    private static final ImmutableList<Class<?>> TEST_CLASSES =
-            ImmutableList.of(
-                    CldrFileDataSourceTest.class,
-                    CldrPathTest.class,
-                    CldrValueTest.class,
-                    FilteredDataTest.class,
-                    PathMatcherTest.class,
-                    PrefixVisitorTest.class,
-                    XmlDataSourceTest.class);
-
     public static void main(String[] args) {
         System.setProperty("CLDR_ENVIRONMENT", "UNITTEST");
         new AllTests().run(args, new PrintWriter(System.out));
     }
 
     private static String[] getTestClassNames() {
-        return TEST_CLASSES.stream()
-                .map(Class::getName)
-                .collect(toImmutableList())
-                .toArray(new String[0]);
+        return ShimmedMain.findAllTests(AllTests.class.getPackage());
     }
 
     public AllTests() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
@@ -11,83 +11,12 @@ import java.util.Date;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.icu.dev.test.TestFmwk.TestGroup;
 import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.ShimmedMain;
 
 /** Top level test used to run all other tests as a batch. */
 public class TestAll extends TestGroup {
-
-    /**
-     * @see {@link TestShim#TestAllIsAll()} for a test against this list
-     */
-    public static final String[] ALMOST_ALL_TESTS =
-            new String[] {
-                "org.unicode.cldr.unittest.LocaleMatcherTest",
-                "org.unicode.cldr.unittest.GenerateTransformTest",
-                "org.unicode.cldr.unittest.LanguageInfoTest",
-                "org.unicode.cldr.unittest.LanguageTest",
-                "org.unicode.cldr.unittest.LikelySubtagsTest",
-                "org.unicode.cldr.unittest.NumberingSystemsTest",
-                "org.unicode.cldr.unittest.StandardCodesTest",
-                "org.unicode.cldr.unittest.TestAnnotations",
-                "org.unicode.cldr.unittest.TestAttributeValues",
-                "org.unicode.cldr.unittest.TestBasic",
-                "org.unicode.cldr.unittest.TestBCP47",
-                "org.unicode.cldr.unittest.TestCLDRFile",
-                "org.unicode.cldr.unittest.TestCLDRUtils",
-                "org.unicode.cldr.unittest.TestCanonicalIds",
-                "org.unicode.cldr.unittest.TestCasingInfo",
-                "org.unicode.cldr.unittest.TestCheckAltOnly",
-                "org.unicode.cldr.unittest.TestCheckCLDR",
-                "org.unicode.cldr.unittest.TestCheckNumbers",
-                "org.unicode.cldr.unittest.TestComparisonBuilder",
-                "org.unicode.cldr.unittest.TestCoverageLevel",
-                "org.unicode.cldr.unittest.TestDTDAttributes",
-                "org.unicode.cldr.unittest.TestDisplayAndInputProcessor",
-                "org.unicode.cldr.unittest.TestExampleCache",
-                "org.unicode.cldr.unittest.TestExampleGenerator",
-                "org.unicode.cldr.unittest.TestExternalCodeAPIs",
-                "org.unicode.cldr.unittest.TestFallbackIterator",
-                "org.unicode.cldr.unittest.TestIdentifierInfo",
-                "org.unicode.cldr.unittest.TestIdentity",
-                "org.unicode.cldr.unittest.TestInheritance",
-                "org.unicode.cldr.unittest.TestKeyboardModifierSet",
-                "org.unicode.cldr.unittest.TestLdml2ICU",
-                "org.unicode.cldr.unittest.TestLocalCurrency",
-                "org.unicode.cldr.unittest.TestLocale",
-                "org.unicode.cldr.unittest.TestLruMap",
-                "org.unicode.cldr.unittest.TestMetadata",
-                "org.unicode.cldr.unittest.TestOutdatedPaths",
-                "org.unicode.cldr.unittest.TestPathHeader",
-                "org.unicode.cldr.unittest.TestPaths",
-                "org.unicode.cldr.unittest.TestPathStarrer",
-                "org.unicode.cldr.unittest.TestPseudolocalization",
-                "org.unicode.cldr.unittest.TestScriptMetadata",
-                "org.unicode.cldr.unittest.TestSupplementalInfo",
-                "org.unicode.cldr.unittest.TestThreadSafeMapOfMapOfMap",
-                "org.unicode.cldr.unittest.TestTransforms",
-                "org.unicode.cldr.unittest.TestHelper",
-                "org.unicode.cldr.unittest.TestCLDRLocaleCoverage",
-                "org.unicode.cldr.unittest.TestDayPeriods",
-                "org.unicode.cldr.unittest.TestSubdivisions",
-                "org.unicode.cldr.unittest.TestAliases",
-                "org.unicode.cldr.unittest.TestValidity",
-                "org.unicode.cldr.unittest.TestDtdData",
-                "org.unicode.cldr.unittest.TestCldrFactory",
-                "org.unicode.cldr.unittest.TestUnContainment",
-                "org.unicode.cldr.unittest.TestUnits",
-                "org.unicode.cldr.unittest.TestNumbers",
-                "org.unicode.cldr.unittest.TestLocaleCanonicalizer",
-                "org.unicode.cldr.unittest.TestPersonNameFormatter",
-                "org.unicode.cldr.unittest.TestCompactNumbers",
-                "org.unicode.cldr.unittest.TestPathLookup",
-                "org.unicode.cldr.unittest.TestDataTest",
-                //            "org.unicode.cldr.unittest.TestCollators" See Ticket #8288
-                "org.unicode.cldr.api.AllTests",
-            };
-
     public static String[] getAllTests() {
-        // TODO CLDR-13465: replace with dynamic
-        return ALMOST_ALL_TESTS;
-        // return ShimmedMain.findAllTests(TestAll.class.getPackage());
+        return ShimmedMain.findAllTests(TestAll.class.getPackage());
     }
 
     private static interface FormattableDate {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
@@ -15,6 +15,81 @@ import org.unicode.cldr.util.CLDRConfig;
 /** Top level test used to run all other tests as a batch. */
 public class TestAll extends TestGroup {
 
+    /**
+     * @see {@link TestShim#TestAllIsAll()} for a test against this list
+     */
+    public static final String[] ALMOST_ALL_TESTS =
+            new String[] {
+                "org.unicode.cldr.unittest.LocaleMatcherTest",
+                "org.unicode.cldr.unittest.GenerateTransformTest",
+                "org.unicode.cldr.unittest.LanguageInfoTest",
+                "org.unicode.cldr.unittest.LanguageTest",
+                "org.unicode.cldr.unittest.LikelySubtagsTest",
+                "org.unicode.cldr.unittest.NumberingSystemsTest",
+                "org.unicode.cldr.unittest.StandardCodesTest",
+                "org.unicode.cldr.unittest.TestAnnotations",
+                "org.unicode.cldr.unittest.TestAttributeValues",
+                "org.unicode.cldr.unittest.TestBasic",
+                "org.unicode.cldr.unittest.TestBCP47",
+                "org.unicode.cldr.unittest.TestCLDRFile",
+                "org.unicode.cldr.unittest.TestCLDRUtils",
+                "org.unicode.cldr.unittest.TestCanonicalIds",
+                "org.unicode.cldr.unittest.TestCasingInfo",
+                "org.unicode.cldr.unittest.TestCheckAltOnly",
+                "org.unicode.cldr.unittest.TestCheckCLDR",
+                "org.unicode.cldr.unittest.TestCheckNumbers",
+                "org.unicode.cldr.unittest.TestComparisonBuilder",
+                "org.unicode.cldr.unittest.TestCoverageLevel",
+                "org.unicode.cldr.unittest.TestDTDAttributes",
+                "org.unicode.cldr.unittest.TestDisplayAndInputProcessor",
+                "org.unicode.cldr.unittest.TestExampleCache",
+                "org.unicode.cldr.unittest.TestExampleGenerator",
+                "org.unicode.cldr.unittest.TestExternalCodeAPIs",
+                "org.unicode.cldr.unittest.TestFallbackIterator",
+                "org.unicode.cldr.unittest.TestIdentifierInfo",
+                "org.unicode.cldr.unittest.TestIdentity",
+                "org.unicode.cldr.unittest.TestInheritance",
+                "org.unicode.cldr.unittest.TestKeyboardModifierSet",
+                "org.unicode.cldr.unittest.TestLdml2ICU",
+                "org.unicode.cldr.unittest.TestLocalCurrency",
+                "org.unicode.cldr.unittest.TestLocale",
+                "org.unicode.cldr.unittest.TestLruMap",
+                "org.unicode.cldr.unittest.TestMetadata",
+                "org.unicode.cldr.unittest.TestOutdatedPaths",
+                "org.unicode.cldr.unittest.TestPathHeader",
+                "org.unicode.cldr.unittest.TestPaths",
+                "org.unicode.cldr.unittest.TestPathStarrer",
+                "org.unicode.cldr.unittest.TestPseudolocalization",
+                "org.unicode.cldr.unittest.TestScriptMetadata",
+                "org.unicode.cldr.unittest.TestSupplementalInfo",
+                "org.unicode.cldr.unittest.TestThreadSafeMapOfMapOfMap",
+                "org.unicode.cldr.unittest.TestTransforms",
+                "org.unicode.cldr.unittest.TestHelper",
+                "org.unicode.cldr.unittest.TestCLDRLocaleCoverage",
+                "org.unicode.cldr.unittest.TestDayPeriods",
+                "org.unicode.cldr.unittest.TestSubdivisions",
+                "org.unicode.cldr.unittest.TestAliases",
+                "org.unicode.cldr.unittest.TestValidity",
+                "org.unicode.cldr.unittest.TestDtdData",
+                "org.unicode.cldr.unittest.TestCldrFactory",
+                "org.unicode.cldr.unittest.TestUnContainment",
+                "org.unicode.cldr.unittest.TestUnits",
+                "org.unicode.cldr.unittest.TestNumbers",
+                "org.unicode.cldr.unittest.TestLocaleCanonicalizer",
+                "org.unicode.cldr.unittest.TestPersonNameFormatter",
+                "org.unicode.cldr.unittest.TestCompactNumbers",
+                "org.unicode.cldr.unittest.TestPathLookup",
+                "org.unicode.cldr.unittest.TestDataTest",
+                //            "org.unicode.cldr.unittest.TestCollators" See Ticket #8288
+                "org.unicode.cldr.api.AllTests",
+            };
+
+    public static String[] getAllTests() {
+        // TODO CLDR-13465: replace with dynamic
+        return ALMOST_ALL_TESTS;
+        // return ShimmedMain.findAllTests(TestAll.class.getPackage());
+    }
+
     private static interface FormattableDate {
         String format(Date d);
     }
@@ -181,72 +256,7 @@ public class TestAll extends TestGroup {
     }
 
     public TestAll() {
-        super(
-                new String[] {
-                    "org.unicode.cldr.unittest.LocaleMatcherTest",
-                    "org.unicode.cldr.unittest.GenerateTransformTest",
-                    "org.unicode.cldr.unittest.LanguageInfoTest",
-                    "org.unicode.cldr.unittest.LanguageTest",
-                    "org.unicode.cldr.unittest.LikelySubtagsTest",
-                    "org.unicode.cldr.unittest.NumberingSystemsTest",
-                    "org.unicode.cldr.unittest.StandardCodesTest",
-                    "org.unicode.cldr.unittest.TestAnnotations",
-                    "org.unicode.cldr.unittest.TestAttributeValues",
-                    "org.unicode.cldr.unittest.TestBasic",
-                    "org.unicode.cldr.unittest.TestBCP47",
-                    "org.unicode.cldr.unittest.TestCLDRFile",
-                    "org.unicode.cldr.unittest.TestCLDRUtils",
-                    "org.unicode.cldr.unittest.TestCanonicalIds",
-                    "org.unicode.cldr.unittest.TestCasingInfo",
-                    "org.unicode.cldr.unittest.TestCheckAltOnly",
-                    "org.unicode.cldr.unittest.TestCheckCLDR",
-                    "org.unicode.cldr.unittest.TestCheckNumbers",
-                    "org.unicode.cldr.unittest.TestComparisonBuilder",
-                    "org.unicode.cldr.unittest.TestCoverageLevel",
-                    "org.unicode.cldr.unittest.TestDTDAttributes",
-                    "org.unicode.cldr.unittest.TestDisplayAndInputProcessor",
-                    "org.unicode.cldr.unittest.TestExampleCache",
-                    "org.unicode.cldr.unittest.TestExampleGenerator",
-                    "org.unicode.cldr.unittest.TestExternalCodeAPIs",
-                    "org.unicode.cldr.unittest.TestFallbackIterator",
-                    "org.unicode.cldr.unittest.TestIdentifierInfo",
-                    "org.unicode.cldr.unittest.TestIdentity",
-                    "org.unicode.cldr.unittest.TestInheritance",
-                    "org.unicode.cldr.unittest.TestKeyboardModifierSet",
-                    "org.unicode.cldr.unittest.TestLdml2ICU",
-                    "org.unicode.cldr.unittest.TestLocalCurrency",
-                    "org.unicode.cldr.unittest.TestLocale",
-                    "org.unicode.cldr.unittest.TestLruMap",
-                    "org.unicode.cldr.unittest.TestMetadata",
-                    "org.unicode.cldr.unittest.TestOutdatedPaths",
-                    "org.unicode.cldr.unittest.TestPathHeader",
-                    "org.unicode.cldr.unittest.TestPaths",
-                    "org.unicode.cldr.unittest.TestPathStarrer",
-                    "org.unicode.cldr.unittest.TestPseudolocalization",
-                    "org.unicode.cldr.unittest.TestScriptMetadata",
-                    "org.unicode.cldr.unittest.TestSupplementalInfo",
-                    "org.unicode.cldr.unittest.TestThreadSafeMapOfMapOfMap",
-                    "org.unicode.cldr.unittest.TestTransforms",
-                    "org.unicode.cldr.unittest.TestHelper",
-                    "org.unicode.cldr.unittest.TestCLDRLocaleCoverage",
-                    "org.unicode.cldr.unittest.TestDayPeriods",
-                    "org.unicode.cldr.unittest.TestSubdivisions",
-                    "org.unicode.cldr.unittest.TestAliases",
-                    "org.unicode.cldr.unittest.TestValidity",
-                    "org.unicode.cldr.unittest.TestDtdData",
-                    "org.unicode.cldr.unittest.TestCldrFactory",
-                    "org.unicode.cldr.unittest.TestUnContainment",
-                    "org.unicode.cldr.unittest.TestUnits",
-                    "org.unicode.cldr.unittest.TestNumbers",
-                    "org.unicode.cldr.unittest.TestLocaleCanonicalizer",
-                    "org.unicode.cldr.unittest.TestPersonNameFormatter",
-                    "org.unicode.cldr.unittest.TestCompactNumbers",
-                    "org.unicode.cldr.unittest.TestPathLookup",
-                    "org.unicode.cldr.unittest.TestDataTest",
-                    //            "org.unicode.cldr.unittest.TestCollators" See Ticket #8288
-                    "org.unicode.cldr.api.AllTests",
-                },
-                "All tests in CLDR");
+        super(getAllTests(), "All tests in CLDR");
     }
 
     public static final String CLASS_TARGET_NAME = "CLDR";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -21,6 +22,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.XPathParts;
 
+@Disabled
 public class TestAlt extends TestFmwk {
     static CLDRConfig testInfo = CLDRConfig.getInstance();
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBcp47Numbers.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBcp47Numbers.java
@@ -9,9 +9,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 
+@Disabled
 public class TestBcp47Numbers extends TestFmwk {
     public static void main(String[] args) {
         new TestBcp47Numbers().run(args);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.Options;
 import org.unicode.cldr.test.CheckDisplayCollisions;
@@ -19,6 +20,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.SimpleXMLSource;
 import org.unicode.cldr.util.XMLSource;
 
+@Disabled
 public class TestCheckDisplayCollisions extends TestFmwkPlus {
     private static final String ukRegion =
             "//ldml/localeDisplayNames/territories/territory[@type=\"GB\"]";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFileWrite.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFileWrite.java
@@ -13,6 +13,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -22,6 +23,7 @@ import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.XMLFileReader;
 
+@Disabled
 public class TestCldrFileWrite extends TestFmwkPlus {
     private static final CLDRConfig CONFIG = CLDRConfig.getInstance();
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrResolver.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.tool.resolver.CldrResolver;
 import org.unicode.cldr.tool.resolver.ResolutionType;
 import org.unicode.cldr.tool.resolver.ResolverUtils;
@@ -24,6 +25,7 @@ import org.unicode.cldr.util.LocaleIDParser;
  *
  * @author jchye@google.com (Jennifer Chye), ryanmentley@google.com (Ryan Mentley)
  */
+@Disabled("Very slow")
 public class TestCldrResolver extends TestFmwkPlus {
 
     static CLDRConfig testInfo = CLDRConfig.getInstance();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollators.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollators.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -17,6 +18,7 @@ import org.unicode.cldr.util.ChainedMap.M3;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.PatternCache;
 
+@Disabled
 public class TestCollators extends TestFmwk {
     public static void main(String[] args) {
         new TestCollators().run(args);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompatibility.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompatibility.java
@@ -6,10 +6,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 
+@Disabled
 public class TestCompatibility extends TestFmwkPlus {
     private static final File ARCHIVE = new File(CLDRPaths.ARCHIVE_DIRECTORY);
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -9,6 +9,7 @@ import com.google.common.collect.TreeMultimap;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -21,6 +22,7 @@ import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
+@Disabled
 public class TestCoverage extends TestFmwkPlus {
     private static final boolean DEBUG = false;
     private static final boolean SHOW_LSR_DATA = false;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.test.CheckDates;
 import org.unicode.cldr.test.DateOrder;
@@ -35,6 +36,7 @@ import org.unicode.cldr.util.SimpleXMLSource;
 import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
 
+@Disabled
 public class TestDateOrder extends TestFmwk {
     private static final Joiner JOIN_TAB = Joiner.on('\t');
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestFmwkPlus.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestFmwkPlus.java
@@ -8,9 +8,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CldrUtility;
 
+@Disabled
 public class TestFmwkPlus extends TestFmwk {
 
     @SuppressWarnings("unchecked")

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestIcuPersonNames.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestIcuPersonNames.java
@@ -1,8 +1,10 @@
 package org.unicode.cldr.unittest;
 
 import java.io.IOException;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 
+@Disabled
 public class TestIcuPersonNames extends TestFmwk {
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -20,6 +21,7 @@ import org.unicode.cldr.util.LanguageGroup;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
+@Disabled
 public class TestLanguageGroup extends TestFmwk {
     static CLDRConfig CONF = CLDRConfig.getInstance();
     static CLDRFile ENGLISH = CONF.getEnglish();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -30,6 +31,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
  * sanity-check the supplementalMetadata.xml alias data, and generate test files for use by
  * implementations.
  */
+@Disabled
 public class TestLsrvCanonicalizer extends TestFmwk {
 
     static final LsrvCanonicalizer rrs = LsrvCanonicalizer.getInstance();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPerf.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPerf.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.DtdData;
@@ -15,6 +16,7 @@ import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.Timer;
 import org.unicode.cldr.util.XPathParts;
 
+@Disabled
 public class TestPerf extends TestFmwkPlus {
     public static void main(String[] args) {
         new TestPerf().run(args);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
@@ -24,12 +24,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.text.FixedDecimal;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
+@Disabled
 public class TestPluralRuleGeneration extends TestFmwkPlus {
     public static void main(String[] args) {
         new TestPluralRuleGeneration().run(args);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestShim.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestShim.java
@@ -1,12 +1,8 @@
 package org.unicode.cldr.unittest;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Set;
-import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.util.ShimmedMain;
 
@@ -34,35 +30,5 @@ public class TestShim extends ShimmedMain {
         String args[] = getArgs(java.lang.String.class, "-a -b -c");
         String expectArgs[] = {"-a", "-b", "-c"};
         assertArrayEquals(args, expectArgs, "Expected arg parse");
-    }
-
-    @Test
-    public void TestAllIsAll() {
-        /** TODO CLDR-13465 only need this until all tests are passing. */
-        final Set<String> oldListOfAll = new TreeSet<String>();
-        for (final String s : TestAll.ALMOST_ALL_TESTS) {
-            oldListOfAll.add(s);
-        }
-        final Set<String> whatsOnDisk = new TreeSet<String>();
-        final String ACTUALLY_ALL[] = ShimmedMain.findAllTests(TestAll.class.getPackage());
-        for (final String s : ACTUALLY_ALL) {
-            whatsOnDisk.add(s);
-        }
-
-        final Set<String> presentButNotBeingRun = new TreeSet<String>(whatsOnDisk);
-        presentButNotBeingRun.removeAll(oldListOfAll);
-        final Set<String> doesNotExistButListed = new TreeSet<String>(oldListOfAll);
-        doesNotExistButListed.removeAll(whatsOnDisk);
-        assertAll(
-                () ->
-                        assertTrue(
-                                presentButNotBeingRun.isEmpty(),
-                                () -> "Not in TestAll’s list:" + presentButNotBeingRun.toString()),
-                () ->
-                        assertTrue(
-                                doesNotExistButListed.isEmpty(),
-                                () ->
-                                        "Doesn't exist but in TestAll’s list:"
-                                                + doesNotExistButListed.toString()));
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestShim.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestShim.java
@@ -1,8 +1,12 @@
 package org.unicode.cldr.unittest;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.util.ShimmedMain;
 
@@ -30,5 +34,35 @@ public class TestShim extends ShimmedMain {
         String args[] = getArgs(java.lang.String.class, "-a -b -c");
         String expectArgs[] = {"-a", "-b", "-c"};
         assertArrayEquals(args, expectArgs, "Expected arg parse");
+    }
+
+    @Test
+    public void TestAllIsAll() {
+        /** TODO CLDR-13465 only need this until all tests are passing. */
+        final Set<String> oldListOfAll = new TreeSet<String>();
+        for (final String s : TestAll.ALMOST_ALL_TESTS) {
+            oldListOfAll.add(s);
+        }
+        final Set<String> whatsOnDisk = new TreeSet<String>();
+        final String ACTUALLY_ALL[] = ShimmedMain.findAllTests(TestAll.class.getPackage());
+        for (final String s : ACTUALLY_ALL) {
+            whatsOnDisk.add(s);
+        }
+
+        final Set<String> presentButNotBeingRun = new TreeSet<String>(whatsOnDisk);
+        presentButNotBeingRun.removeAll(oldListOfAll);
+        final Set<String> doesNotExistButListed = new TreeSet<String>(oldListOfAll);
+        doesNotExistButListed.removeAll(whatsOnDisk);
+        assertAll(
+                () ->
+                        assertTrue(
+                                presentButNotBeingRun.isEmpty(),
+                                () -> "Not in TestAll’s list:" + presentButNotBeingRun.toString()),
+                () ->
+                        assertTrue(
+                                doesNotExistButListed.isEmpty(),
+                                () ->
+                                        "Doesn't exist but in TestAll’s list:"
+                                                + doesNotExistButListed.toString()));
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUExtension.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUExtension.java
@@ -1,11 +1,13 @@
 package org.unicode.cldr.unittest;
 
 import com.ibm.icu.impl.Relation;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.UExtension;
 
+@Disabled
 public class TestUExtension extends TestFmwk {
 
     static SupplementalDataInfo data =

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestURLs.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestURLs.java
@@ -21,9 +21,11 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRPaths;
 
+@Disabled
 public class TestURLs extends TestFmwk {
 
     private static final boolean DISABLE_BROKEN = true; // test for broken URL not working yet

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestXMLSource.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestXMLSource.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -12,6 +13,7 @@ import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts.Comments;
 
+@Disabled
 public class TestXMLSource extends TestFmwk {
     public static class DummyXMLSource extends XMLSource {
         Map<String, String> valueMap = CldrUtility.newConcurrentHashMap();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
@@ -33,6 +34,7 @@ import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.UnicodeSetPrettyPrinter;
 import org.unicode.cldr.util.XPathParts;
 
+@Disabled
 public class UnicodeSetPrettyPrinterTest extends TestFmwk {
     public static void main(String[] args) throws Exception {
         new UnicodeSetPrettyPrinterTest().run(args);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleDistanceTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleDistanceTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.draft.XLikelySubtags.LSR;
 import org.unicode.cldr.draft.XLocaleDistance;
 import org.unicode.cldr.draft.XLocaleDistance.DistanceNode;
@@ -21,6 +22,7 @@ import org.unicode.cldr.icu.util.LocaleMatcher;
  *
  * @author markdavis
  */
+@Disabled
 public class XLocaleDistanceTest extends TestFmwk {
     private static final boolean REFORMAT =
             false; // set to true to get a reformatted data file listed

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
@@ -12,6 +12,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.draft.XLocaleDistance;
 import org.unicode.cldr.draft.XLocaleDistance.DistanceOption;
 import org.unicode.cldr.draft.XLocaleMatcher;
@@ -23,6 +24,7 @@ import org.unicode.cldr.icu.util.LocaleMatcher;
  *
  * @author markdavis
  */
+@Disabled
 public class XLocaleMatcherTest extends TestFmwk {
     private static final boolean REFORMAT =
             false; // set to true to get a reformatted data file listed

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -192,7 +192,11 @@
 				<artifactId>mybatis</artifactId>
 				<version>3.5.6</version>
 			</dependency>
-
+			<dependency>
+				<groupId>io.github.classgraph</groupId>
+				<artifactId>classgraph</artifactId>
+				<version>4.8.184</version>
+			</dependency>
 
 			<!-- XSD generation -->
 			<dependency>


### PR DESCRIPTION
- add a test comparing TestAll's list with what's on disk
- use ClassGraph for introspection
- for now, still use the old list

CLDR-13465

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

Analysis:

### Wasn't in TestAll, but had to mark with `@Disabled` because it broke. 

These are remanded to https://unicode-org.atlassian.net/browse/CLDR-19472

- TestAlt
- TestBcp47Numbers
- TestCheckDisplayCollisions
- TestCldrFileWrite
- TestCldrResolver (didn't fail just super slow)
- TestCollators “See Ticket CLDR-8288”
- TestCompatibility
- TestCoverage
- TestDateOrder
- TestFmwkPlus (framework tests)
- TestIcuPersonNames
- TestLanguageGroup
- TestLsrvCanonicalizer
- TestPerf
- TestPluralRuleGeneration
- TestUExtension
- TestURLs
- TestXMLSource
- UnicodeSetPrettyPrinterTest
- XLocaleDistanceTest
- XLocaleMatcherTest

### Not in TestAll, so previously not tested.

- TestBcp47Transforms
- TestCheckWidths
- TestMetadataEquals
- TestPathsModule
- TestUnicodeProperty
- TestVettingViewerCategories

### In TestAll's list, but didn't exist (ignored)

- org.unicode.cldr.unittest.TestKeyboardModifierSet
- org.unicode.cldr.unittest.TestLdml2ICU
- org.unicode.cldr.unittest.TestLocaleCanonicalizer
- org.unicode.cldr.unittest.TestMetadata
- org.unicode.cldr.unittest.TestNumbers

### Shouldn't be in TestAll, run separately (separate group)

- org.unicode.cldr.api.AllTests
