### PR TITLE
CLDR-13465 fix ShimmedMain.findAllTests to include subclasses

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/dev/test/TestFmwk.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/dev/test/TestFmwk.java
@@ -636,9 +636,16 @@ public class TestFmwk extends AbstractTestLog {
         if (errorCount > 0) {
             writeStepSummary("- :x: " + errorCount + " TEST(S) FAILED");
             localParams.log.println("\n<< " + errorCount + " TEST(S) FAILED >>");
-        } else {
-            localParams.log.println("\n<< ALL TESTS PASSED >>");
-            writeStepSummary("- :white_check_mark: ALL TESTS PASSED");
+        } else if (params.testCount > 0) {
+            localParams.log.println("\n<< ALL " + params.testCount + " TESTS PASSED >>");
+            writeStepSummary("- :white_check_mark: ALL \" + params.testCount + \" TESTS PASSED");
+        } else if (params.listlevel == 0) {
+            // unless in list mode
+            final String ALL_TESTS_SKIPPED =
+                    "No tests were run: either nothing matched the filters, all tests were skipped, or they were never written. This is an error.";
+            writeStepSummary("- :x: " + ALL_TESTS_SKIPPED);
+            localParams.log.println("\n ERROR: " + ALL_TESTS_SKIPPED);
+            return 1;
         }
 
         if (prompt) {
@@ -658,12 +665,14 @@ public class TestFmwk extends AbstractTestLog {
 
     public int runTests(TestParams _params, String[] tests) {
         int ec = 0;
+        // int runCount = 0;
 
         StringBuffer summary = null;
         try {
             if (tests.length == 0 || tests[0] == null) { // no args
                 _params.init();
                 resolveTarget(_params).run();
+                // runCount++;
                 ec = _params.errorCount;
             } else {
                 for (int i = 0; i < tests.length; ++i) {
@@ -694,6 +703,11 @@ public class TestFmwk extends AbstractTestLog {
             _params.log.println("\nencountered a test failure, exiting\n" + e);
             e.printStackTrace(_params.log);
         }
+        // if (runCount == 0) {
+        //     ec++;
+        //     writeStepSummary("- :x: No tests were run. This is an error.");
+        //     _params.log.println("\nNo tests were run. This is an error.\n");
+        // }
 
         return ec;
     }
@@ -2140,7 +2154,15 @@ public class TestFmwk extends AbstractTestLog {
             if (source == null || source.equals("TestShim.java")) {
                 return new SourceLocation(); // hit the end of helpful stack traces
             } else if (source != null
+                    // exclude locations here that are 'not useful'.
+                    // That is, we want to have throws happen in the test code,
+                    // not in the 'framework'
+                    && (st.getLineNumber() != 1) // exclude line 1!
                     && !source.equals("TestFmwk.java")
+                    && !source.equals("TestFmwkForChecks.java")
+                    // exclude utility functions in TestFmwkPlus, but not its TestTest!
+                    && !(source.equals("TestFmwkPlus.java")
+                            && !st.getMethodName().equals("TestTest"))
                     && !source.equals("AbstractTestLog.java")) {
                 String methodName = st.getMethodName();
                 if (methodName != null && methodName.startsWith("lambda$")) { // unpack inner lambda

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ShimmedMain.java
@@ -91,20 +91,33 @@ public class ShimmedMain {
                         .acceptPackages(inPackage.getName())
                         .enableAnnotationInfo()
                         .enableClassInfo()
+                        // .verbose() // NOTE: Uncomment this for lots of verbose info about
+                        // scanning
                         .scan()) {
-            for (ClassInfo info : scanResult.getSubclasses(TestFmwk.class)) {
-                if (info.getPackageName().equals(inPackage.getName())
-                        && !info.getSuperclass()
-                                .getName()
-                                .equals(TestFmwk.TestGroup.class.getName())) {
-                    if (info.hasAnnotation("org.junit.jupiter.api.Disabled")) {
-                        System.err.println("Skipping, @Disabled: " + info.getName());
-                    } else {
-                        allTestClasses.add(info.getName());
-                    }
-                }
-            }
+            processScanResult(inPackage, allTestClasses, scanResult, TestFmwk.class);
             return allTestClasses.toArray(new String[allTestClasses.size()]);
+        }
+    }
+
+    private static void processScanResult(
+            final Package inPackage,
+            final Set<String> allTestClasses,
+            ScanResult scanResult,
+            final Class<?> clazz) {
+        for (ClassInfo info : scanResult.getClassInfo(clazz.getCanonicalName()).getSubclasses()) {
+            processScanResult(inPackage, allTestClasses, info);
+        }
+    }
+
+    private static void processScanResult(
+            final Package inPackage, final Set<String> allTestClasses, ClassInfo info) {
+        if (info.getPackageName().equals(inPackage.getName())
+                && !info.getSuperclass().getName().equals(TestFmwk.TestGroup.class.getName())) {
+            if (info.hasAnnotation("org.junit.jupiter.api.Disabled")) {
+                System.err.println("Skipping, @Disabled: " + info.getName());
+            } else {
+                allTestClasses.add(info.getName());
+            }
         }
     }
 }


### PR DESCRIPTION
- subclasses (such as TestFmwkPlus) were apparently actually skipped
- also, make it an error to run a TestFmwk run but no actual tests are run
- also, update TestFmwk printouts to skip utility functions in the stack trace

CLDR-13465

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
