### PR TITLE
CLDR-19495 CheckNames: add test for "ZA 123" crash

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
@@ -24,9 +24,11 @@ public class CheckNames extends CheckCLDR {
         Matcher matcher = RegexUtilities.PATTERN_3_OR_4_DIGITS.matcher(value);
         if (matcher.find()) {
             // If same as the code-fallback value (territories) then no error
-            if (path.startsWith("//ldml/localeDisplayNames/territories")
-                    && getCldrFileToCheck().getBaileyValue(path, null, null).equals(value)) {
-                return this;
+            if (path.startsWith("//ldml/localeDisplayNames/territories")) {
+                final String baileyFallback = getCldrFileToCheck().getBaileyValue(path, null, null);
+                if (baileyFallback != null && baileyFallback.equals(value)) {
+                    return this; // no error
+                }
             }
             // Allow years in currencies if enclosed by brackets.
             if (path.startsWith("//ldml/localeDisplayNames/currencies")

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -623,6 +623,16 @@ public class TestCheckCLDR extends TestFmwk {
         xpath = "//ldml/localeDisplayNames/currencies/currency[@type=\"afa\"]/name";
         c.check(xpath, xpath, "Afghan Afghani (1927-2002)", options, possibleErrors);
         assertEquals("Currencies are allowed to have dates", 0, possibleErrors.size());
+
+        possibleErrors.clear();
+        xpath = "//ldml/localeDisplayNames/territories/territory[@type=\"ZA\"]";
+        try {
+            c.check(xpath, xpath, "Africa of the South 123", options, possibleErrors);
+            assertEquals("Can have an odd value", 0, possibleErrors.size());
+        } catch(Throwable t) {
+            t.printStackTrace();
+            fail(xpath + " Crashed with " + t.getMessage());
+        }
     }
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -626,10 +626,16 @@ public class TestCheckCLDR extends TestFmwk {
 
         possibleErrors.clear();
         xpath = "//ldml/localeDisplayNames/territories/territory[@type=\"ZA\"]";
+        final String ZA_123 = "Africa of the South 123";
         try {
-            c.check(xpath, xpath, "Africa of the South 123", options, possibleErrors);
-            assertEquals("Can have an odd value", 0, possibleErrors.size());
-        } catch(Throwable t) {
+            c.check(xpath, xpath, ZA_123, options, possibleErrors);
+            if (assertEquals("Can have an odd value " + ZA_123, 1, possibleErrors.size())) {
+                assertEquals(
+                        "Can have an odd value " + ZA_123,
+                        Subtype.nameContainsYear,
+                        possibleErrors.get(0).getSubtype());
+            }
+        } catch (Throwable t) {
             t.printStackTrace();
             fail(xpath + " Crashed with " + t.getMessage());
         }


### PR DESCRIPTION
CLDR-19495

This is an old (at least CLDR v48) bug
null isn't checked from getBaileyValue
Also, there was no test for this scenario.

ALLOW_MANY_COMMITS=TRUE