### PR TITLE
CLDR-19496 Prevent NO_WINNING_VALUE from showing as candidate item

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -401,8 +401,8 @@ function getValueAndClass(theRow, item) {
     item?.value === cldrSurvey.INHERITANCE_MARKER
       ? theRow?.inheritedDisplayValue
       : item?.value;
-  if (!displayValue) {
-    displayValue = ""; // not "undefined"
+  if (!displayValue || cldrTable.NO_WINNING_VALUE === displayValue) {
+    displayValue = ""; // not "undefined" or "no-winning-value"
   }
   const valueClass = item?.status || "value";
   return { displayValue, valueClass };

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -619,7 +619,7 @@ public class DataPage {
          *     myItem = row.addItem(ourValue, "our");
          */
         private CandidateItem addItem(String value, String candidateHistory) {
-            if (value == null) {
+            if (value == null || VoteResolver.NO_WINNING_VALUE.equals(value)) {
                 return null;
             }
             if (VoteResolver.DROP_HARD_INHERITANCE && value.equals(inheritedValue)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -1317,6 +1317,10 @@ public abstract class CheckCLDR implements CheckAccessor {
         // }
         result.clear();
 
+        if (VoteResolver.NO_WINNING_VALUE.equals(value)) {
+            return this;
+        }
+
         /*
          * If the item is non-winning, and either inherited or it is code-fallback, then don't run
          * any tests on this item.  See http://unicode.org/cldr/trac/ticket/7574

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -98,6 +98,7 @@ import org.unicode.cldr.util.UnitConverter;
 import org.unicode.cldr.util.UnitConverter.UnitId;
 import org.unicode.cldr.util.UnitConverter.UnitSystem;
 import org.unicode.cldr.util.Units;
+import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.XListFormatter.ListTypeLength;
 import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.personname.PersonNameFormatter;
@@ -501,7 +502,10 @@ public class ExampleGenerator {
     }
 
     private String getExampleHtmlExtended(String xpath, String value, boolean nonTrivial) {
-        if (value == null || xpath == null || xpath.endsWith("/alias")) {
+        if (value == null
+                || xpath == null
+                || xpath.endsWith("/alias")
+                || VoteResolver.NO_WINNING_VALUE.equals(value)) {
             return null;
         }
         String result;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -97,7 +97,7 @@ public class VoteResolver<T> {
      * A placeholder for winningValue when it would otherwise be null. It must match
      * NO_WINNING_VALUE in the client JavaScript code.
      */
-    private static final String NO_WINNING_VALUE = "no-winning-value";
+    public static final String NO_WINNING_VALUE = "no-winning-value";
 
     /** A placeholder for vote-for-missing. Not allowed as a normal value. */
     public static final String VOTE_FOR_MISSING = "🚫🚫🚫"; // U+1F6AB x 3


### PR DESCRIPTION
-Skip NO_WINNING_VALUE in DataPage.DataRow.addItem, CheckCLDR.check, ExampleGenerator.getExampleHtmlExtended, and cldrInfo.getValueAndClass

-Comments

CLDR-19496

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
