### PR TITLE
CLDR-19489 add New category

### DIFF
--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -1413,20 +1413,25 @@ public class SurveyDriver {
 
         result = sanityLogin(SurveyDriverCredentials.SPECIAL_USER_TC) && result;
 
-        /// ----- OK. now start the steps
-        /// 10. CLA
-        result = testCla() && result;
+        // Exit quickly if we can't even login.
+        if (result) {
+            /// ----- OK. now start the steps
+            /// 10. CLA
+            result = testCla() && result;
 
-        /// 11.- Voting
-        result = testVoting() && result;
+            /// 11.- Voting
+            result = testVoting() && result;
 
-        /// 24.- Forum
-        result = testForum() && result;
+            /// 24.- Forum
+            result = testForum() && result;
 
-        /// 28.- Reports
-        result = testReports() && result;
+            /// 28.- Reports
+            result = testReports() && result;
 
-        /// 29 BRS - n/a
+            /// 29 BRS - n/a
+        } else {
+            printlnSummary("- Can’t proceed, since login has failed.");
+        }
 
         printSection("Overall Sanity Test: " + getResult(result));
         return result;

--- a/tools/cldr-apps/Dockerfile
+++ b/tools/cldr-apps/Dockerfile
@@ -13,6 +13,8 @@ FROM icr.io/appcafe/open-liberty:26.0.0.4-kernel-slim-java17-openj9-ubi AS serve
 # copy just the server file so we get config
 COPY --from=setup /opt/ol/wlp/usr/servers/cldr/server.xml /opt/ol/wlp/usr/servers/defaultServer/server.xml
 USER root
+# needed for cldr-archive
+RUN dnf install -y git
 RUN mkdir /home/default
 RUN chown default /config/server.xml /home/default
 RUN mkdir -p /srv/st/config  /srv/st/src && chown -R default /srv/st

--- a/tools/cldr-apps/js/src/esm/cldrStatus.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.mjs
@@ -75,7 +75,7 @@ function updateAll(status) {
     setOldVersion(status.oldVersion);
   }
   if (status.lastVoteVersion) {
-    setNewVersion(status.lastVoteVersion);
+    setLastVoteVersion(status.lastVoteVersion);
   }
   if (status.organizationName) {
     setOrganizationName(status.organizationName);
@@ -317,6 +317,26 @@ function setNewVersion(version) {
   newVersion = version;
 }
 
+let oldVersion = "Old";
+
+function getOldVersion() {
+  return oldVersion;
+}
+
+function setOldVersion(version) {
+  oldVersion = version;
+}
+
+let lastVoteVersion = "Last Vote Version";
+
+function getLastVoteVersion() {
+  return lastVoteVersion;
+}
+
+function setLastVoteVersion(version) {
+  lastVoteVersion = version;
+}
+
 /**
  * Is this an "unofficial" (test or non-production) instance of Survey Tool? (Boolean)
  */
@@ -532,7 +552,9 @@ export {
   getExtendedPhase,
   getIsPhaseBeta,
   getIsUnofficial,
+  getLastVoteVersion,
   getNewVersion,
+  getOldVersion,
   getOrganizationName,
   getPermissions,
   getPhase,

--- a/tools/cldr-apps/js/src/esm/cldrStatus.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.mjs
@@ -71,6 +71,12 @@ function updateAll(status) {
   if (status.newVersion) {
     setNewVersion(status.newVersion);
   }
+  if (status.oldVersion) {
+    setOldVersion(status.oldVersion);
+  }
+  if (status.lastVoteVersion) {
+    setNewVersion(status.lastVoteVersion);
+  }
   if (status.organizationName) {
     setOrganizationName(status.organizationName);
   }

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -569,6 +569,8 @@ const strings = {
 
   mail_noMail: "No simulated notification emails.",
 
+
+  // NB: see DashboardWidget.vue#describe forthe notification_category replacement values
   notification_category_abstained:
     "You have abstained, or not yet voted for any value.",
   notification_category_changed:
@@ -588,6 +590,8 @@ const strings = {
   notification_category_missing:
     "Your current coverage level requires the item to be present. " +
     "(During the vetting phase, this is informational: you can’t add new values.)",
+  notification_category_new:
+    "Item did not have a winning value in ${lastVoteVersion}, and you have not voted for it.",
   notification_category_provisional:
     "There are not enough votes for this item to be approved (and used).",
   notification_category_warning:

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -569,8 +569,7 @@ const strings = {
 
   mail_noMail: "No simulated notification emails.",
 
-
-  // NB: see DashboardWidget.vue#describe forthe notification_category replacement values
+  // NB: see DashboardWidget.vue#describe for the notification_category replacement values
   notification_category_abstained:
     "You have abstained, or not yet voted for any value.",
   notification_category_changed:

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -413,11 +413,14 @@ export default {
     },
 
     describe(category) {
+      const lastVoteVersion = cldrStatus.getLastVoteVersion();
       // The category is like "English_Changed" or "English Changed"
       // The corresponding key is like "notification_category_english_changed"
       const key =
         "notification_category_" + category.toLowerCase().replaceAll(" ", "_");
-      let description = cldrText.get(key);
+      let description = cldrText.sub(key, {
+        lastVoteVersion,
+      });
       if (description === key) {
         console.error(
           "Dashboard is missing a description for the category: " + category

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -246,6 +246,7 @@ public class Dashboard {
         VettingViewer<Organization> vv =
                 new VettingViewer<>(
                         sm.getSupplementalDataInfo(), sourceFactory, new STUsersChoice(sm));
+        vv.setOldVoteFactory(sm.getLastVoteDiskFactory());
         EnumSet<NotificationCategory> choiceSet =
                 VettingViewer.getDashboardNotificationCategories(usersOrg);
         if (includeOther) {
@@ -258,7 +259,7 @@ public class Dashboard {
         } else {
             args.setUserAndOrganization(UserRegistry.NO_USER, usersOrg);
         }
-        args.setFiles(locale, sourceFactory, sm.getDiskFactory());
+        args.setFiles(locale, sourceFactory, sm.getDiskFactory(), sm.getLastVoteDiskFactory());
         if (xpath != null) {
             args.setXpath(xpath);
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -66,6 +68,7 @@ import org.unicode.cldr.tool.CheckoutArchive;
 import org.unicode.cldr.tool.ToolConstants;
 import org.unicode.cldr.util.CLDRCacheDir;
 import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRConfig.Environment;
 import org.unicode.cldr.util.CLDRConfigImpl;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
@@ -403,7 +406,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             verifyConfigSanity();
             ensureCldrToolsIsFunctioning();
             getDbInstance();
-            SurveyThreadManager.getExecutorService().submit(this::doStartup);
+            startupFuture = SurveyThreadManager.getExecutorService().submit(this::doStartup);
             klm = new KeepLoggedInManager(null);
         } catch (Throwable t) {
             t.printStackTrace();
@@ -2377,16 +2380,15 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     private Supplier<Factory> gLastVoteDiskFactory =
             Suppliers.memoize(
                     () -> {
-                        final File[] list = {
-                            new File(ToolConstants.getBaseDirectory(lastVoteVersion))
-                        };
-                        CLDRConfig config = CLDRConfig.getInstance();
+                        String baseOldDirectory = ToolConstants.getBaseDirectory(lastVoteVersion);
+                        File main = new File(baseOldDirectory, "common/main");
+                        File annotations = new File(baseOldDirectory, "common/annotations");
+                        final File[] list = {main, annotations};
                         // verify readable
-                        File root = new File(list[0], "common/main");
-                        if (!root.isDirectory()) {
+                        if (!main.isDirectory()) {
                             throw new InternalError(
                                     "Not a dir:  "
-                                            + root.getAbsolutePath()
+                                            + main.getAbsolutePath()
                                             + " - check the value of CLDR_LASTVOTEVERSION="
                                             + lastVoteVersion
                                             + " in cldr.properties.");
@@ -2812,6 +2814,10 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     /** Class to startup ST in background and perform background operations. */
     public transient SurveyThreadManager startupThread = new SurveyThreadManager();
 
+    private transient Future<?> startupFuture = null;
+    private transient Future<?> checkoutFuture = null;
+    private transient Future<?> abstractFuture = null;
+
     /** Progress bar manager */
     private final SurveyProgressManager progressManager = new SurveyProgressManager();
 
@@ -2821,35 +2827,40 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     private void doCheckoutArchive() {
         if (lastVoteVersion == null
                 || lastVoteVersion.isBlank()
-                || !ToolConstants.CLDR_VERSIONS.contains(lastVoteVersion)) {
+                || !ToolConstants.haveVersion(lastVoteVersion)) {
             busted(
                     "CLDR_LASTVOTEVERSION="
                             + lastVoteVersion
                             + " but does not exist in ToolConstants.");
         }
+        ElapsedTimer archiveTimer = new ElapsedTimer("Checkout " + lastVoteVersion);
         try {
             // create the ARCHIVE dir.
             Path archiveDir = new File(CLDRPaths.ARCHIVE_DIRECTORY).toPath();
             if (!archiveDir.toFile().isDirectory()) {
                 archiveDir.toFile().mkdirs();
             }
-            // now, checkout the last version
-            int created = CheckoutArchive.doCheckout(true, lastVoteVersion);
+            // now, checkout the last version.
+            // Prune may cause trouble in some situations.
+            // We use a clone so that we don't have to write to the base git repo.
+            int created =
+                    CheckoutArchive.doCheckout(
+                            false, ToolConstants.formatVersion(lastVoteVersion), true);
             if (created > 0) {
-                System.err.println("Successfully checked out " + lastVoteVersion);
+                logger.info("Successfully checked out " + lastVoteVersion + " in " + archiveTimer);
             }
         } catch (Throwable t) {
             busted("Could not checkout CLDR_LASTVOTEVERSION=" + lastVoteVersion, t);
             return; /* NOTREACHED */
         }
-
         try {
             getLastVoteDiskFactory().make("en", false);
         } catch (Throwable t) {
+            t.printStackTrace();
             busted("Could not create disk file in CLDR_LASTVOTEVERSION=" + lastVoteVersion, t);
             return; /* NOTREACHED */
         }
-        System.err.println("Validated CLDR_LASTVOTEVERSION=" + lastVoteVersion);
+        logger.info("Validated CLDR_LASTVOTEVERSION=" + lastVoteVersion + " in " + archiveTimer);
     }
 
     /** Startup function. Called in a separate thread. */
@@ -2931,6 +2942,10 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             oldVersion = survprops.getProperty(CLDR_OLDVERSION, CLDR_OLDVERSION);
             lastVoteVersion = survprops.getProperty(CLDR_LASTVOTEVERSION, oldVersion);
 
+            // sublaunch checkoutArchive as soon as we have the lastVoteVersion
+            checkoutFuture =
+                    SurveyThreadManager.getExecutorService().submit(this::doCheckoutArchive);
+
             setupHomeDir(progress);
 
             progress.update("Setup vap and message..");
@@ -3004,15 +3019,20 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
 
             progress.update("Making your Survey Tool happy..");
 
-            // sublaunch checkoutArchive
-            SurveyThreadManager.getExecutorService().submit(this::doCheckoutArchive);
-
             if (isBusted == null) {
                 MailSender.getInstance();
                 Summary.scheduleAutomaticSnapshots();
             } else {
                 progress.update("Not loading mail - SurveyTool already busted.");
             }
+
+            progress.update("Waiting for checkoutArchive");
+            try {
+                checkoutFuture.get(2, TimeUnit.MINUTES);
+            } catch (InterruptedException ie) {
+                throw new RuntimeException("Timed out waiting for checkoutArchive", ie);
+            }
+
         } catch (Throwable t) {
             t.printStackTrace();
             SurveyLog.logException(logger, t, "StartupThread");
@@ -3079,6 +3099,17 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         }
     }
 
+    private void doSetupAbstractCache() {
+        CLDRConfig config = CLDRConfig.getInstance();
+        if (config.getEnvironment() == Environment.PRODUCTION
+                || config.getProperty("CLDR_LOAD_ABSTRACTCACHE", false)) {
+            AbstractCacheManager.getInstance().setup();
+        } else {
+            logger.warning(
+                    "CLDR_LOAD_ABSTRACTCACHE=false and we aren’t on PRODUCTION, skipping abstract cache");
+        }
+    }
+
     /**
      * Setup things that are dependent on the CLDR home directory being set.
      *
@@ -3088,8 +3119,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         progress.update("Setup the Home dir..");
 
         // load abstracts in a separate thread.
-        SurveyThreadManager.getExecutorService()
-                .submit(() -> AbstractCacheManager.getInstance().setup());
+        abstractFuture =
+                SurveyThreadManager.getExecutorService().submit(() -> doSetupAbstractCache());
 
         // we could setup the url subtype mapper here, but instead we leave that
         // to be lazily loaded.

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -24,6 +24,7 @@ import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -61,6 +62,8 @@ import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.ExampleGenerator;
 import org.unicode.cldr.test.HelpMessages;
 import org.unicode.cldr.test.SubmissionLocales;
+import org.unicode.cldr.tool.CheckoutArchive;
+import org.unicode.cldr.tool.ToolConstants;
 import org.unicode.cldr.util.CLDRCacheDir;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfigImpl;
@@ -68,6 +71,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRLocale.CLDRFormatter;
 import org.unicode.cldr.util.CLDRLocale.FormatBehavior;
+import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CoverageInfo;
@@ -2366,6 +2370,31 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                         return SimpleFactory.make(list, ".*");
                     });
 
+    public final Factory getLastVoteDiskFactory() {
+        return gLastVoteDiskFactory.get();
+    }
+
+    private Supplier<Factory> gLastVoteDiskFactory =
+            Suppliers.memoize(
+                    () -> {
+                        final File[] list = {
+                            new File(ToolConstants.getBaseDirectory(lastVoteVersion))
+                        };
+                        CLDRConfig config = CLDRConfig.getInstance();
+                        // verify readable
+                        File root = new File(list[0], "common/main");
+                        if (!root.isDirectory()) {
+                            throw new InternalError(
+                                    "Not a dir:  "
+                                            + root.getAbsolutePath()
+                                            + " - check the value of CLDR_LASTVOTEVERSION="
+                                            + lastVoteVersion
+                                            + " in cldr.properties.");
+                        }
+
+                        return SimpleFactory.make(list, ".*");
+                    });
+
     private void ensureOrCheckout(final File dir) {
         if (dir == null) {
             busted("Configuration Error: " + CldrUtility.DIR_KEY + " is not set.");
@@ -2788,6 +2817,41 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
 
     private String cldrHome;
 
+    /** Checkout prior. Called in separate thread. */
+    private void doCheckoutArchive() {
+        if (lastVoteVersion == null
+                || lastVoteVersion.isBlank()
+                || !ToolConstants.CLDR_VERSIONS.contains(lastVoteVersion)) {
+            busted(
+                    "CLDR_LASTVOTEVERSION="
+                            + lastVoteVersion
+                            + " but does not exist in ToolConstants.");
+        }
+        try {
+            // create the ARCHIVE dir.
+            Path archiveDir = new File(CLDRPaths.ARCHIVE_DIRECTORY).toPath();
+            if (!archiveDir.toFile().isDirectory()) {
+                archiveDir.toFile().mkdirs();
+            }
+            // now, checkout the last version
+            int created = CheckoutArchive.doCheckout(true, lastVoteVersion);
+            if (created > 0) {
+                System.err.println("Successfully checked out " + lastVoteVersion);
+            }
+        } catch (Throwable t) {
+            busted("Could not checkout CLDR_LASTVOTEVERSION=" + lastVoteVersion, t);
+            return; /* NOTREACHED */
+        }
+
+        try {
+            getLastVoteDiskFactory().make("en", false);
+        } catch (Throwable t) {
+            busted("Could not create disk file in CLDR_LASTVOTEVERSION=" + lastVoteVersion, t);
+            return; /* NOTREACHED */
+        }
+        System.err.println("Validated CLDR_LASTVOTEVERSION=" + lastVoteVersion);
+    }
+
     /** Startup function. Called in a separate thread. */
     private void doStartup() {
         ElapsedTimer setupTime = new ElapsedTimer();
@@ -2939,6 +3003,9 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
             doStartupDB(); // will take over progress 50-60
 
             progress.update("Making your Survey Tool happy..");
+
+            // sublaunch checkoutArchive
+            SurveyThreadManager.getExecutorService().submit(this::doCheckoutArchive);
 
             if (isBusted == null) {
                 MailSender.getInstance();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -3786,6 +3786,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         private final boolean isSetup = SurveyMain.isSetup;
         private final boolean isUnofficial = SurveyMain.isUnofficial();
         private final String newVersion = SurveyMain.newVersion;
+        private final String oldVersion = SurveyMain.oldVersion;
+        private final String lastVoteVersion = SurveyMain.lastVoteVersion;
         private String organizationName = null;
         private final int pages = SurveyMain.pages;
         private Object permissions = null;
@@ -3820,6 +3822,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                     .put("isSetup", isSetup)
                     .put("isUnofficial", isUnofficial)
                     .put("newVersion", newVersion)
+                    .put("oldVersion", oldVersion)
+                    .put("lastVoteVersion", lastVoteVersion)
                     .put("organizationName", organizationName)
                     .put("pages", pages)
                     .put("permissions", permissions)

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -3099,14 +3099,15 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         }
     }
 
+    /** Separate thread runner for launching the Abstract Cache. */
     private void doSetupAbstractCache() {
         CLDRConfig config = CLDRConfig.getInstance();
-        if (config.getEnvironment() == Environment.PRODUCTION
-                || config.getProperty("CLDR_LOAD_ABSTRACTCACHE", false)) {
+        if (config.getProperty(
+                "CLDR_LOAD_ABSTRACTCACHE", config.getEnvironment() == Environment.PRODUCTION)) {
             AbstractCacheManager.getInstance().setup();
         } else {
             logger.warning(
-                    "CLDR_LOAD_ABSTRACTCACHE=false and we aren’t on PRODUCTION, skipping abstract cache");
+                    "CLDR_LOAD_ABSTRACTCACHE=false (only defaults on in PRODUCTION), skipping abstract cache");
         }
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
@@ -294,6 +294,7 @@ public class VettingViewerQueue {
             vv =
                     new VettingViewer<>(
                             sm.getSupplementalDataInfo(), sm.getSTFactory(), new STUsersChoice(sm));
+            vv.setOldVoteFactory(sm.getLastVoteDiskFactory());
             vv.setSummarizeAllLocales(summarizeAllLocales);
             int localeCount = vv.getLocaleCount(usersOrg);
             int pathCount = getMax(sm.getEnglishFile());

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/About.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/About.java
@@ -73,6 +73,8 @@ public class About {
         }
         r.put("GEN_VERSION", CLDRFile.GEN_VERSION);
         r.put("OLD_VERSION", SurveyMain.getOldVersion());
+        r.put("CLDR_NEWVERSION", SurveyMain.getNewVersion());
+        r.put("CLDR_LASTVOTEVERSION", SurveyMain.getLastVoteVersion());
         r.put("ICU_VERSION", VersionInfo.ICU_VERSION.toString());
         try {
             ServletContext sc = CookieSession.sm.getServletContext();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletionCounter.java
@@ -31,13 +31,14 @@ public class LocaleCompletionCounter {
         final VettingViewer.UsersChoice<Organization> userVoteStatus =
                 isBaseline ? new VotelessUsersChoice() : new STUsersChoice(sm);
         vv = new VettingViewer<>(sm.getSupplementalDataInfo(), factory, userVoteStatus);
+        vv.setOldVoteFactory(sm.getLastVoteDiskFactory());
         final EnumSet<NotificationCategory> set = VettingViewer.getLocaleCompletionCategories();
         args = new VettingParameters(set, cldrLocale, level);
         args.setUserAndOrganization(0, VettingViewer.getNeutralOrgForSummary());
         if (isBaseline) {
             args.setFilesForBaseline(cldrLocale, factory);
         } else {
-            args.setFiles(cldrLocale, factory, sm.getDiskFactory());
+            args.setFiles(cldrLocale, factory, sm.getDiskFactory(), sm.getLastVoteDiskFactory());
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
@@ -91,6 +91,8 @@ public class CheckoutArchive {
         for (final String ver : ToolConstants.CLDR_VERSIONS) {
             if (onlyVersion != null && !onlyVersion.equals(ver)) continue;
             final Path dirName = archiveDir.resolve("cldr-" + ver);
+            // 48.1 -> release-48-1
+            // 49.0 -> release-49
             final String tag = "release-" + ver.replaceAll("\\.", "-").replaceAll("-0$", "");
             if (dirName.toFile().isDirectory()) {
                 skip++;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.Set;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CLDRTool;
 
 @CLDRTool(
@@ -16,6 +17,7 @@ import org.unicode.cldr.util.CLDRTool;
 public class CheckoutArchive {
     enum MyOptions {
         prune("Perform a 'git prune' first"),
+        clone("Perform a clone instead of creating a worktree"),
         echo("Only show commands, don't run them. (Dry run)"),
         ;
 
@@ -47,15 +49,19 @@ public class CheckoutArchive {
         MyOptions.parse(args, true);
 
         final boolean doPrune = MyOptions.prune.option.doesOccur();
-        final String onlyVersion = null;
+        final boolean doClone = MyOptions.clone.option.doesOccur();
 
-        doCheckout(doPrune, onlyVersion);
+        doCheckout(doPrune, null, doClone);
     }
 
     /**
+     * Perform the checkout.
+     * @param doPrune perform a git worktree prune first
+     * @param onlyVersion only checkout this version. See {@link ToolConstants#formatVersion(String)} and {@link ToolConstants#haveVersion(String)}
+     * @param doClone use a git clone instead of a worktree
      * @returns number of created directories
      */
-    public static int doCheckout(final boolean doPrune, final String onlyVersion)
+    public static int doCheckout(final boolean doPrune, final String onlyVersion, final boolean doClone)
             throws IOException, InterruptedException {
 
         Path archiveDir = new File(CLDRPaths.ARCHIVE_DIRECTORY).toPath();
@@ -82,14 +88,27 @@ public class CheckoutArchive {
         for (final String ver : ToolConstants.CLDR_VERSIONS) {
             if (onlyVersion != null && !onlyVersion.equals(ver)) continue;
             final Path dirName = archiveDir.resolve("cldr-" + ver);
+            final String tag = "release-" + ver.replaceAll("\\.", "-").replaceAll("-0$", "");
             if (dirName.toFile().isDirectory()) {
                 skip++;
                 System.out.println("# Skipping existing \t" + dirName.toString());
+            } else if (doClone) {
+                // do a linked clone instead of a worktree
+                // the reference should prevent us from hitting the repo again
+                final String cmd[] = { "git", "clone", "--branch", tag, "--single-branch", CLDRURLS.CLDR_REPO_BASE, "--reference-if-able",
+                    CLDRPaths.BASE_DIRECTORY, dirName.toString() };
+                if (runCommand(cmd)) {
+                    err++;
+                } else {
+                    created++;
+                }
             } else {
-                final String tag = "release-" + ver.replaceAll("\\.", "-").replaceAll("-0$", "");
+                // add a worktree
                 final String cmd[] = {"git", "worktree", "add", dirName.toString(), tag};
                 if (runCommand(cmd)) {
                     err++;
+                } else {
+                    created++;
                 }
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
@@ -7,8 +7,8 @@ import java.nio.file.Path;
 import java.util.Set;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CLDRTool;
+import org.unicode.cldr.util.CLDRURLS;
 
 @CLDRTool(
         alias = "checkout-archive",
@@ -56,12 +56,15 @@ public class CheckoutArchive {
 
     /**
      * Perform the checkout.
+     *
      * @param doPrune perform a git worktree prune first
-     * @param onlyVersion only checkout this version. See {@link ToolConstants#formatVersion(String)} and {@link ToolConstants#haveVersion(String)}
+     * @param onlyVersion only checkout this version. See {@link
+     *     ToolConstants#formatVersion(String)} and {@link ToolConstants#haveVersion(String)}
      * @param doClone use a git clone instead of a worktree
      * @returns number of created directories
      */
-    public static int doCheckout(final boolean doPrune, final String onlyVersion, final boolean doClone)
+    public static int doCheckout(
+            final boolean doPrune, final String onlyVersion, final boolean doClone)
             throws IOException, InterruptedException {
 
         Path archiveDir = new File(CLDRPaths.ARCHIVE_DIRECTORY).toPath();
@@ -95,8 +98,17 @@ public class CheckoutArchive {
             } else if (doClone) {
                 // do a linked clone instead of a worktree
                 // the reference should prevent us from hitting the repo again
-                final String cmd[] = { "git", "clone", "--branch", tag, "--single-branch", CLDRURLS.CLDR_REPO_BASE, "--reference-if-able",
-                    CLDRPaths.BASE_DIRECTORY, dirName.toString() };
+                final String cmd[] = {
+                    "git",
+                    "clone",
+                    "--branch",
+                    tag,
+                    "--single-branch",
+                    CLDRURLS.CLDR_REPO_BASE,
+                    "--reference-if-able",
+                    CLDRPaths.BASE_DIRECTORY,
+                    dirName.toString()
+                };
                 if (runCommand(cmd)) {
                     err++;
                 } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckoutArchive.java
@@ -46,6 +46,18 @@ public class CheckoutArchive {
     public static void main(String args[]) throws IOException, InterruptedException {
         MyOptions.parse(args, true);
 
+        final boolean doPrune = MyOptions.prune.option.doesOccur();
+        final String onlyVersion = null;
+
+        doCheckout(doPrune, onlyVersion);
+    }
+
+    /**
+     * @returns number of created directories
+     */
+    public static int doCheckout(final boolean doPrune, final String onlyVersion)
+            throws IOException, InterruptedException {
+
         Path archiveDir = new File(CLDRPaths.ARCHIVE_DIRECTORY).toPath();
         if (!archiveDir.toFile().isDirectory()) {
             throw new FileNotFoundException(
@@ -58,7 +70,7 @@ public class CheckoutArchive {
         int created = 0;
         int err = 0;
 
-        if (MyOptions.prune.option.doesOccur()) {
+        if (doPrune) {
             final String cmd[] = {
                 "git", "worktree", "prune",
             };
@@ -68,6 +80,7 @@ public class CheckoutArchive {
         }
 
         for (final String ver : ToolConstants.CLDR_VERSIONS) {
+            if (onlyVersion != null && !onlyVersion.equals(ver)) continue;
             final Path dirName = archiveDir.resolve("cldr-" + ver);
             if (dirName.toFile().isDirectory()) {
                 skip++;
@@ -84,6 +97,7 @@ public class CheckoutArchive {
         if (err != 0) {
             throw new RuntimeException("Total errors: " + err);
         }
+        return created;
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
@@ -114,7 +114,6 @@ public class ToolConstants {
         return formatVersion(vi);
     }
 
-
     // allows overriding with -D
     public static final VersionInfo CHART_VI =
             VersionInfo.getInstance(CldrUtility.getProperty("CHART_VERSION", DEV_VERSION));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ToolConstants.java
@@ -96,6 +96,25 @@ public class ToolConstants {
         return getBaseDirectory(vi);
     }
 
+    public static boolean haveVersion(String version) {
+        VersionInfo vi = VersionInfo.getInstance(version);
+        return haveVersion(vi);
+    }
+
+    public static boolean haveVersion(VersionInfo version) {
+        return CLDR_VERSIONS_VI.contains(version);
+    }
+
+    public static String formatVersion(VersionInfo version) {
+        return version.getVersionString(2, 2);
+    }
+
+    public static String formatVersion(String version) {
+        VersionInfo vi = VersionInfo.getInstance(version);
+        return formatVersion(vi);
+    }
+
+
     // allows overriding with -D
     public static final VersionInfo CHART_VI =
             VersionInfo.getInstance(CldrUtility.getProperty("CHART_VERSION", DEV_VERSION));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -739,6 +739,13 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     }
 
     /**
+     * @return DraftStatus for DPath
+     */
+    public DraftStatus getDraftStatus(String xpath) {
+        return DraftStatus.forXpath(getFullXPath(xpath));
+    }
+
+    /**
      * Get the last modified date (if available) from a distinguished path.
      *
      * @return date or null if not available.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Counter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Counter.java
@@ -331,6 +331,10 @@ public class Counter<T> implements Iterable<T>, Comparable<Counter<T>> {
         return this;
     }
 
+    public Counter<T> decrement(T key) {
+        return add(key, -1, getTime(key));
+    }
+
     // public RWLong put(T key, RWLong value) {
     // return map.put(key, value);
     // }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
@@ -4,17 +4,6 @@ public enum NotificationCategory {
     /** There is a console-check error */
     error('E', "Error", "The Survey Tool detected an error in the winning value."),
 
-    /**
-     * New since CLDR_LASTVOTEVERSION
-     *
-     * @see {@link VettingParameters#setFiles(CLDRLocale, Factory, Factory, Factory)}
-     * @see {@link VettingViewer#setOldVoteFactory(Factory)}
-     */
-    newSinceLastVote(
-            'N',
-            "New",
-            "Item did not have a winning value (contributed+) in the previous cycle, and you have not voted for it."),
-
     /** Given the users' coverage, some items are missing */
     missingCoverage(
             'M',
@@ -27,6 +16,17 @@ public enum NotificationCategory {
             'P',
             "Provisional",
             "There are not enough votes for this item to be approved (and used)."),
+
+        /**
+         * New since CLDR_LASTVOTEVERSION
+         *
+         * @see {@link VettingParameters#setFiles(CLDRLocale, Factory, Factory, Factory)}
+         * @see {@link VettingViewer#setOldVoteFactory(Factory)}
+         */
+    newSinceLastVote(
+            'N',
+            "New",
+            "Item did not have a winning value (contributed+) in the previous cycle, and you have not voted for it."),
 
     /** There is a dispute. */
     hasDispute(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
@@ -17,12 +17,12 @@ public enum NotificationCategory {
             "Provisional",
             "There are not enough votes for this item to be approved (and used)."),
 
-        /**
-         * New since CLDR_LASTVOTEVERSION
-         *
-         * @see {@link VettingParameters#setFiles(CLDRLocale, Factory, Factory, Factory)}
-         * @see {@link VettingViewer#setOldVoteFactory(Factory)}
-         */
+    /**
+     * New since CLDR_LASTVOTEVERSION
+     *
+     * @see {@link VettingParameters#setFiles(CLDRLocale, Factory, Factory, Factory)}
+     * @see {@link VettingViewer#setOldVoteFactory(Factory)}
+     */
     newSinceLastVote(
             'N',
             "New",

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
@@ -26,7 +26,7 @@ public enum NotificationCategory {
     newSinceLastVote(
             'N',
             "New",
-            "Item did not have a winning value (contributed+) in the previous cycle, and you have not voted for it."),
+            "Item did not have a winning value (at least contributed) in the previous cycle, and you have not voted for it."),
 
     /** There is a dispute. */
     hasDispute(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
@@ -4,6 +4,17 @@ public enum NotificationCategory {
     /** There is a console-check error */
     error('E', "Error", "The Survey Tool detected an error in the winning value."),
 
+    /**
+     * New since CLDR_LASTVOTEVERSION
+     *
+     * @see {@link VettingParameters#setFiles(CLDRLocale, Factory, Factory, Factory)}
+     * @see {@link VettingViewer#setOldVoteFactory(Factory)}
+     */
+    newSinceLastVote(
+            'N',
+            "New",
+            "Item did not have a winning value (contributed+) in the previous cycle, and you have not voted for it."),
+
     /** Given the users' coverage, some items are missing */
     missingCoverage(
             'M',

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingParameters.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingParameters.java
@@ -37,7 +37,10 @@ public class VettingParameters {
      * @param oldFactory Needed for category {@link NotificationCategory#newSinceLastVote}
      */
     public void setFiles(
-            CLDRLocale locale, Factory sourceFactory, Factory baselineFactory, Factory oldFactory) {
+            CLDRLocale locale,
+            Factory sourceFactory,
+            Factory baselineFactory,
+            Factory oldVoteFactory) {
         /*
          * sourceFile provides the current winning values, taking into account recent votes.
          * baselineFile provides the "baseline" (a.k.a. "trunk") values, i.e., the values that
@@ -48,11 +51,23 @@ public class VettingParameters {
         final String localeId = locale.getBaseName();
         final CLDRFile sourceFile = sourceFactory.make(localeId, true /* resolved */);
         final CLDRFile baselineFile = baselineFactory.make(localeId, true);
+        setFiles(sourceFile, baselineFile, makeOldVoteFile(oldVoteFactory, localeId));
+    }
+
+    /**
+     * Optionally get the oldVoteFile given a factory.
+     *
+     * @return null if oldVoteFactory is null or if the locale doesn't exist, or if oldVoteFactory
+     *     is null.
+     */
+    public static CLDRFile makeOldVoteFile(Factory oldVoteFactory, final String localeId) {
         CLDRFile oldVoteFile = null;
-        if (oldFactory != null) {
-            oldVoteFile = oldFactory.make(localeId, true);
+        if (oldVoteFactory != null) {
+            if (oldVoteFactory.getAvailable().contains(localeId)) {
+                oldVoteFile = oldVoteFactory.make(localeId, true);
+            }
         }
-        setFiles(sourceFile, baselineFile, oldVoteFile);
+        return oldVoteFile;
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingParameters.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingParameters.java
@@ -11,6 +11,7 @@ public class VettingParameters {
     Organization organization = null;
     CLDRFile sourceFile = null;
     CLDRFile baselineFile = null;
+    CLDRFile oldVoteFile = null;
 
     /**
      * A path like "//ldml/dates/timeZoneNames/zone[@type="America/Guadeloupe"]/short/daylight", or
@@ -26,6 +27,17 @@ public class VettingParameters {
     }
 
     public void setFiles(CLDRLocale locale, Factory sourceFactory, Factory baselineFactory) {
+        setFiles(locale, sourceFactory, baselineFactory, null);
+    }
+
+    /**
+     * @param locale
+     * @param sourceFactory
+     * @param baselineFactory
+     * @param oldFactory Needed for category {@link NotificationCategory#newSinceLastVote}
+     */
+    public void setFiles(
+            CLDRLocale locale, Factory sourceFactory, Factory baselineFactory, Factory oldFactory) {
         /*
          * sourceFile provides the current winning values, taking into account recent votes.
          * baselineFile provides the "baseline" (a.k.a. "trunk") values, i.e., the values that
@@ -36,7 +48,11 @@ public class VettingParameters {
         final String localeId = locale.getBaseName();
         final CLDRFile sourceFile = sourceFactory.make(localeId, true /* resolved */);
         final CLDRFile baselineFile = baselineFactory.make(localeId, true);
-        setFiles(sourceFile, baselineFile);
+        CLDRFile oldVoteFile = null;
+        if (oldFactory != null) {
+            oldVoteFile = oldFactory.make(localeId, true);
+        }
+        setFiles(sourceFile, baselineFile, oldVoteFile);
     }
 
     /**
@@ -60,8 +76,13 @@ public class VettingParameters {
     }
 
     public void setFiles(CLDRFile sourceFile, CLDRFile baselineFile) {
+        setFiles(sourceFile, baselineFile, oldVoteFile);
+    }
+
+    public void setFiles(CLDRFile sourceFile, CLDRFile baselineFile, CLDRFile oldVoteFile) {
         this.sourceFile = sourceFile;
         this.baselineFile = baselineFile;
+        this.oldVoteFile = oldVoteFile;
     }
 
     public void setXpath(String xpath) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -632,12 +632,15 @@ public class VettingViewer<T> {
                 missingStatus = MissingStatus.PRESENT;
             }
             if (choices.contains(NotificationCategory.newSinceLastVote)
-                // completely new file
-                && (oldVoteFile == null
-                    // no previous winner
-                    || (oldVoteFile.getStringValue(path) == null
-                        // previous winner below contributed
-                        || oldVoteFile.getDraftStatus(path).compareTo(DraftStatus.contributed) < 0))) {
+                    // completely new file
+                    && (oldVoteFile == null
+                            // no previous winner
+                            || (oldVoteFile.getStringValue(path) == null
+                                    // previous winner below contributed
+                                    || oldVoteFile
+                                                    .getDraftStatus(path)
+                                                    .compareTo(DraftStatus.contributed)
+                                            < 0))) {
                 problems.add(NotificationCategory.newSinceLastVote);
                 vc.problemCounter.increment(NotificationCategory.newSinceLastVote);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -276,8 +276,7 @@ public class VettingViewer<T> {
     }
 
     /**
-     * Set the prior old vote factory. Needed for category {@link
-     * NotificationCategory#newSinceLastVote}
+     * Set the old vote factory. Needed for category {@link NotificationCategory#newSinceLastVote}
      */
     public void setOldVoteFactory(final Factory oldVoteFactory) {
         this.oldVoteFactory = oldVoteFactory;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -34,6 +34,7 @@ import org.unicode.cldr.test.CheckNew;
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.test.OutdatedPaths;
 import org.unicode.cldr.test.SubmissionLocales;
+import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
@@ -598,6 +599,9 @@ public class VettingViewer<T> {
             if (userVoteStatus.userDidVote(voterId, cldrLocale, path)) {
                 VoteType voteType = userVoteStatus.getUserVoteType(voterId, cldrLocale, path);
                 voterProgress.incrementVotedPathCount(voteType);
+                if(problems.remove(NotificationCategory.newSinceLastVote)) {
+                    vc.problemCounter.decrement(NotificationCategory.newSinceLastVote);
+                }
             } else if (choices.contains(NotificationCategory.abstained)) {
                 problems.add(NotificationCategory.abstained);
                 problems.remove(NotificationCategory.other); // may have been added above
@@ -626,6 +630,14 @@ public class VettingViewer<T> {
                 missingStatus = getMissingStatus(sourceFile, path, latin);
             } else {
                 missingStatus = MissingStatus.PRESENT;
+            }
+            if (choices.contains(NotificationCategory.newSinceLastVote)
+                    && oldVoteFile == null // completely new file
+                    || (oldVoteFile.getStringValue(path) == null
+                            || oldVoteFile.getDraftStatus(path).compareTo(DraftStatus.contributed)
+                                    < 0)) {
+                problems.add(NotificationCategory.newSinceLastVote);
+                vc.problemCounter.increment(NotificationCategory.newSinceLastVote);
             }
             if (choices.contains(NotificationCategory.missingCoverage)
                     && missingStatus == MissingStatus.ABSENT) {
@@ -1023,11 +1035,10 @@ public class VettingViewer<T> {
                 }
             }
             FileInfo fileInfo = new FileInfo(localeID, level, choices, context.organization);
-            CLDRFile oldVoteFile = null;
-            if (oldVoteFactory != null) {
-                oldVoteFile = oldVoteFactory.make(localeID, true);
-            }
-            fileInfo.setFiles(sourceFile, baselineFile, oldVoteFile);
+            fileInfo.setFiles(
+                    sourceFile,
+                    baselineFile,
+                    VettingParameters.makeOldVoteFile(oldVoteFactory, localeID));
             fileInfo.getFileInfo();
 
             if (context.localeNameToFileInfo != null) {
@@ -1756,6 +1767,7 @@ public class VettingViewer<T> {
                     EnumSet.of(
                             NotificationCategory.error,
                             NotificationCategory.warning,
+                            NotificationCategory.newSinceLastVote,
                             NotificationCategory.hasDispute,
                             NotificationCategory.notApproved,
                             NotificationCategory.missingCoverage);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -599,7 +599,7 @@ public class VettingViewer<T> {
             if (userVoteStatus.userDidVote(voterId, cldrLocale, path)) {
                 VoteType voteType = userVoteStatus.getUserVoteType(voterId, cldrLocale, path);
                 voterProgress.incrementVotedPathCount(voteType);
-                if(problems.remove(NotificationCategory.newSinceLastVote)) {
+                if (problems.remove(NotificationCategory.newSinceLastVote)) {
                     vc.problemCounter.decrement(NotificationCategory.newSinceLastVote);
                 }
             } else if (choices.contains(NotificationCategory.abstained)) {
@@ -632,7 +632,7 @@ public class VettingViewer<T> {
                 missingStatus = MissingStatus.PRESENT;
             }
             if (choices.contains(NotificationCategory.newSinceLastVote)
-                    && oldVoteFile == null // completely new file
+                            && oldVoteFile == null // completely new file
                     || (oldVoteFile.getStringValue(path) == null
                             || oldVoteFile.getDraftStatus(path).compareTo(DraftStatus.contributed)
                                     < 0)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -632,10 +632,12 @@ public class VettingViewer<T> {
                 missingStatus = MissingStatus.PRESENT;
             }
             if (choices.contains(NotificationCategory.newSinceLastVote)
-                            && oldVoteFile == null // completely new file
+                // completely new file
+                && (oldVoteFile == null
+                    // no previous winner
                     || (oldVoteFile.getStringValue(path) == null
-                            || oldVoteFile.getDraftStatus(path).compareTo(DraftStatus.contributed)
-                                    < 0)) {
+                        // previous winner below contributed
+                        || oldVoteFile.getDraftStatus(path).compareTo(DraftStatus.contributed) < 0))) {
                 problems.add(NotificationCategory.newSinceLastVote);
                 vc.problemCounter.increment(NotificationCategory.newSinceLastVote);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -240,6 +240,10 @@ public class VettingViewer<T> {
     }
 
     private final Factory cldrFactory;
+
+    /** optional factory */
+    private Factory oldVoteFactory = null;
+
     private final CLDRFile englishFile;
     private final UsersChoice<T> userVoteStatus;
     private final SupplementalDataInfo supplementalDataInfo;
@@ -268,6 +272,14 @@ public class VettingViewer<T> {
         this.defaultContentLocales = supplementalDataInfo.getDefaultContentLocales();
 
         reasonsToPaths = Relation.of(new HashMap<>(), HashSet.class);
+    }
+
+    /**
+     * Set the prior old vote factory. Needed for category {@link
+     * NotificationCategory#newSinceLastVote}
+     */
+    public void setOldVoteFactory(final Factory oldVoteFactory) {
+        this.oldVoteFactory = oldVoteFactory;
     }
 
     public class WritingInfo implements Comparable<WritingInfo> {
@@ -321,7 +333,7 @@ public class VettingViewer<T> {
         if (args.specificSinglePath != null) {
             fileInfo.setSinglePath(args.specificSinglePath);
         }
-        fileInfo.setFiles(args.sourceFile, args.baselineFile);
+        fileInfo.setFiles(args.sourceFile, args.baselineFile, args.oldVoteFile);
         fileInfo.setSorted(dd.sorted);
         fileInfo.setVoterProgressAndId(dd.voterProgress, args.userId);
         fileInfo.getFileInfo();
@@ -339,7 +351,7 @@ public class VettingViewer<T> {
                         args.coverageLevel,
                         args.choices,
                         (T) args.organization);
-        fileInfo.setFiles(args.sourceFile, args.baselineFile);
+        fileInfo.setFiles(args.sourceFile, args.baselineFile, args.oldVoteFile);
         fileInfo.getFileInfo();
         return new LocaleCompletionData(fileInfo.vc.problemCounter);
     }
@@ -389,10 +401,12 @@ public class VettingViewer<T> {
         private CLDRFile baselineFile = null;
         private CLDRFile baselineFileUnresolved = null;
         private boolean latin = false;
+        private CLDRFile oldVoteFile = null;
 
-        private void setFiles(CLDRFile sourceFile, CLDRFile baselineFile) {
+        private void setFiles(CLDRFile sourceFile, CLDRFile baselineFile, CLDRFile oldVoteFile) {
             this.sourceFile = sourceFile;
             this.baselineFile = baselineFile;
+            this.oldVoteFile = oldVoteFile;
             this.baselineFileUnresolved =
                     (baselineFile == null) ? null : baselineFile.getUnresolved();
             this.latin = VettingViewer.isLatinScriptLocale(sourceFile);
@@ -966,7 +980,7 @@ public class VettingViewer<T> {
         /**
          * Calculate the Priority Items Summary output for one locale
          *
-         * @param n
+         * @param n index to items in 'context' to be processed
          */
         private void computeOne(int n) {
             if (progressCallback.isStopped()) {
@@ -989,6 +1003,9 @@ public class VettingViewer<T> {
             CLDRFile sourceFile = cldrFactory.make(localeID, true);
             CLDRFile baselineFile = null;
             if (!context.ourChoicesThatRequireOldFile.isEmpty()) {
+                // TODO CLDR-19503: see VettingViewer() constructor vs VettingParameters. Much
+                // duplication.
+                // Here specifically, 'baselineFactory' should be a parameter, not read locally.
                 try {
                     Factory baselineFactory =
                             CLDRConfig.getInstance().getCommonAndSeedAndMainAndAnnotationsFactory();
@@ -1006,7 +1023,11 @@ public class VettingViewer<T> {
                 }
             }
             FileInfo fileInfo = new FileInfo(localeID, level, choices, context.organization);
-            fileInfo.setFiles(sourceFile, baselineFile);
+            CLDRFile oldVoteFile = null;
+            if (oldVoteFactory != null) {
+                oldVoteFile = oldVoteFactory.make(localeID, true);
+            }
+            fileInfo.setFiles(sourceFile, baselineFile, oldVoteFile);
             fileInfo.getFileInfo();
 
             if (context.localeNameToFileInfo != null) {


### PR DESCRIPTION
CLDR-19489

<img width="720" height="310" alt="image_720" src="https://github.com/user-attachments/assets/fc4e280a-0411-46fb-a755-25458916f80b" />

- refactor CheckoutArchive so we can run it on server
- run CheckoutArchive at startup
- track a factory for the last-vote-value files

- Note, does NOT support unhiding the 'New' category. Once you have voted for it, it's no longer New.

Also, while touching the loading code:

- make the abstracts  (The Wikipedia descriptions of languages etc) only load in production. they are often broken in smoketest (there’s another issue [CLDR-18518](https://unicode-org.atlassian.net/browse/CLDR-18518) for that)

Prints the warning: `CLDR_LOAD_ABSTRACTCACHE=false and we aren't on PRODUCTION, skipping abstract cache`

You can set CLDR_LOAD_ABSTRACTCACHE=true to override and load them locally


Also, since this affects server startup:
- Fail-fast when the webdriver can't login.  More improvements will be in CLDR-16859

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true


[CLDR-18518]: https://unicode-org.atlassian.net/browse/CLDR-18518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ