### PR TITLE
CLDR-19455 Dashboard/Abstain test with minimal change

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
@@ -61,8 +61,7 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
          * TODO: move this into the caller somehow. Maybe just use a special resolver that just
          * calls into diskData.
          */
-        if (voteLoadingContext == STFactory.VoteLoadingContext.ORDINARY_LOAD_VOTES
-                && (xpd == null || xpd.isEmpty())) {
+        if (xpd == null || xpd.isEmpty()) {
             /*
              * Skip vote resolution
              */


### PR DESCRIPTION
-In BallotBoxXMLSource.setValueFromResolver, skip vote resolution if xpd is null or empty, even if voteLoadingContext is not ORDINARY_LOAD_VOTES

-This is expected to fail TestSTFactory.TestSparseVote which expects INHERITANCE_MARKER but gets null

CLDR-19455

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
