### PR TITLE
CLDR-19455 Refresh Dashboard after Abstain: work-around

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrDashContext.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDashContext.mjs
@@ -145,11 +145,28 @@ function updateWithCoverage(newLevel) {
   }
 }
 
+function updateAfterAbstain() {
+  if (dashVisible) {
+    // Crude work-around: reload entire dashboard.
+    // Delay is to avoid interference with single-row dash update (cldrDashContext.updatePath).
+    // TODO: Avoid reloading entire dashboard after abstain; cldrDashContext.updatePath should
+    // detect that Missing count needs increase in the context where user votes (missing decreases by one)
+    // then user abstains (missing increases by one).
+    // Reference: https://unicode-org.atlassian.net/browse/CLDR-19455
+    const SECONDS_IN_MS = 1000;
+    const DELAY_AFTER_ABSTAIN = 2 * SECONDS_IN_MS;
+    setTimeout(function () {
+      wrapper?.reloadDashboard();
+    }, DELAY_AFTER_ABSTAIN);
+  }
+}
+
 export {
   hide,
   insert,
   isVisible,
   shouldBeShown,
+  updateAfterAbstain,
   updateRow,
   updateWithCoverage,
   wireUpOpenButtons,

--- a/tools/cldr-apps/js/src/esm/cldrDashData.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDashData.mjs
@@ -340,6 +340,10 @@ function convertData(json, locale) {
  *               containing notifications for a single path (old format)
  */
 function updatePath(dashData, json) {
+  if (!dashData) {
+    console.warn("dashData is null in cldrDashDarta.updatePath; skipping.");
+    return;
+  }
   try {
     if (json.xpstrid in dashData.pathIndex) {
       // We already have an entry for this path

--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -3,6 +3,7 @@
  */
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrConstants from "./cldrConstants.mjs";
+import * as cldrDashContext from "./cldrDashContext.mjs";
 import * as cldrDom from "./cldrDom.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
@@ -133,7 +134,7 @@ async function handleWiredClick(
         method: "DELETE",
       });
       if (response.ok && response.status === 204) {
-        handleVoteOk({ didVote: true }, tr, theRow, button, "");
+        handleVoteOk({ didVote: true }, tr, theRow, button, "", isAbstain);
       } else {
         const message = "Server response: " + response.statusText;
         handleVoteErr(tr, message, button);
@@ -147,7 +148,7 @@ async function handleWiredClick(
       tr.className = originalTrClassName;
       if (response.ok) {
         const json = await response.json();
-        handleVoteOk(json, tr, theRow, button, valToShow);
+        handleVoteOk(json, tr, theRow, button, valToShow, isAbstain);
       } else {
         const message = "Server response: " + response.statusText;
         handleVoteErr(tr, message, button);
@@ -173,7 +174,7 @@ async function handleWiredClick(
  * @param {Element} button the GUI button
  * @param {String} valToShow the value the user is voting for
  */
-function handleVoteOk(json, tr, theRow, button, valToShow) {
+function handleVoteOk(json, tr, theRow, button, valToShow, isAbstain) {
   if (theRow.voteVhash) {
     cldrStatus.setCurrentValueHash(theRow.voteVhash);
   }
@@ -181,6 +182,9 @@ function handleVoteOk(json, tr, theRow, button, valToShow) {
     handleVoteErr(tr, json.err, button);
   } else if (json.didVote) {
     handleVoteSubmitted(json, tr, theRow, button, valToShow);
+    if (isAbstain) {
+      cldrDashContext.updateAfterAbstain();
+    }
   } else {
     handleVoteNotSubmitted(json, tr, theRow, button, valToShow);
   }

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -302,10 +302,12 @@ export default {
       this.includeOther = true;
       this.reloadDashboard();
     },
+
     reloadWithoutOther() {
       this.includeOther = false;
       this.reloadDashboard();
     },
+
     fetchData() {
       this.locale = cldrStatus.getCurrentLocale();
       this.level = cldrCoverage.effectiveName(this.locale);


### PR DESCRIPTION
-Reload the entire Dashboard after user Abstains

-Wait 2 seconds for reload, to avoid conflict with cldrDashContext.updatePath

-This is a crude work-around, pending row-specific update that should be possible with cldrDashContext.updatePath

-Comments, including TODO

CLDR-19455

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
