### PR TITLE
CLDR-19001 Remove gmtZeroFormat

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1854,6 +1854,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@DEPRECATED:true, false-->
 <!ATTLIST gmtZeroFormat references CDATA #IMPLIED >
     <!--@METADATA-->
+    <!--@DEPRECATED-->
 
 <!ELEMENT gmtUnknownFormat ( #PCDATA ) >
 <!ATTLIST gmtUnknownFormat alt NMTOKENS #IMPLIED >

--- a/common/main/ab.xml
+++ b/common/main/ab.xml
@@ -1708,7 +1708,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">{0} Аамҭа</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} Аԥхынтәи Аамҭа</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">{0} Астандартә Аамҭа</regionFormat>

--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -2656,7 +2656,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}-tyd</regionFormat>
 			<regionFormat type="daylight">{0}-dagligtyd</regionFormat>

--- a/common/main/ak.xml
+++ b/common/main/ak.xml
@@ -2174,7 +2174,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Berɛ {0}</regionFormat>
 			<regionFormat type="daylight">Awia ber {0}</regionFormat>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -3665,7 +3665,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HHmm;-HHmm</hourFormat>
 			<gmtFormat>ጂ ኤም ቲ{0}</gmtFormat>
-			<gmtZeroFormat>ጂ ኤም ቲ</gmtZeroFormat>
 			<gmtUnknownFormat>ጂ ኤም ቲ+</gmtUnknownFormat>
 			<regionFormat>{0} ሰዓት</regionFormat>
 			<regionFormat type="daylight">{0} የቀን ብርሃን ሰዓት</regionFormat>

--- a/common/main/an.xml
+++ b/common/main/an.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1278,7 +1278,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">Hora de {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">Hora de verano de {0}</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">Hora standard de {0}</regionFormat>

--- a/common/main/apc.xml
+++ b/common/main/apc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -114,7 +114,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">↑↑↑</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">↑↑↑</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">↑↑↑</regionFormat>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -3693,7 +3693,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>غرينتش{0}</gmtFormat>
-			<gmtZeroFormat>غرينتش</gmtZeroFormat>
 			<gmtUnknownFormat>غرينتش+?</gmtUnknownFormat>
 			<regionFormat>توقيت {0}</regionFormat>
 			<regionFormat type="daylight">توقيت {0} الصيفي</regionFormat>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -2603,7 +2603,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} সময়</regionFormat>
 			<regionFormat type="daylight">{0} (+1) ডেলাইট সময়</regionFormat>

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -4300,7 +4300,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Hora de {0}</regionFormat>
 			<regionFormat type="daylight">Hora braniega de {0}</regionFormat>
 			<regionFormat type="standard">Hora estándar de {0}</regionFormat>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -3026,7 +3026,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Vaxtı</regionFormat>
 			<regionFormat type="daylight">{0} Yay Vaxtı</regionFormat>

--- a/common/main/ba.xml
+++ b/common/main/ba.xml
@@ -3403,7 +3403,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} ваҡыты</regionFormat>
 			<regionFormat type="daylight">{0} йәйге ваҡыты</regionFormat>

--- a/common/main/bal_Latn.xml
+++ b/common/main/bal_Latn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3477,7 +3477,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -2994,7 +2994,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Час: {0}</regionFormat>
 			<regionFormat type="daylight">Летні час: {0}</regionFormat>

--- a/common/main/be_TARASK.xml
+++ b/common/main/be_TARASK.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2555,7 +2555,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat draft="provisional">↑↑↑</hourFormat>
 			<gmtFormat draft="provisional">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="provisional">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="provisional">час: {0}</regionFormat>
 			<regionFormat type="daylight" draft="provisional">летні час: {0}</regionFormat>
 			<regionFormat type="standard" draft="provisional">змоўчны час: {0}</regionFormat>

--- a/common/main/bew.xml
+++ b/common/main/bew.xml
@@ -2923,7 +2923,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">+HH.mm;-HH.mm</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">Waktu {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">Waktu Musim Pentèr {0}</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">Waktu Pakem {0}</regionFormat>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -2975,7 +2975,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>Гринуич{0}</gmtFormat>
-			<gmtZeroFormat>Гринуич</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">Гринуич+?</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0} – лятно часово време</regionFormat>

--- a/common/main/bgc.xml
+++ b/common/main/bgc.xml
@@ -168,7 +168,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} समय</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">{0} (+0) स्टैण्डर्ड समय</regionFormat>

--- a/common/main/bho.xml
+++ b/common/main/bho.xml
@@ -141,7 +141,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} टाइम</regionFormat>
 			<regionFormat type="daylight">{0} डेलाइट समय</regionFormat>
 			<regionFormat type="standard">{0} मानक समय</regionFormat>

--- a/common/main/blo.xml
+++ b/common/main/blo.xml
@@ -1833,7 +1833,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>{0} Gk</gmtFormat>
-			<gmtZeroFormat>Gk</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} kaakɔŋkɔŋɔ̀</regionFormat>
 			<regionFormat type="daylight">{0} kaakɔŋkɔŋɔ̀ gafʊbaka</regionFormat>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -3909,7 +3909,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} সময়</regionFormat>
 			<regionFormat type="daylight">{0} দিবালোক সময়</regionFormat>

--- a/common/main/bqi.xml
+++ b/common/main/bqi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -293,7 +293,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">‎+HH:mm;‎−HH:mm</hourFormat>
 			<gmtFormat draft="unconfirmed">{0} گرینویچ</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">گرینویچ</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">مجال {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">مجال توستووی {0}</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">مجال عادی {0}</regionFormat>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -6520,7 +6520,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>UTC{0}</gmtFormat>
-			<gmtZeroFormat>UTC</gmtZeroFormat>
 			<gmtUnknownFormat>UTC+?</gmtUnknownFormat>
 			<regionFormat>eur {0}</regionFormat>
 			<regionFormat type="daylight">eur hañv {0}</regionFormat>

--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -2664,7 +2664,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>जि.एम.ति {0}</gmtFormat>
-			<gmtZeroFormat>जि.एम.ति</gmtZeroFormat>
 			<regionFormat>{0} सम</regionFormat>
 			<regionFormat type="daylight">{0} साननि सोरां सम</regionFormat>
 			<regionFormat type="standard">{0} थाखोआरि सम</regionFormat>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -8104,7 +8104,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH:mm; -HH:mm</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, ljetno vrijeme</regionFormat>

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -3140,7 +3140,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Време: {0}</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/bua.xml
+++ b/common/main/bua.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -190,7 +190,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -3533,7 +3533,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Hora de: {0}</regionFormat>
 			<regionFormat type="daylight">Hora d’estiu, {0}</regionFormat>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -2545,7 +2545,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} 𑄃𑄧𑄇𑄴𑄖𑄧</regionFormat>
 			<regionFormat type="daylight">{0} 𑄘𑄨𑄝𑄪𑄌𑄴𑄎𑄳𑄠 𑄃𑄧𑄇𑄴𑄖𑄧𑄖𑄴</regionFormat>
 			<regionFormat type="standard">{0} 𑄟𑄚𑄧𑄇𑄴 𑄃𑄧𑄇𑄴𑄖𑄧𑄖𑄴</regionFormat>

--- a/common/main/ce.xml
+++ b/common/main/ce.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1576,7 +1576,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -1369,7 +1369,6 @@ the LDML specification (http://unicode.org/reports/tr35/)
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Oras sa {0}</regionFormat>
 			<regionFormat type="daylight">Daylight nga Oras sa {0}</regionFormat>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -2507,7 +2507,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} ᎠᏟᎢᎵᏒ</regionFormat>
 			<regionFormat type="daylight">{0} ᎪᎯ ᎢᎦ ᎠᏟᎢᎵᏒ</regionFormat>

--- a/common/main/ckb.xml
+++ b/common/main/ckb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1651,7 +1651,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>گرینیچ {0}</gmtFormat>
-			<gmtZeroFormat>گرینیچ</gmtZeroFormat>
 			<regionFormat>بەکاتی {0}</regionFormat>
 			<regionFormat type="daylight">کاتی {0} هاوینە</regionFormat>
 			<regionFormat type="standard">کاتی {0} فەرمی</regionFormat>

--- a/common/main/co.xml
+++ b/common/main/co.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1084,7 +1084,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">UTC{0}</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">UTC</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">ora : {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} (ora d’estate)</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">{0} (ora usuale)</regionFormat>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -7025,7 +7025,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+H:mm;-H:mm</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>časové pásmo {0}</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/csw.xml
+++ b/common/main/csw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -953,7 +953,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} ᐁᐃᐢᐸᓂᐠ</regionFormat>
 			<regionFormat type="daylight">{0} ᑮᓯᑳᐤ ᐁᐃᐢᐸᓂᐠ</regionFormat>
 			<regionFormat type="standard">{0} ᐯᔭᑯᐦᑖᐏᐣ ᐁᐃᐢᐸᓂᐠ</regionFormat>

--- a/common/main/cu.xml
+++ b/common/main/cu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -598,7 +598,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">{0} (вре́мѧ)</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} (лѣ́тнее вре́мѧ)</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">{0} (зи́мнее вре́мѧ)</regionFormat>

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -7903,7 +7903,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} вӑхӑчӗ</regionFormat>
 			<regionFormat type="daylight">{0} ҫуллахи вӑхӑчӗ</regionFormat>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -3108,7 +3108,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Amser {0}</regionFormat>
 			<regionFormat type="daylight">Amser Haf {0}</regionFormat>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -3214,7 +3214,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH.mm;-HH.mm</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}-tid</regionFormat>
 			<regionFormat type="daylight">{0}-sommertid</regionFormat>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -4236,7 +4236,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} (Ortszeit)</regionFormat>
 			<regionFormat type="daylight">{0} (Sommerzeit)</regionFormat>

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -2782,7 +2782,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/doi.xml
+++ b/common/main/doi.xml
@@ -1000,7 +1000,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} समां</regionFormat>
 			<regionFormat type="daylight">{0} डेलाइट समां</regionFormat>
 			<regionFormat type="standard">{0} मानक समां</regionFormat>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -2686,7 +2686,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Casowe pasmo {0}</regionFormat>
 			<regionFormat type="daylight">{0} lěśojski cas</regionFormat>

--- a/common/main/dz.xml
+++ b/common/main/dz.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1273,7 +1273,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>ཇི་ཨེམ་ཏི་{0}</gmtFormat>
-			<gmtZeroFormat>ཇི་ཨེམ་ཊི་</gmtZeroFormat>
 			<regionFormat>{0}་ཆུ་ཚོད།</regionFormat>
 			<fallbackFormat>{1}། ({0}་)</fallbackFormat>
 			<zone type="Etc/Unknown">

--- a/common/main/ee.xml
+++ b/common/main/ee.xml
@@ -2306,7 +2306,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>{0} GMT</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} game</regionFormat>
 			<regionFormat type="daylight">{0} ŋkekemeɣeyiɣi</regionFormat>
 			<regionFormat type="standard">{0} game ɖoɖoea</regionFormat>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -3592,7 +3592,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ώρα ({0})</regionFormat>
 			<regionFormat type="daylight">Θερινή ώρα ({0})</regionFormat>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -3582,7 +3582,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -3386,7 +3386,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/en_Dsrt.xml
+++ b/common/main/en_Dsrt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -738,7 +738,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</fields>
 		<timeZoneNames>
 			<gmtFormat>𐐘𐐣𐐓 {0}</gmtFormat>
-			<gmtZeroFormat>𐐘𐐣𐐓</gmtZeroFormat>
 			<regionFormat>{0} 𐐓𐐴𐑋</regionFormat>
 			<zone type="Pacific/Honolulu">
 				<exemplarCity>𐐐𐐪𐑌𐐲𐑊𐐭𐑊𐐭</exemplarCity>

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -4036,7 +4036,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -3371,7 +3371,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/en_Shaw.xml
+++ b/common/main/en_Shaw.xml
@@ -1196,7 +1196,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat>·𐑜𐑥𐑑{0}</gmtFormat>
-			<gmtZeroFormat>·𐑜𐑥𐑑</gmtZeroFormat>
 			<gmtUnknownFormat draft="unconfirmed">𐑜𐑥𐑑+?</gmtUnknownFormat>
 			<regionFormat>{0} 𐑑𐑲𐑥</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} 𐑛𐑱𐑤𐑲𐑑 𐑑𐑲𐑥</regionFormat>

--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -2523,7 +2523,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>UTC{0}</gmtFormat>
-			<gmtZeroFormat>UTC</gmtZeroFormat>
 			<gmtUnknownFormat>UTC+?</gmtUnknownFormat>
 			<regionFormat>tempo: {0}</regionFormat>
 			<regionFormat type="daylight">{0} (somera tempo)</regionFormat>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -3686,7 +3686,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>hora de {0}</regionFormat>
 			<regionFormat type="daylight">horario de verano de {0}</regionFormat>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -3087,7 +3087,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">hora de verano de {0}</regionFormat>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -2729,7 +2729,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -2756,7 +2756,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -3174,7 +3174,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH:mm;−HH:mm</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>({0})</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -7912,7 +7912,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH:mm;–HH:mm</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} aldeko ordua</regionFormat>
 			<regionFormat type="daylight">{0} (udako ordua)</regionFormat>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -3994,7 +3994,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>‎+HH:mm;‎−HH:mm</hourFormat>
 			<gmtFormat>{0} گرینویچ</gmtFormat>
-			<gmtZeroFormat>گرینویچ</gmtZeroFormat>
 			<gmtUnknownFormat>گرینویچ+؟</gmtUnknownFormat>
 			<regionFormat>وقت {0}</regionFormat>
 			<regionFormat type="daylight">وقت تابستانی {0}</regionFormat>

--- a/common/main/ff_Adlm.xml
+++ b/common/main/ff_Adlm.xml
@@ -7384,7 +7384,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>𞤑𞤖𞤘{0}</gmtFormat>
-			<gmtZeroFormat>𞤑𞤖𞤘</gmtZeroFormat>
 			<regionFormat>{0} 𞤑𞤭𞤶𞤮𞥅𞤪𞤫</regionFormat>
 			<regionFormat type="daylight">{0} 𞤐𞤶𞤢𞤥𞤲𞤣𞤭 𞤕𞤫𞥅𞤯𞤵</regionFormat>
 			<regionFormat type="standard">{0} 𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤖𞤢𞤱𞤪𞤵𞤲𞥋𞤣𞤫</regionFormat>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -3937,7 +3937,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+H.mm;-H.mm</hourFormat>
 			<gmtFormat>UTC{0}</gmtFormat>
-			<gmtZeroFormat>UTC</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>aikavyöhyke: {0}</regionFormat>
 			<regionFormat type="daylight">{0} (kesäaika)</regionFormat>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -4779,7 +4779,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Oras sa {0}</regionFormat>
 			<regionFormat type="daylight">Daylight Time ng {0}</regionFormat>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2646,7 +2646,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} tíð</regionFormat>
 			<regionFormat type="daylight">{0} summartíð</regionFormat>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -4867,7 +4867,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH:mm;−HH:mm</hourFormat>
 			<gmtFormat>UTC{0}</gmtFormat>
-			<gmtZeroFormat>UTC</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>heure : {0}</regionFormat>
 			<regionFormat type="daylight">{0} (heure d’été)</regionFormat>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -3621,7 +3621,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0} (heure avancée)</regionFormat>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -2411,7 +2411,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="unconfirmed">↑↑↑</gmtUnknownFormat>
 			<regionFormat draft="unconfirmed">{0} Tidj</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} Somertidj</regionFormat>

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4000,7 +4000,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">{0}-tiid</regionFormat>
 			<regionFormat type="daylight" draft="contributed">Zomertiid {0}</regionFormat>
 			<regionFormat type="standard" draft="contributed">Standaardtiid {0}</regionFormat>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -3298,7 +3298,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>MAG{0}</gmtFormat>
-			<gmtZeroFormat>MAG</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/gaa.xml
+++ b/common/main/gaa.xml
@@ -1199,7 +1199,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} Be</regionFormat>
 			<regionFormat type="daylight">{0} Be Yɛ Latsa Beiaŋ</regionFormat>
 			<regionFormat type="standard">{0} Be Yɛ Fɛi Beiaŋ</regionFormat>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -4542,7 +4542,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">Tìde samhraidh: {0}</regionFormat>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -2652,7 +2652,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>hora de: {0}</regionFormat>
 			<regionFormat type="daylight">hora de verán de: {0}</regionFormat>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -3494,7 +3494,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} સમય</regionFormat>
 			<regionFormat type="daylight">{0} દિવસ સમય</regionFormat>

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -2658,7 +2658,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Lokaci</regionFormat>
 			<regionFormat type="daylight">{0} Lokacin Rana</regionFormat>

--- a/common/main/ha_NE.xml
+++ b/common/main/ha_NE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2652,7 +2652,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Lokaci</regionFormat>
 			<regionFormat type="daylight">{0} Lokacin Rana</regionFormat>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -4647,7 +4647,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>‎+HH:mm;-HH:mm‎</hourFormat>
 			<gmtFormat>GMT{0}‎</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>שעון {0}</regionFormat>
 			<regionFormat type="daylight">שעון {0} (קיץ)</regionFormat>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -3346,7 +3346,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} समय</regionFormat>
 			<regionFormat type="daylight">{0} डेलाइट समय</regionFormat>

--- a/common/main/hi_Latn.xml
+++ b/common/main/hi_Latn.xml
@@ -3246,7 +3246,6 @@ annotations.
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -3591,7 +3591,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH:mm; -HH:mm</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, ljetno vrijeme</regionFormat>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -2680,7 +2680,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>časowe pasmo {0}</regionFormat>
 			<regionFormat type="daylight">{0} lětni čas</regionFormat>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -3548,7 +3548,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} idő</regionFormat>
 			<regionFormat type="daylight">{0} nyári idő</regionFormat>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -2652,7 +2652,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -2490,7 +2490,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>hora de {0}</regionFormat>
 			<regionFormat type="daylight">hora estive de {0}</regionFormat>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -4641,7 +4641,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH.mm;-HH.mm</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Waktu {0}</regionFormat>
 			<regionFormat type="daylight">Waktu Musim Panas {0}</regionFormat>

--- a/common/main/ie.xml
+++ b/common/main/ie.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1959,7 +1959,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>TMG{0}</gmtFormat>
-			<gmtZeroFormat>TMG</gmtZeroFormat>
 			<gmtUnknownFormat>TMG+?</gmtUnknownFormat>
 			<regionFormat>témpor de {0}</regionFormat>
 			<regionFormat type="daylight">témpor estival de {0}</regionFormat>

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -2628,7 +2628,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Oge {0}</regionFormat>
 			<regionFormat type="daylight">Oge Ihe {0}</regionFormat>

--- a/common/main/ii.xml
+++ b/common/main/ii.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -638,7 +638,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>ꋧꃅꎕꏦꄮꈉ{0}</gmtFormat>
-			<gmtZeroFormat>ꋧꃅꎕꏦꄮꈉ</gmtZeroFormat>
 			<regionFormat>{0}ꄮꈉ</regionFormat>
 			<regionFormat type="daylight">{0}ꃅꎸꄮꈉ</regionFormat>
 			<regionFormat type="standard">{0}ꎕꏦꄮꈉ</regionFormat>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -5158,7 +5158,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0} (sumartími)</regionFormat>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -3130,7 +3130,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ora {0}</regionFormat>
 			<regionFormat type="daylight">Ora legale: {0}</regionFormat>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -4619,7 +4619,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}時間</regionFormat>
 			<regionFormat type="daylight">{0}夏時間</regionFormat>

--- a/common/main/jgo.xml
+++ b/common/main/jgo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -520,7 +520,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<fallbackFormat>↑↑↑</fallbackFormat>
 		</timeZoneNames>

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -2555,7 +2555,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Wektu {0}</regionFormat>
 			<regionFormat type="daylight">Wektu Ketigo {0}</regionFormat>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -3121,7 +3121,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>დრო: {0}</regionFormat>
 			<regionFormat type="daylight">{0} ზაფხულის დრო</regionFormat>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -2531,7 +2531,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">KLG {0}</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">KLG</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">Akud: {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} Akud n unebdu</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">{0} Akud amezday</regionFormat>

--- a/common/main/kea.xml
+++ b/common/main/kea.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2022,7 +2022,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Ora di {0}</regionFormat>
 			<regionFormat type="daylight">Ora di Veron di {0}</regionFormat>
 			<regionFormat type="standard">Ora Padron di {0}</regionFormat>

--- a/common/main/kgp.xml
+++ b/common/main/kgp.xml
@@ -2875,7 +2875,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Óra kar {0}</regionFormat>
 			<regionFormat type="daylight">Prỹg kã óra kar {0}</regionFormat>
 			<regionFormat type="standard">Óra pẽ {0}</regionFormat>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -3751,7 +3751,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} уақыты</regionFormat>
 			<regionFormat type="daylight">{0} жазғы уақыты</regionFormat>

--- a/common/main/kk_Arab.xml
+++ b/common/main/kk_Arab.xml
@@ -3123,7 +3123,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} ۋاقىتى</regionFormat>
 			<regionFormat type="daylight">{0} جازعى ۋاقىتى</regionFormat>

--- a/common/main/kl.xml
+++ b/common/main/kl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1095,7 +1095,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">+HH:mm;−HH:mm</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">↑↑↑</regionFormat>
 			<fallbackFormat draft="unconfirmed">{0} ({1})</fallbackFormat>
 			<zone type="Etc/Unknown">

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -2540,7 +2540,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>ម៉ោង​សកល {0}</gmtFormat>
-			<gmtZeroFormat>ម៉ោង​សកល</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>ម៉ោង​នៅ​ {0}</regionFormat>
 			<regionFormat type="daylight">ម៉ោង​ពេល​ថ្ងៃ​នៅ​ {0}</regionFormat>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -3504,7 +3504,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} ಸಮಯ</regionFormat>
 			<regionFormat type="daylight">{0} ದಿನದ ಸಮಯ</regionFormat>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -4186,7 +4186,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} 시간</regionFormat>
 			<regionFormat type="daylight">{0} 하계 표준시</regionFormat>

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -2674,7 +2674,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} वेळ</regionFormat>
 			<regionFormat type="daylight">{0} डेलायट वेळ</regionFormat>

--- a/common/main/kok_Latn.xml
+++ b/common/main/kok_Latn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2061,7 +2061,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Vell</regionFormat>
 			<regionFormat type="daylight">{0} Dis-uzvadd Vachovp Vell</regionFormat>

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -1956,7 +1956,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>جی ایم ٹی</gmtZeroFormat>
 			<regionFormat>{0} وَکھ</regionFormat>
 			<regionFormat type="daylight">{0} ڈے لائٹ وَکھ</regionFormat>
 			<regionFormat type="standard">{0} معیٲری وَکھ</regionFormat>

--- a/common/main/ks_Deva.xml
+++ b/common/main/ks_Deva.xml
@@ -648,7 +648,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>जी एम टी {0}</gmtFormat>
-			<gmtZeroFormat>जी एम टी</gmtZeroFormat>
 			<regionFormat>{0} वख</regionFormat>
 			<regionFormat type="daylight">{0} डे लाइट वख</regionFormat>
 			<regionFormat type="standard">{0} मयॉरी वख</regionFormat>

--- a/common/main/ku.xml
+++ b/common/main/ku.xml
@@ -6295,7 +6295,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Saeta {0}(y)ê</regionFormat>
 			<regionFormat type="daylight">Saeta Havînê ya {0}(y)ê</regionFormat>

--- a/common/main/kxv.xml
+++ b/common/main/kxv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1211,7 +1211,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} belā</regionFormat>
 			<regionFormat type="daylight">{0} ḍayliṭ belā</regionFormat>
 			<regionFormat type="standard">{0} mānānka belā</regionFormat>

--- a/common/main/kxv_Deva.xml
+++ b/common/main/kxv_Deva.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1109,7 +1109,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} बेला</regionFormat>
 			<regionFormat type="daylight">{0} मानांकॉ बेला</regionFormat>
 			<regionFormat type="standard">{0} डेलाइट बेला</regionFormat>

--- a/common/main/kxv_Orya.xml
+++ b/common/main/kxv_Orya.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1100,7 +1100,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} ବେଲା</regionFormat>
 			<regionFormat type="daylight">{0} ଡେଲାଇଟ ବେଲା</regionFormat>
 			<regionFormat type="standard">{0} ମାନାଙ୍କ ବେଲା</regionFormat>

--- a/common/main/kxv_Telu.xml
+++ b/common/main/kxv_Telu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1074,7 +1074,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} సమయం</regionFormat>
 			<regionFormat type="daylight">{0} పగటి వెలుతురు సమయం</regionFormat>
 			<regionFormat type="standard">{0} ప్రామాణిక సమయం</regionFormat>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -2594,7 +2594,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} убактысы</regionFormat>
 			<regionFormat type="daylight">{0} Күндүзгү убакыт</regionFormat>

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -2330,7 +2330,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} Zäit</regionFormat>
 			<regionFormat type="daylight">{0} Summerzäit</regionFormat>
 			<regionFormat type="standard">{0} Normalzäit</regionFormat>

--- a/common/main/lij.xml
+++ b/common/main/lij.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2421,7 +2421,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat draft="contributed">+HH:mm;−HH:mm</hourFormat>
 			<gmtFormat draft="contributed">UTC{0}</gmtFormat>
-			<gmtZeroFormat draft="contributed">UTC</gmtZeroFormat>
 			<regionFormat draft="contributed">oa: {0}</regionFormat>
 			<regionFormat type="daylight" draft="contributed">oa de stæ: {0}</regionFormat>
 			<regionFormat type="standard" draft="contributed">oa standard: {0}</regionFormat>

--- a/common/main/lld.xml
+++ b/common/main/lld.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1969,7 +1969,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="unconfirmed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ora: {0}</regionFormat>
 			<regionFormat type="daylight">Ora da d’isté: {0}</regionFormat>

--- a/common/main/lmo.xml
+++ b/common/main/lmo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -110,7 +110,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">↑↑↑</regionFormat>
 			<regionFormat type="daylight" draft="contributed">↑↑↑</regionFormat>
 			<regionFormat type="standard" draft="contributed">↑↑↑</regionFormat>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -3649,7 +3649,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>ເວລາ {0}</regionFormat>
 			<regionFormat type="daylight">ເວລາກາງເວັນ {0}</regionFormat>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -4689,7 +4689,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH:mm;−HH:mm</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Laikas: {0}</regionFormat>
 			<regionFormat type="daylight">Vasaros laikas: {0}</regionFormat>

--- a/common/main/ltg.xml
+++ b/common/main/ltg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -145,7 +145,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">Laika jūsla: {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0}: vosorys laiks</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">{0}: standarta laiks</regionFormat>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -3339,7 +3339,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Laika josla: {0}</regionFormat>
 			<regionFormat type="daylight">{0}: vasaras laiks</regionFormat>

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -2348,7 +2348,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>जीएमटी{0}</gmtFormat>
-			<gmtZeroFormat>जीएमटी</gmtZeroFormat>
 			<regionFormat>{0} समय</regionFormat>
 			<regionFormat type="daylight">{0} डेलाइट समय</regionFormat>
 			<regionFormat type="standard">{0} मानक समय</regionFormat>

--- a/common/main/mgo.xml
+++ b/common/main/mgo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -460,7 +460,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<fallbackFormat>↑↑↑</fallbackFormat>
 		</timeZoneNames>

--- a/common/main/mi.xml
+++ b/common/main/mi.xml
@@ -2329,7 +2329,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Wā</regionFormat>
 			<regionFormat type="daylight">{0} Wā Awatea</regionFormat>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -4144,7 +4144,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Време во {0}</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -4264,7 +4264,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>ജിഎംടി{0}</gmtFormat>
-			<gmtZeroFormat>ജിഎംടി</gmtZeroFormat>
 			<gmtUnknownFormat>ജിഎംടി+?</gmtUnknownFormat>
 			<regionFormat>{0} സമയം</regionFormat>
 			<regionFormat type="daylight">{0} ഡേലൈറ്റ് സമയം</regionFormat>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -3123,7 +3123,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}-н цаг</regionFormat>
 			<regionFormat type="daylight">{0}-н зуны цаг</regionFormat>

--- a/common/main/mni.xml
+++ b/common/main/mni.xml
@@ -620,7 +620,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>জি এম টি {0}</gmtFormat>
-			<gmtZeroFormat>জি এম টি</gmtZeroFormat>
 			<regionFormat>{0} টাইম</regionFormat>
 			<regionFormat type="daylight">{0} (+1) দেলাইট টাইম</regionFormat>
 			<regionFormat type="standard">{0} (+0) ষ্টেন্দর্দ টাইম</regionFormat>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -3501,7 +3501,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>[GMT]{0}</gmtFormat>
-			<gmtZeroFormat>[GMT]</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} वेळ</regionFormat>
 			<regionFormat type="daylight">{0} सूर्यप्रकाश वेळ</regionFormat>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -4467,7 +4467,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Waktu {0}</regionFormat>
 			<regionFormat type="daylight">Waktu Siang {0}</regionFormat>

--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2157,7 +2157,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Ħin ta’ {0}</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">{0} Ħin Standard</regionFormat>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -2532,7 +2532,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} အချိန်</regionFormat>
 			<regionFormat type="daylight">{0} နွေရာသီ စံတော်ချိန်</regionFormat>

--- a/common/main/mzn.xml
+++ b/common/main/mzn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1043,7 +1043,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/nds.xml
+++ b/common/main/nds.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1630,7 +1630,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">+HH.mm;-HH.mm</hourFormat>
 			<gmtFormat draft="contributed">UTC{0}</gmtFormat>
-			<gmtZeroFormat draft="contributed">UTC</gmtZeroFormat>
 			<regionFormat draft="contributed">{0}-Tiet</regionFormat>
 			<regionFormat type="daylight" draft="contributed">{0}-Summertiet</regionFormat>
 			<regionFormat type="standard" draft="contributed">{0}-Standardtiet</regionFormat>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -3027,7 +3027,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} समय</regionFormat>
 			<regionFormat type="daylight">{0} (+१)</regionFormat>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -8132,7 +8132,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>tijd in {0}</regionFormat>
 			<regionFormat type="daylight">zomertijd in {0}</regionFormat>

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -3616,7 +3616,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">sommartid – {0}</regionFormat>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -7202,7 +7202,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>tidssone for {0}</regionFormat>
 			<regionFormat type="daylight">sommertid – {0}</regionFormat>

--- a/common/main/nqo.xml
+++ b/common/main/nqo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1264,7 +1264,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>ߜ߭ߕߖ{0}</gmtFormat>
-			<gmtZeroFormat>ߜ߭ߕߖ</gmtZeroFormat>
 			<regionFormat>{0} ߕߎ߬ߡߊ</regionFormat>
 			<regionFormat type="daylight">{0} ߕߎ߬ߡߊ߬-ߦߟߍߡߊ߲</regionFormat>
 			<regionFormat type="standard">{0} ߕߎ߬ߡߊ߬-ߦߟߍߡߊ߲ߓߊߟߌ</regionFormat>

--- a/common/main/nso.xml
+++ b/common/main/nso.xml
@@ -553,7 +553,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/oc.xml
+++ b/common/main/oc.xml
@@ -1986,7 +1986,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">UTC{0}</gmtFormat>
-			<gmtZeroFormat draft="contributed">UTC</gmtZeroFormat>
 			<regionFormat draft="contributed">ora de {0}</regionFormat>
 			<regionFormat type="daylight" draft="contributed">{0} (ora d’estiu)</regionFormat>
 			<regionFormat type="standard" draft="contributed">{0} (ora estandard)</regionFormat>

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1394,7 +1394,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="unconfirmed">↑↑↑</gmtUnknownFormat>
 			<regionFormat draft="unconfirmed">↑↑↑</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">orari d’estiu de {0}</regionFormat>

--- a/common/main/om.xml
+++ b/common/main/om.xml
@@ -2037,7 +2037,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Sa’aatii {0}</regionFormat>
 			<regionFormat type="daylight">Sa’aatii Guyyaa {0}</regionFormat>
 			<regionFormat type="standard">Sa’aatii Istaandardii {0}</regionFormat>

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -2802,7 +2802,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} ସମୟ</regionFormat>
 			<regionFormat type="daylight">{0} ଦିବାଲୋକ ସମୟ</regionFormat>

--- a/common/main/os.xml
+++ b/common/main/os.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -699,7 +699,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">{0} рӕстӕг</regionFormat>
 			<fallbackFormat draft="contributed">↑↑↑</fallbackFormat>
 			<zone type="Etc/Unknown">

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -3366,7 +3366,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} ਵੇਲਾ</regionFormat>
 			<regionFormat type="daylight">{0} ਪ੍ਰਕਾਸ਼ ਵੇਲਾ</regionFormat>

--- a/common/main/pap.xml
+++ b/common/main/pap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1549,7 +1549,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="unconfirmed">↑↑↑</gmtUnknownFormat>
 			<regionFormat draft="unconfirmed">ora di {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">↑↑↑</regionFormat>

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -2483,7 +2483,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Taim</regionFormat>
 			<regionFormat type="daylight">{0} Délaít Taim</regionFormat>

--- a/common/main/pis.xml
+++ b/common/main/pis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -98,7 +98,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 		<timeZoneNames>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} Taem</regionFormat>
 			<regionFormat type="daylight">{0} Delaet Taem</regionFormat>
 			<regionFormat type="standard">{0} Standad Taem</regionFormat>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -3724,7 +3724,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>czas: {0}</regionFormat>
 			<regionFormat type="daylight">{0} (czas letni)</regionFormat>

--- a/common/main/pms.xml
+++ b/common/main/pms.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -113,7 +113,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Ora {0}</regionFormat>
 			<regionFormat type="daylight">Ora legal: {0}</regionFormat>
 			<regionFormat type="standard">Ora stàndar: {0}</regionFormat>

--- a/common/main/prg.xml
+++ b/common/main/prg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -774,7 +774,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">Kerdā: {0}</regionFormat>
 			<regionFormat type="daylight" draft="contributed">Daggas kerdā: {0}</regionFormat>
 			<regionFormat type="standard" draft="contributed">Zēimas kerdā: {0}</regionFormat>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -2865,7 +2865,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} وخت</regionFormat>
 			<regionFormat type="daylight">{0} رڼا ورځ وخت</regionFormat>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -3791,7 +3791,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Horário {0}</regionFormat>
 			<regionFormat type="daylight">Horário de Verão: {0}</regionFormat>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -3057,7 +3057,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Hora de {0}</regionFormat>
 			<regionFormat type="daylight">Hora padrão de {0}</regionFormat>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -2407,7 +2407,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/raj.xml
+++ b/common/main/raj.xml
@@ -168,7 +168,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/rif.xml
+++ b/common/main/rif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1469,7 +1469,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="unconfirmed">↑↑↑</gmtUnknownFormat>
 			<regionFormat draft="unconfirmed">akud n {0}</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">akud unebdu n {0}</regionFormat>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -2779,7 +2779,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} (temp local)</regionFormat>
 			<regionFormat type="daylight">{0} (temp da stad)</regionFormat>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -4240,7 +4240,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ora din {0}</regionFormat>
 			<regionFormat type="daylight">Ora de vară din {0}</regionFormat>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -2852,7 +2852,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<hourFormat>+HH:mm;-HH:mm</hourFormat>
 			<gmtFormat>GMT{0}</gmtFormat>
 			<gmtFormat alt="utc">UTC{0}</gmtFormat>
-			<gmtZeroFormat>GMT</gmtZeroFormat>
 			<gmtUnknownFormat>GMT+?</gmtUnknownFormat>
 			<gmtUnknownFormat alt="utc">UTC+?</gmtUnknownFormat>
 			<dualOffsetFormat>{0}/{1}</dualOffsetFormat>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -3976,7 +3976,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, летнее время</regionFormat>

--- a/common/main/rw.xml
+++ b/common/main/rw.xml
@@ -727,7 +727,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/sa.xml
+++ b/common/main/sa.xml
@@ -811,7 +811,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>जी.एम.टी. {0}</gmtFormat>
-			<gmtZeroFormat>जी.एम.टी.</gmtZeroFormat>
 			<regionFormat>{0} समय:</regionFormat>
 			<regionFormat type="daylight">{0} अयामसमयः</regionFormat>
 			<regionFormat type="standard">{0} प्रमाणसमयः</regionFormat>

--- a/common/main/sah.xml
+++ b/common/main/sah.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1063,7 +1063,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">↑↑↑</regionFormat>
 			<regionFormat type="daylight" draft="contributed">↑↑↑</regionFormat>
 			<regionFormat type="standard" draft="contributed">↑↑↑</regionFormat>

--- a/common/main/sat.xml
+++ b/common/main/sat.xml
@@ -1841,7 +1841,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>ᱡᱤᱮᱢᱴᱤ{0}</gmtFormat>
-			<gmtZeroFormat>ᱡᱤᱮᱢᱴᱤ</gmtZeroFormat>
 			<regionFormat>{0} ᱚᱠᱛᱚ</regionFormat>
 			<regionFormat type="daylight">{0} ᱫᱤᱱᱵᱮᱲᱟ ᱚᱠᱛᱚ</regionFormat>
 			<regionFormat type="standard">{0} ᱢᱟᱱᱚᱠ ᱚᱠᱛᱚ</regionFormat>

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -7949,7 +7949,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ora {0}</regionFormat>
 			<regionFormat type="daylight">Ora legale: {0}</regionFormat>

--- a/common/main/scn.xml
+++ b/common/main/scn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1862,7 +1862,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0} (ura ligali)</regionFormat>

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -2934,7 +2934,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>GMT+؟</gmtUnknownFormat>
 			<regionFormat>{0} وقت</regionFormat>
 			<regionFormat type="daylight">{0} ڏينهن جو وقت</regionFormat>

--- a/common/main/sd_Deva.xml
+++ b/common/main/sd_Deva.xml
@@ -624,7 +624,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>जीएमटी{0}</gmtFormat>
-			<gmtZeroFormat>जीएमटी</gmtZeroFormat>
 			<regionFormat>{0} वक़्तु</regionFormat>
 			<regionFormat type="daylight">{0} दीं॒ह जो वक्त</regionFormat>
 			<regionFormat type="standard">{0} मइयारी वक़्तु</regionFormat>

--- a/common/main/se.xml
+++ b/common/main/se.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1074,7 +1074,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">+HH:mm;−HH:mm</hourFormat>
 			<gmtFormat draft="contributed">UTC{0}</gmtFormat>
-			<gmtZeroFormat draft="contributed">UTC</gmtZeroFormat>
 			<regionFormat draft="contributed">{0} áigi</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} geassiáigi</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">{0} dábálašáigi</regionFormat>

--- a/common/main/se_FI.xml
+++ b/common/main/se_FI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1188,7 +1188,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>+HH:mm;-HH:mm</hourFormat>
 			<gmtFormat>{0} GMT</gmtFormat>
-			<gmtZeroFormat>GMT</gmtZeroFormat>
 			<regionFormat type="daylight">{0} geasseáigi</regionFormat>
 			<regionFormat type="standard">{0} dálveáigi</regionFormat>
 			<zone type="Etc/UTC">

--- a/common/main/shn.xml
+++ b/common/main/shn.xml
@@ -6079,7 +6079,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>ၶၢဝ်းယၢမ်း {0}</regionFormat>
 			<regionFormat type="daylight">ၶၢဝ်းယၢမ်း ၵၢင်ဝၼ်း {0}</regionFormat>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -2600,7 +2600,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH.mm;-HH.mm</hourFormat>
 			<gmtFormat>ග්‍රිමවේ{0}</gmtFormat>
-			<gmtZeroFormat>ග්‍රිමවේ</gmtZeroFormat>
 			<gmtUnknownFormat>ග්‍රිමවේ+?</gmtUnknownFormat>
 			<regionFormat>{0} වේලාව</regionFormat>
 			<regionFormat type="daylight">{0} දිවාආලෝක වේලාව</regionFormat>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -3496,7 +3496,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>časové pásmo {0}</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/skr.xml
+++ b/common/main/skr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -115,7 +115,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">جی ایم ٹی {0}</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">جی ایم ٹی</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">{0} وقت</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} ݙین٘ہ موسمی وقت</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">↑↑↑</regionFormat>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -3750,7 +3750,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH.mm;-HH.mm</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>GMT +?</gmtUnknownFormat>
 			<regionFormat>{0} (lokalni čas)</regionFormat>
 			<regionFormat type="daylight">{0} (poletni čas)</regionFormat>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -6347,7 +6347,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Waqtiga {0}</regionFormat>
 			<regionFormat type="daylight">Waqtiga Dharaarta ee {0}</regionFormat>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -2931,7 +2931,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ora: {0}</regionFormat>
 			<regionFormat type="daylight">Ora verore: {0}</regionFormat>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -3291,7 +3291,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, летње време</regionFormat>

--- a/common/main/sr_Cyrl_BA.xml
+++ b/common/main/sr_Cyrl_BA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2861,7 +2861,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, љетње вријеме</regionFormat>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -3290,7 +3290,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, letnje vreme</regionFormat>

--- a/common/main/sr_Latn_BA.xml
+++ b/common/main/sr_Latn_BA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2861,7 +2861,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, ljetnje vrijeme</regionFormat>

--- a/common/main/st.xml
+++ b/common/main/st.xml
@@ -619,7 +619,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} Nako</regionFormat>
 			<regionFormat type="daylight">{0} Nako ya Motshehare</regionFormat>
 			<regionFormat type="standard">{0} Nako ya Tlwaelo</regionFormat>

--- a/common/main/su.xml
+++ b/common/main/su.xml
@@ -653,7 +653,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -4281,7 +4281,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>+HH:mm;−HH:mm</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}tid</regionFormat>
 			<regionFormat type="daylight">{0} (sommartid)</regionFormat>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -2673,7 +2673,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Saa za {0}</regionFormat>
 			<regionFormat type="daylight">Saa za Mchana za {0}</regionFormat>

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2494,7 +2494,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -2098,7 +2098,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>ܥܕܢܐ ܕ{0}</regionFormat>
 			<regionFormat type="daylight">ܥܕܢܐ ܕܒܗܪ ܝܘܡܐ ܕ{0}</regionFormat>

--- a/common/main/szl.xml
+++ b/common/main/szl.xml
@@ -2122,7 +2122,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">czas: {0}</regionFormat>
 			<regionFormat type="daylight" draft="contributed">{0} (latowy czas)</regionFormat>
 			<regionFormat type="standard" draft="contributed">{0} (sztandardowy czas)</regionFormat>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -3582,7 +3582,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat draft="contributed">↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} நேரம்</regionFormat>
 			<regionFormat type="daylight">{0} பகலொளி நேரம்</regionFormat>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -3504,7 +3504,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} సమయం</regionFormat>
 			<regionFormat type="daylight">{0} పగటి కాంతి సమయం</regionFormat>

--- a/common/main/tg.xml
+++ b/common/main/tg.xml
@@ -2318,7 +2318,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Вақти {0}</regionFormat>
 			<regionFormat type="daylight">Вақти рӯзонаи {0}</regionFormat>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -4479,7 +4479,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>เวลา{0}</regionFormat>
 			<regionFormat type="daylight">เวลาออมแสง{0}</regionFormat>

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -2912,7 +2912,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>ግዘ {0}</regionFormat>
 			<regionFormat type="daylight">ናይ {0} መዓልቲ ግዘ</regionFormat>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -2705,7 +2705,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} wagty</regionFormat>
 			<regionFormat type="daylight">{0} tomusky wagty</regionFormat>

--- a/common/main/tn.xml
+++ b/common/main/tn.xml
@@ -639,7 +639,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>
 			<regionFormat type="standard">↑↑↑</regionFormat>

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -3430,7 +3430,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Taimi {0}</regionFormat>
 			<regionFormat type="daylight">{0} Taimi liliu</regionFormat>
 			<regionFormat type="standard">{0} Taimi totonu</regionFormat>

--- a/common/main/tok.xml
+++ b/common/main/tok.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -817,7 +817,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>tenpo GMT{0}</gmtFormat>
-			<gmtZeroFormat>tenpo UTC</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>tenpo pi {0}</regionFormat>
 			<regionFormat type="daylight">tenpo seli suno pi {0}</regionFormat>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -3604,7 +3604,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Saati</regionFormat>
 			<regionFormat type="daylight">{0} Yaz Saati</regionFormat>

--- a/common/main/trw.xml
+++ b/common/main/trw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1714,7 +1714,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="unconfirmed">↑↑↑</hourFormat>
 			<gmtFormat draft="unconfirmed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="unconfirmed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="unconfirmed">{0} وَخ</regionFormat>
 			<regionFormat type="daylight" draft="unconfirmed">{0} دھات</regionFormat>
 			<regionFormat type="standard" draft="unconfirmed">{0} معیاری وَخ</regionFormat>

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -2155,7 +2155,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} вакыты</regionFormat>
 			<regionFormat type="daylight">{0} җәйге вакыты</regionFormat>

--- a/common/main/tyv.xml
+++ b/common/main/tyv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -939,7 +939,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}, чайгы үе</regionFormat>
 			<regionFormat type="standard">{0}, стандарт үе</regionFormat>

--- a/common/main/ug.xml
+++ b/common/main/ug.xml
@@ -2119,7 +2119,6 @@ Reviewed by Waris Abdukerim Janbaz <oyghan@gmail.com> of the Uyghur Computer Sci
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">{0} ۋاقتى</regionFormat>
 			<regionFormat type="daylight" draft="contributed">{0} يازلىق ۋاقتى</regionFormat>
 			<regionFormat type="standard" draft="contributed">{0} ئۆلچەملىك ۋاقتى</regionFormat>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -3707,7 +3707,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>час: {0}</regionFormat>
 			<regionFormat type="daylight">час: {0}, літній</regionFormat>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -3245,7 +3245,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>GMT {0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} وقت</regionFormat>
 			<regionFormat type="daylight">{0} ڈے لائٹ ٹائم</regionFormat>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -2805,7 +2805,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/uz_Cyrl.xml
+++ b/common/main/uz_Cyrl.xml
@@ -1559,7 +1559,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} вақти</regionFormat>
 			<regionFormat type="daylight">{0} кундузги вақти</regionFormat>
 			<regionFormat type="standard">{0} стандарт вақти</regionFormat>

--- a/common/main/vec.xml
+++ b/common/main/vec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2612,7 +2612,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>UTC{0}</gmtFormat>
-			<gmtZeroFormat>UTC</gmtZeroFormat>
 			<gmtUnknownFormat>UTC+?</gmtUnknownFormat>
 			<regionFormat>Ora {0}</regionFormat>
 			<regionFormat type="daylight">Ora d’istà {0}</regionFormat>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -4703,7 +4703,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Giờ {0}</regionFormat>
 			<regionFormat type="daylight">Giờ mùa hè {0}</regionFormat>

--- a/common/main/vmw.xml
+++ b/common/main/vmw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -110,7 +110,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">+H:mm;-H:mm</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">okathi wa {0}</regionFormat>
 			<regionFormat type="daylight" draft="contributed">okathi wa othana wa {0}</regionFormat>
 			<regionFormat type="standard" draft="contributed">okathi oolikana wa {0}</regionFormat>

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -1936,7 +1936,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -1985,7 +1985,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0} Time</regionFormat>
 			<regionFormat type="daylight">{0} Daylight Time</regionFormat>

--- a/common/main/xnr.xml
+++ b/common/main/xnr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2176,7 +2176,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>ग्री॰ मै॰ टै॰{0}</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>{0} टैम</regionFormat>
 			<regionFormat type="daylight">{0} ध्याड़े दे उजाले दा टैम</regionFormat>
 			<regionFormat type="standard">{0} मानक टैम</regionFormat>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -2426,7 +2426,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>WAT{0}</gmtFormat>
-			<gmtZeroFormat>WAT</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ìgbà {0}</regionFormat>
 			<regionFormat type="daylight">{0} Àkókò ojúmọmọ</regionFormat>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -2423,7 +2423,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>WAT{0}</gmtFormat>
-			<gmtZeroFormat>WAT</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Ìgbà {0}</regionFormat>
 			<regionFormat type="daylight">{0} Àkókò ojúmɔmɔ</regionFormat>

--- a/common/main/yrl.xml
+++ b/common/main/yrl.xml
@@ -2870,7 +2870,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<regionFormat>Hurariyu {0}</regionFormat>
 			<regionFormat type="daylight">Kurasí Ara Hurariyu: {0}</regionFormat>
 			<regionFormat type="standard">Hurariyu Retewa: {0}</regionFormat>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -4449,7 +4449,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}時間</regionFormat>
 			<regionFormat type="daylight">{0}夏令時間</regionFormat>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -4446,7 +4446,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}时间</regionFormat>
 			<regionFormat type="daylight">{0}夏令时间</regionFormat>

--- a/common/main/za.xml
+++ b/common/main/za.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -555,7 +555,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
 			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
-			<gmtZeroFormat draft="contributed">↑↑↑</gmtZeroFormat>
 			<regionFormat draft="contributed">{0} Sizgenh</regionFormat>
 			<regionFormat type="daylight" draft="contributed">{0} Yaling Sizgenh</regionFormat>
 			<regionFormat type="standard" draft="contributed">{0} Byauhcunj Sizgenh</regionFormat>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -5492,7 +5492,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}时间</regionFormat>
 			<regionFormat type="daylight">{0}夏令时间</regionFormat>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -7424,7 +7424,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>{0}時間</regionFormat>
 			<regionFormat type="daylight">↑↑↑</regionFormat>

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -7463,7 +7463,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>↑↑↑</regionFormat>
 			<regionFormat type="daylight">{0}夏令時間</regionFormat>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -3178,7 +3178,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
 			<gmtUnknownFormat>↑↑↑</gmtUnknownFormat>
 			<regionFormat>Isikhathi sase-{0}</regionFormat>
 			<regionFormat type="daylight">{0} Isikhathi sasemini</regionFormat>

--- a/common/supplemental-temp/coverageLevels2.xml
+++ b/common/supplemental-temp/coverageLevels2.xml
@@ -356,7 +356,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/regionFormat[@type='%regionFormatTypes']"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/fallbackFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtFormat"/>
-		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtZeroFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtUnknownFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/hourFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/metazone[@type='GMT']/long/standard"/>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -455,7 +455,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/fallbackFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtFormat[@alt='utc']"/>
-		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtZeroFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/hourFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/metazone[@type='GMT']/long/standard"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/long/standard"/>

--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -1387,11 +1387,10 @@ For examples, see [Day Periods Chart](https://www.unicode.org/cldr/charts/latest
 ## <a name="Time_Zone_Names" href="#Time_Zone_Names">Time Zone Names</a>
 
 ```xml
-<!ELEMENT timeZoneNames (alias | (hourFormat*, gmtFormat*, gmtZeroFormat*, gmtUnknownFormat*, regionFormat*, fallbackFormat*, zone*, metazone*, special*)) >
+<!ELEMENT timeZoneNames (alias | (hourFormat*, gmtFormat*, gmtUnknownFormat*, regionFormat*, fallbackFormat*, zone*, metazone*, special*)) >
 
 <!ELEMENT hourFormat ( #PCDATA ) >
 <!ELEMENT gmtFormat ( #PCDATA ) >
-<!ELEMENT gmtZeroFormat ( #PCDATA ) >
 <!ELEMENT gmtUnknownFormat ( #PCDATA ) >
 
 <!ELEMENT regionFormat ( #PCDATA ) >
@@ -1504,7 +1503,6 @@ The following subelements of `<timeZoneNames>` are used to control the fallback 
     <tr><td>"-1200"</td></tr>
 <tr><td rowspan="2">gmtFormat</td><td>"GMT{0}"</td><td>"GMT-0800"</td></tr>
     <tr><td>"{0}ВпГ"</td><td>"-0800ВпГ"</td></tr>
-<tr><td>gmtZeroFormat</td><td>"GMT"</td><td>Specifies how GMT/UTC with an offset of zero should be represented.</td></tr>
 <tr><td>gmtUnknownFormat</td><td>"GMT"</td><td>Specifies how GMT/UTC with an unknown offset should be represented.</td></tr>
 <tr><td rowspan="2">regionFormat</td><td>"{0} Time"</td><td>"Japan Time"</td></tr>
     <tr><td>"Hora de {0}"</td><td>"Hora de Japón"</td></tr>

--- a/docs/ldml/tr35-modifications.md
+++ b/docs/ldml/tr35-modifications.md
@@ -48,6 +48,8 @@ This is a partial document, describing only the changes to the LDML since the pr
 * [`numberFormat`](tr35-numbers.md#Number_Formats) Revise numberFormat description
 <!-- CLDR-18963 -->
 
+* [`dateTime`](tr35-dates.md#Time_Zone_Names) Removed `gmtZeroOffset` item
+
 **Changes in LDML Version 48.2 (Differences from Version 48.1)**
 
 <!-- CLDR-19231 reformatted/simplified tr35.md version block to improve deployment-->

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLConstants.java
@@ -90,7 +90,6 @@ public class LDMLConstants {
     public static final String HOUR_FORMAT = "hourFormat";
     public static final String HOURS_FORMAT = "hoursFormat";
     public static final String GMT_FORMAT = "gmtFormat";
-    public static final String GMT_ZERO_FORMAT = "gmtZeroFormat";
     public static final String GMT_UNKNOWN_FORMAT = "gmtUnknownFormat";
     public static final String REGION_FORMAT = "regionFormat";
     public static final String FALLBACK_FORMAT = "fallbackFormat";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -28,7 +28,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
                                     + "|intervalFormatItem"
                                     + "|exemplarCharacters\\[@type=\"(currencySymbol|index)\"]"
                                     + "|scientificFormat"
-                                    + "|timeZoneNames/(hourFormat|gmtFormat|gmtZeroFormat|gmtUnknownFormat)"
+                                    + "|timeZoneNames/(hourFormat|gmtFormat|gmtUnknownFormat)"
                                     + "|dayPeriod"
                                     + "|(monthWidth|dayWidth|quarterWidth)\\[@type=\"(narrow|abbreviated)\"]"
                                     + "|exemplarCity"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -411,14 +411,11 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                             result);
                 }
             }
-        } else if (path.contains("/gmtFormat")
-                || path.contains("/gmtZeroFormat")
-                || path.contains("/gmtUnknownFormat")) {
+        } else if (path.contains("/gmtFormat") || path.contains("/gmtUnknownFormat")) {
             if (null
                     != (disallowed =
                             containsAllCountingParens(exemplars, exemplarsPlusAscii, value))) {
-                disallowed.removeAll(
-                        LETTER); // Allow ASCII A-Z in gmtFormat, gmtZeroFormat, gmtUnknownFormat
+                disallowed.removeAll(LETTER); // Allow ASCII A-Z in gmtFormat, gmtUnknownFormat
                 if (disallowed.size() > 0) {
                     addMissingMessage(
                             disallowed,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
@@ -312,8 +312,8 @@ public class CheckWidths extends CheckCLDR {
                                         Special.PLACEHOLDERS)
                             })
                     .add(
-                            "//ldml/dates/timeZoneNames/(gmtFormat|gmtZeroFormat|gmtUnknownFormat)",
-                            new Limit[] { // GMT{0}, GMT
+                            "//ldml/dates/timeZoneNames/(gmtFormat|gmtUnknownFormat)",
+                            new Limit[] { // GMT{0}
                                 new Limit(
                                         5 * EM,
                                         10 * EM,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2193,11 +2193,19 @@ public class ExampleGenerator {
                 break;
             case "Timezone":
                 timeIndex = DateFormat.MEDIUM;
-                toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
+                toAppend =
+                        getGMTFormat(
+                                null,
+                                cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtFormat"),
+                                8);
                 break;
             case "Date-Timezone":
                 dateIndex = DateFormat.MEDIUM;
-                toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
+                toAppend =
+                        getGMTFormat(
+                                null,
+                                cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtFormat"),
+                                8);
                 break;
             default:
                 return;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1687,7 +1687,6 @@ public class PathHeader implements Comparable<PathHeader> {
                                             .put(
                                                     "dualOffsetFormat",
                                                     "Dual Standard/Daylight Format")
-                                            .put("gmtZeroFormat", "GMT Zero Format")
                                             .put("gmtUnknownFormat", "GMT Unknown Format")
                                             .put("fallbackFormat", "Location Fallback Format")
                                             .freeze();
@@ -1698,7 +1697,6 @@ public class PathHeader implements Comparable<PathHeader> {
                                             "regionFormat-daylight",
                                             "gmtFormat",
                                             "hourFormat",
-                                            "gmtZeroFormat",
                                             "gmtUnknownFormat",
                                             "dualOffsetFormat",
                                             "fallbackFormat");

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,3 +1,3 @@
 #locale;	action	path	new_value
-locale=/.*/ ; action=delete ; path=/currencies/currency[@type="CNX"].*/
+locale=/.*/ ; action=delete ; path=/dates/timeZoneNames/gmtZeroFormat.*/
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/paths/missingOk.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/paths/missingOk.txt
@@ -10,7 +10,6 @@
 #//ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/dateTimeFormatLength[@type="%A"]/dateTimeFormat[@type="standard"]/pattern[@type="standard"] ; ok
 #//ldml/localeDisplayNames/localeDisplayPattern/locale(KeyTypePattern|Pattern|Separator) ; ok
 #//ldml/listPatterns/listPattern/listPatternPart[@type="(middle|start)"] ; ok
-#//ldml/dates/timeZoneNames/gmtZeroFormat ; ok
 //ldml/numbers/defaultNumberingSystem ; ok
 //ldml/numbers/otherNumberingSystems/native ; ok
 //ldml/localeDisplayNames/variants/variant[@type="%A"] ; ok

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/test/widthSpecification.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/test/widthSpecification.xml
@@ -65,7 +65,7 @@
 			<limit>MAXIMUM</limit>
 			<measure>DISPLAY_WIDTH</measure>
 			<special>PLACEHOLDERS</special>
-			<pathName>//ldml/dates/timeZoneNames/(gmtFormat|gmtZeroFormat|gmtUnknownFormat)</pathName>
+			<pathName>//ldml/dates/timeZoneNames/(gmtFormat|gmtUnknownFormat)</pathName>
 		</path>
 		<!-- // Narrow items .add("//ldml/dates/calendars/calendar.*[@type=\"narrow\"](?!/cyclic|/dayPeriod|/monthPattern)", 
 			new Limit[] { new Limit(1.5 * EM, 2.25 * EM, Measure.DISPLAY_WIDTH, LimitType.MAXIMUM, 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -213,7 +213,6 @@ public class TestExampleGenerator extends TestFmwk {
                     "//ldml/dates/calendars/calendar[@type=\"([^\"]*+)\"]/eras/eraAbbr/era[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]",
                     "//ldml/dates/calendars/calendar[@type=\"([^\"]*+)\"]/eras/eraNarrow/era[@type=\"([^\"]*+)\"][@alt=\"([^\"]*+)\"]",
                     "//ldml/dates/calendars/calendar[@type=\"([^\"]*+)\"]/months/monthContext[@type=\"([^\"]*+)\"]/monthWidth[@type=\"([^\"]*+)\"]/month[@type=\"([^\"]*+)\"][@yeartype=\"([^\"]*+)\"]",
-                    "//ldml/dates/timeZoneNames/gmtZeroFormat", // TODO CLDR-14121
                     "//ldml/dates/timeZoneNames/gmtUnknownFormat", // TODO CLDR-14121
                     "//ldml/dates/timeZoneNames/gmtUnknownFormat[@alt=\"([^\"]*+)\"]", // TODO
                     // CLDR-14121
@@ -941,9 +940,7 @@ public class TestExampleGenerator extends TestFmwk {
             String value = cldrFile.getStringValue(xpath);
             String actual = exampleGenerator.getExampleHtml(xpath, value);
             if (actual == null) {
-                if (!xpath.contains("singleCountries")
-                        && !xpath.contains("gmtZeroFormat")
-                        && !xpath.contains("gmtUnknownFormat")) {
+                if (!xpath.contains("singleCountries") && !xpath.contains("gmtUnknownFormat")) {
                     errln("Null value for " + value + "\t" + xpath);
                     // for debugging
                     exampleGenerator.getExampleHtml(xpath, value);
@@ -2205,7 +2202,6 @@ public class TestExampleGenerator extends TestFmwk {
                 "//ldml/characters/moreInformation"
                         + "//ldml/characters/nestedBracketReplacement[@bracket=\"*\"]"
                         + "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]"
-                        + "//ldml/dates/timeZoneNames/gmtZeroFormat"
                         + "//ldml/dates/timeZoneNames/gmtUnknownFormat"
                         + "//ldml/dates/timeZoneNames/gmtUnknownFormat[@alt=\"*\"]" // TODO
                         // CLDR-14121

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -366,7 +366,7 @@ public class TestPathHeader extends TestFmwkPlus {
         String example =
                 eg.getExampleHtml(APPEND_TIMEZONE, cldrFile.getStringValue(APPEND_TIMEZONE));
         String result = ExampleGenerator.simplify(example, false);
-        assertEquals("", "〖❬6:25:59 PM❭ ❬GMT❭〗", result);
+        assertEquals("", "〖❬6:25:59 PM❭ ❬GMT❬+08:00❭❭〗", result);
     }
 
     public void TestOptional() {


### PR DESCRIPTION
CLDR-19001

- [x] This PR completes the ticket.

Removes the `gmtZeroFormat` item, which has been unused since CLDR 47.

ALLOW_MANY_COMMITS=true
