### PR TITLE
CLDR-19455 Make vote plus abstain equivalent to not voting

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
@@ -85,7 +85,8 @@ function sendRequest(xpstrid, newValue) {
     tr.theRow,
     "",
     newValue,
-    cldrSurvey.cloneAnon(protoButton)
+    cldrSurvey.cloneAnon(protoButton),
+    false /* not an abstention */
   );
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -5,7 +5,6 @@ import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrConstants from "./cldrConstants.mjs";
 import * as cldrDom from "./cldrDom.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
-import * as cldrInfo from "./cldrInfo.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
 import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrRetry from "./cldrRetry.mjs";
@@ -35,7 +34,8 @@ let voteLevelChanged = 0;
  */
 function wireUpButton(button, tr, theRow, vHash) {
   let vHashStr = vHash;
-  if (vHash == null) {
+  const isAbstain = vHash == null;
+  if (isAbstain) {
     // this is an "Abstain" ("no") button
     button.id = "NO_" + tr.rowHash;
     vHash = null;
@@ -46,7 +46,7 @@ function wireUpButton(button, tr, theRow, vHash) {
   }
   cldrDom.listenFor(button, "change", function (e) {
     if (button.checked) {
-      handleWiredClick(tr, theRow, vHash, undefined, button);
+      handleWiredClick(tr, theRow, vHash, undefined, button, isAbstain);
     }
     cldrEvent.stopPropagation(e);
     return false;
@@ -75,11 +75,19 @@ function wireUpButton(button, tr, theRow, vHash) {
  *                       or empty string for newly submitted value
  * @param {Object} newValue the newly submitted value, or undefined if it's a vote for an already existing value (buttonb)
  * @param {Element} button the GUI button
+ * @param {Boolean} isAbstain true for an abstain button, false for a vote/submit button
  *
- * Called from cldrTable.addValueVote (for new value submission)
+ * Called from cldrAddValue.sendRequest (for new value submission)
  * as well as locally in cldrVote (vote for existing value or abstain)
  */
-async function handleWiredClick(tr, theRow, vHash, newValue, button) {
+async function handleWiredClick(
+  tr,
+  theRow,
+  vHash,
+  newValue,
+  button,
+  isAbstain
+) {
   if (!tr || !theRow || tr.wait) {
     return;
   }
@@ -112,6 +120,7 @@ async function handleWiredClick(tr, theRow, vHash, newValue, button) {
   const ourContent = {
     value: valToShow,
     voteLevelChanged: voteLevelChanged,
+    isAbstain: isAbstain,
   };
   const ourUrl = getSubmitUrl(theRow.xpstrid);
   const init = cldrAjax.makePostData(ourContent);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
@@ -71,6 +71,15 @@ public interface BallotBox<T> {
      * @param value raw (non-display) value
      */
     public void voteForValueWithType(
+            T user,
+            String distinguishingXpath,
+            String value,
+            Integer withVote,
+            boolean isAbstain,
+            VoteType voteType)
+            throws VoteNotAcceptedException, InvalidXPathException;
+
+    public void voteForValueWithType(
             T user, String distinguishingXpath, String value, Integer withVote, VoteType voteType)
             throws InvalidXPathException, VoteNotAcceptedException;
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.web;
 import java.util.Date;
 import java.util.logging.Logger;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
+import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.VoteResolver.Status;
 import org.unicode.cldr.util.XMLSource;
@@ -57,7 +58,7 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
          * result in "no votes", "skip vote resolution", failure to get the right winning value, possibly inherited.
          */
 
-        /**
+        /*
          * TODO: move this into the caller somehow. Maybe just use a special resolver that just
          * calls into diskData.
          */
@@ -71,6 +72,16 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
         } else {
             resolver = ballotBox.getResolver(path, resolver);
             value = resolver.getWinningValue();
+            Status status = resolver.getWinningStatus();
+            // If there are no votes, the winning value may be INHERITANCE_MARKER and the status may
+            // be missing. This should not lead to delegate.putValueAtPath(INHERITANCE_MARKER),
+            // since that would be inconsistent with the initial state when there are no votes, vote
+            // resolution is skipped, and diskData.getValueAtDPath returns null (see above). For
+            // example, a vote followed by an abstention by the same user should result in no
+            // change, just as if the user had never voted.
+            if (value == CldrUtility.INHERITANCE_MARKER && status == Status.missing) {
+                value = null;
+            }
             fullPath = getFullPathWithResolver(path, resolver);
         }
         delegate.removeValueAtDPath(path);
@@ -122,7 +133,7 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
      *     <p>References: https://unicode.org/cldr/trac/ticket/11721
      *     https://unicode.org/cldr/trac/ticket/11766 https://unicode.org/cldr/trac/ticket/11103
      */
-    private static final DraftStatus draftStatusFromWinningStatus(VoteResolver.Status win) {
+    private static DraftStatus draftStatusFromWinningStatus(VoteResolver.Status win) {
         try {
             return DraftStatus.forString(win.toString());
         } catch (IllegalArgumentException e) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -73,10 +73,16 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
         ORDINARY_LOAD_VOTES,
 
         /**
-         * The context when a voting (or abstaining) event occurs and setValueFromResolver is called
-         * by voteForValue (not used for loadVoteValues)
+         * The context when a voting (NOT abstaining) event occurs and setValueFromResolver is
+         * called by voteForValue (not used for loadVoteValues)
          */
         SINGLE_VOTE,
+
+        /**
+         * The context when an abstaining event occurs and setValueFromResolver is called by
+         * voteForValue (not used for loadVoteValues)
+         */
+        SINGLE_ABSTENTION,
     }
 
     /** Names of some columns in DBUtils.Table.VOTE_VALUE */
@@ -244,6 +250,8 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
 
             private void setVoteForValue(
                     User user, String value, Integer voteOverride, Date when, VoteType voteType) {
+                // If voteType == VoteType.VOTE_FOR_MISSING, then value may be null and the null
+                // value does not mean abstention.
                 if (value != null || voteType == VoteType.VOTE_FOR_MISSING) {
                     setPerUserData(user, new PerUserData(value, voteOverride, when, voteType));
                 } else {
@@ -787,14 +795,12 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
         @Override
         public void voteForValue(User user, String distinguishingXpath, String value)
                 throws InvalidXPathException, VoteNotAcceptedException {
-            voteForValueWithType(user, distinguishingXpath, value, null, VoteType.DIRECT);
-        }
-
-        @Override
-        public void voteForValueWithType(
-                User user, String distinguishingXpath, String value, VoteType voteType)
-                throws VoteNotAcceptedException, InvalidXPathException {
-            voteForValueWithType(user, distinguishingXpath, value, null, voteType);
+            // TODO: derive isAbstain from the caller where possible, instead of inferring it here
+            // based on null or empty value. Reference:
+            // https://unicode-org.atlassian.net/browse/CLDR-19455
+            boolean isAbstain = value == null || value.isEmpty();
+            voteForValueWithType(
+                    user, distinguishingXpath, value, null, isAbstain, VoteType.DIRECT);
         }
 
         @Override
@@ -803,6 +809,33 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 String distinguishingXpath,
                 String value,
                 Integer withVote,
+                VoteType voteType)
+                throws VoteNotAcceptedException, InvalidXPathException {
+            // TODO: derive isAbstain from the caller where possible, instead of inferring it here
+            // based on null or empty value. Reference:
+            // https://unicode-org.atlassian.net/browse/CLDR-19455
+            boolean isAbstain = value == null || value.isEmpty();
+            voteForValueWithType(user, distinguishingXpath, value, withVote, isAbstain, voteType);
+        }
+
+        @Override
+        public void voteForValueWithType(
+                User user, String distinguishingXpath, String value, VoteType voteType)
+                throws VoteNotAcceptedException, InvalidXPathException {
+            // TODO: derive isAbstain from the caller where possible, instead of inferring it here
+            // based on null or empty value. Reference:
+            // https://unicode-org.atlassian.net/browse/CLDR-19455
+            boolean isAbstain = value == null || value.isEmpty();
+            voteForValueWithType(user, distinguishingXpath, value, null, isAbstain, voteType);
+        }
+
+        @Override
+        public void voteForValueWithType(
+                User user,
+                String distinguishingXpath,
+                String value,
+                Integer withVote,
+                boolean isAbstain,
                 VoteType voteType)
                 throws BallotBox.InvalidXPathException, BallotBox.VoteNotAcceptedException {
             makeSureInPathsForFile(distinguishingXpath, user, value);
@@ -880,11 +913,20 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 if (withVote != null && withVote == VoteResolver.Level.PERMANENT_VOTES) {
                     doPermanentVote(distinguishingXpath, xpathId, value);
                 }
-
+                // TODO: clarify whether value can be null or empty here even if isAbstain is false
+                // Reference: https://unicode-org.atlassian.net/browse/CLDR-19455
+                if (false && (value == null || value.isEmpty()) && !isAbstain) {
+                    throw new VoteNotAcceptedException(
+                            ErrorCode.E_INTERNAL, "Bad value for non-abstention vote");
+                }
+                VoteLoadingContext voteLoadingContext =
+                        isAbstain
+                                ? VoteLoadingContext.SINGLE_ABSTENTION
+                                : VoteLoadingContext.SINGLE_VOTE;
                 dataBackedSource.setValueFromResolver(
                         distinguishingXpath,
                         null,
-                        VoteLoadingContext.SINGLE_VOTE,
+                        voteLoadingContext,
                         peekXpathData(distinguishingXpath));
             }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -1802,7 +1802,14 @@ public class SurveyAjax extends HttpServlet {
         /*
          * Submit the anonymous vote.
          */
-        box.voteForValueWithType(anonUser, xpathString, processedValue, VoteType.MANUAL_IMPORT);
+        boolean isAbstain = false;
+        box.voteForValueWithType(
+                anonUser,
+                xpathString,
+                processedValue,
+                null /* withVote */,
+                isAbstain,
+                VoteType.MANUAL_IMPORT);
         logger.finest(() -> "Voted " + xpathId);
         /*
          * Add a row to the IMPORT table, to avoid importing the same value repeatedly.
@@ -2272,8 +2279,17 @@ public class SurveyAjax extends HttpServlet {
                      * Since we're going through tables in reverse chronological order, "already" here implies
                      * "for a later version".
                      */
+                    // TODO: verify that null or empty value means isAbstain should be true here.
+                    // Reference: https://unicode-org.atlassian.net/browse/CLDR-19455
+                    boolean isAbstain = (value == null || value.isEmpty());
                     if (box.getVoteValue(user, xpathString) == null) {
-                        box.voteForValueWithType(user, xpathString, value, VoteType.AUTO_IMPORT);
+                        box.voteForValueWithType(
+                                user,
+                                xpathString,
+                                value,
+                                null /* withVote */,
+                                isAbstain,
+                                VoteType.AUTO_IMPORT);
                         confirmations++;
                     }
                 }
@@ -2813,7 +2829,17 @@ public class SurveyAjax extends HttpServlet {
                             resultIcon = "stop";
                         } else {
                             if (doFinal) {
-                                ballotBox.voteForValueWithType(u, base, val0, VoteType.BULK_UPLOAD);
+                                // TODO: verify that null or empty value means isAbstain should be
+                                // true here.
+                                // Reference: https://unicode-org.atlassian.net/browse/CLDR-19455
+                                boolean isAbstain = (val0 == null || val0.isEmpty());
+                                ballotBox.voteForValueWithType(
+                                        u,
+                                        base,
+                                        val0,
+                                        null /* withVote */,
+                                        isAbstain,
+                                        VoteType.BULK_UPLOAD);
                                 result = "Vote accepted";
                                 resultIcon = "vote";
                             } else {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -407,6 +407,7 @@ public class VoteAPI {
                 xp,
                 request.value,
                 request.voteLevelChanged,
+                request.isAbstain,
                 mySession,
                 true /* forbiddenIsOk */);
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -479,23 +479,19 @@ public class VoteAPIHelper {
     // forbiddenIsOk is false when called from XPathAlt for the special purpose of adding a new
     // path, so that
     // XPathAlt will get something other than OK (200) in case of failure.
-    //
-    // This method needs refactoring into smaller subroutines, with the lower-level details
-    // separated from
-    // the HTTP response concerns, so that VoteAPI and XPathAlt can share code without the
-    // awkwardness of forbiddenIsOk.
     public static Response handleVote(
             String loc,
             String xp,
             String value,
             int voteLevelChanged,
+            boolean isAbstain,
             final CookieSession mySession,
             boolean forbiddenIsOk) {
         // translate this call into jax-rs Response
         try {
             final VoteResponse r =
                     getHandleVoteResponse(
-                            loc, xp, value, voteLevelChanged, mySession, forbiddenIsOk);
+                            loc, xp, value, voteLevelChanged, isAbstain, mySession, forbiddenIsOk);
             return Response.ok(r).build();
         } catch (Throwable se) {
             return new STError(se).build();
@@ -528,6 +524,7 @@ public class VoteAPIHelper {
             String xp,
             String value,
             int voteLevelChanged,
+            boolean isAbstain,
             final CookieSession mySession,
             boolean forbiddenIsOk)
             throws SurveyException {
@@ -578,7 +575,7 @@ public class VoteAPIHelper {
                                     stf.ballotBoxForLocale(locale);
                             Integer withVote = (voteLevelChanged == 0) ? null : voteLevelChanged;
                             ballotBox.voteForValueWithType(
-                                    mySession.user, xp, val, withVote, VoteType.DIRECT);
+                                    mySession.user, xp, val, withVote, isAbstain, VoteType.DIRECT);
                             r.didVote = true;
                         } catch (VoteNotAcceptedException e) {
                             if (e.getErrCode() == ErrorCode.E_PERMANENT_VOTE_NO_FORUM) {
@@ -645,12 +642,17 @@ public class VoteAPIHelper {
                     if (!r.statusAction.isForbidden()) {
                         final BallotBox<UserRegistry.User> ballotBox =
                                 stf.ballotBoxForLocale(locale);
-                        // Hey, VOTE_FOR_MISSING is the point of this function..
+                        // Hey, VOTE_FOR_MISSING is the point of this function.
+                        // Note: here value is null, and isAbstain is false; this is verified
+                        // to work correctly.
+                        String value = null;
+                        boolean isAbstain = false;
                         ballotBox.voteForValueWithType(
                                 mySession.user,
                                 xp,
-                                null,
+                                value,
                                 voteLevelChanged,
+                                isAbstain,
                                 VoteType.VOTE_FOR_MISSING);
                         r.didVote = true;
                     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteRequest.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteRequest.java
@@ -12,4 +12,7 @@ public class VoteRequest {
             nullable = true,
             defaultValue = "null")
     public Integer voteLevelChanged;
+
+    @Schema(description = "True for abstention, false for vote/submission")
+    public boolean isAbstain;
 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAlt.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAlt.java
@@ -166,14 +166,16 @@ public class XPathAlt {
             if (cldrFile.isHere(newXpath)) { // compare STFactory.getPathsForFile()
                 return alreadyExists(newXpath);
             }
-            String newValue = null; // Abstain; CldrUtility.INHERITANCE_MARKER could give
-            // StatusAction.FORBID_NULL
+            // Abstain; CldrUtility.INHERITANCE_MARKER could give StatusAction.FORBID_NULL
+            boolean isAbstain = true;
+            String newValue = null;
             Response r =
                     VoteAPIHelper.handleVote(
                             locale.getBaseName(),
                             newXpath,
                             newValue,
                             1 /* one vote */,
+                            isAbstain,
                             session,
                             false /* forbiddenIsOk */);
             int status = r.getStatus();

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/DataDrivenSTTestHandler.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/DataDrivenSTTestHandler.java
@@ -82,11 +82,17 @@ final class DataDrivenSTTestHandler extends XMLFileReader.SimpleHandler {
                 break;
             case "apivote":
             case "apiunvote":
-                handleElementApivote(attrs, value, elem, xpath);
+                {
+                    boolean isAbstain = elem.equals("apiunvote");
+                    handleElementApivote(attrs, value, isAbstain, elem, xpath);
+                }
                 break;
             case "vote":
             case "unvote":
-                handleElementVote(fac, attrs, value, elem, xpath);
+                {
+                    boolean isAbstain = elem.equals("unvote");
+                    handleElementVote(fac, attrs, value, isAbstain, elem, xpath);
+                }
                 break;
             case "apiverify":
                 handleElementApiverify(attrs, value, xpath);
@@ -421,6 +427,7 @@ final class DataDrivenSTTestHandler extends XMLFileReader.SimpleHandler {
             final STFactory fac,
             final Map<String, String> attrs,
             String value,
+            boolean isAbstain,
             String elem,
             String xpath) {
         UserRegistry.User u = getUserFromAttrs(attrs, "name");
@@ -428,8 +435,8 @@ final class DataDrivenSTTestHandler extends XMLFileReader.SimpleHandler {
         BallotBox<User> box = fac.ballotBoxForLocale(locale);
         value = value.trim();
         boolean needException = getBooleanAttr(attrs, "exception", false);
-        if (elem.equals("unvote")) {
-            value = null;
+        if (isAbstain) {
+            value = null; // ABSTAIN
         }
         try {
             box.voteForValue(u, xpath, value);
@@ -457,11 +464,15 @@ final class DataDrivenSTTestHandler extends XMLFileReader.SimpleHandler {
     }
 
     private void handleElementApivote(
-            final Map<String, String> attrs, String value, String elem, String xpath) {
+            final Map<String, String> attrs,
+            String value,
+            boolean isAbstain,
+            String elem,
+            String xpath) {
         UserRegistry.User u = getUserFromAttrs(attrs, "name");
         CLDRLocale locale = CLDRLocale.getInstance(attrs.get("locale"));
         boolean needException = getBooleanAttr(attrs, "exception", false);
-        if (elem.equals("apiunvote")) {
+        if (isAbstain) {
             value = null;
         }
         assertEquals(
@@ -476,7 +487,7 @@ final class DataDrivenSTTestHandler extends XMLFileReader.SimpleHandler {
         try {
             final VoteAPI.VoteResponse r =
                     VoteAPIHelper.getHandleVoteResponse(
-                            locale.getBaseName(), xpath, value, 0, mySession, false);
+                            locale.getBaseName(), xpath, value, 0, isAbstain, mySession, false);
             final boolean isOk = r.didVote;
             final boolean asExpected = (isOk == !needException);
             if (!asExpected) {

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSTFactory.java
@@ -31,7 +31,6 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.FileReaders;
 import org.unicode.cldr.util.SpecialLocales;
 import org.unicode.cldr.util.StackTracker;
@@ -107,7 +106,7 @@ public class TestSTFactory {
         if (expectString == null) expectString = NULL;
         if (currentWinner == null) currentWinner = NULL;
 
-        if (expectString != ANY && !expectString.equals(currentWinner)) {
+        if (!expectString.equals(ANY) && !expectString.equals(currentWinner)) {
             assertEquals(
                     expectString,
                     currentWinner,
@@ -371,16 +370,17 @@ public class TestSTFactory {
         String changedTo2 = null;
         CLDRLocale locale2 = CLDRLocale.getInstance("fr_BE");
         // Can't (and shouldn't) try to do this test if the locale is configured as read-only
-        // (including algorithmic).
-        if (SpecialLocales.Type.isReadOnly(SpecialLocales.getType(locale2))) {
-            return;
-        }
+        // (including algorithmic), in which case this test needs fixing and should fail.
+        assertFalse(SpecialLocales.Type.isReadOnly(SpecialLocales.getType(locale2)));
 
         // test sparsity
         {
             CLDRFile cldrFile = fac.make(locale2, false);
             BallotBox<User> box = fac.ballotBoxForLocale(locale2);
 
+            /*
+             * No one has voted; expect null to win
+             */
             originalValue2 = expect(somePath2, null, false, cldrFile, box);
 
             changedTo2 = "The alternate pump fixing screws with the incorrect strength class";
@@ -411,9 +411,9 @@ public class TestSTFactory {
             box.voteForValue(getMyUser(), somePath2, null);
 
             /*
-             * No one has voted; expect inheritance to win
+             * Vote followed by abstain should be the same as if no one has voted; expect null to win
              */
-            expect(somePath2, CldrUtility.INHERITANCE_MARKER, false, cldrFile, box);
+            expect(somePath2, null, false, cldrFile, box);
         }
         fac = resetFactory();
         {


### PR DESCRIPTION
-Revise BallotBoxXMLSource.setValueFromResolver to recognize Status.missing

-Fix TestSTFactory.TestSparseVote

-Add isAbstain to http request, making Abstain explicitly distinct from Vote/Submit and not only implied by null or empty value

-The value of isAbstain does not yet change the behavior of Survey Tool; it serves as a basis for debugging and future improvement

-Empty values are legal for some paths; how vetters (should) input them in ST needs clarification, which should be facilitated by making explicit distinctions in the code

-New value for STFactory.VoteLoadingContext: SINGLE_ABSTENTION, distinct from SINGLE_VOTE and ORDINARY_LOAD_VOTES

-Fix a compiler warning for expectString != ANY

-Comments, including TODO

CLDR-19455

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
