### PR TITLE
CLDR-18314 Add language names for apw, mid, nnp, rej, sjd, sje, sju 

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -45,6 +45,7 @@ annotations.
 			<language type="ang">Old English</language>
 			<language type="ann">Obolo</language>
 			<language type="anp">Angika</language>
+			<language type="apw">Western Apache</language>
 			<language type="ar">Arabic</language>
 			<language type="ar_001">Modern Standard Arabic</language>
 			<language type="arc">Aramaic</language>
@@ -415,6 +416,7 @@ annotations.
 			<language type="mh">Marshallese</language>
 			<language type="mi">Māori</language>
 			<language type="mic">Mi'kmaw</language>
+			<language type="mid">Mandaic</language>
 			<language type="min">Minangkabau</language>
 			<language type="mk">Macedonian</language>
 			<language type="ml">Malayalam</language>
@@ -460,6 +462,7 @@ annotations.
 			<language type="nmg">Kwasio</language>
 			<language type="nn">Norwegian Nynorsk</language>
 			<language type="nnh">Ngiemboon</language>
+			<language type="nnp">Wancho</language>
 			<language type="no">Norwegian</language>
 			<language type="nog">Nogai</language>
 			<language type="non">Old Norse</language>
@@ -522,6 +525,7 @@ annotations.
 			<language type="raj">Rajasthani</language>
 			<language type="rap">Rapanui</language>
 			<language type="rar">Rarotongan</language>
+			<language type="rej">Rejang</language>
 			<language type="rgn">Romagnol</language>
 			<language type="rhg">Rohingya</language>
 			<language type="rif">Riffian</language>
@@ -573,6 +577,9 @@ annotations.
 			<language type="shu">Chadian Arabic</language>
 			<language type="si">Sinhala</language>
 			<language type="sid">Sidamo</language>
+			<language type="sjd">Kildin Sami</language>
+			<language type="sje">Pite Sami</language>
+			<language type="sju">Ume Sami</language>
 			<language type="sk">Slovak</language>
 			<language type="sl">Slovenian</language>
 			<language type="slh">Southern Lushootseed</language>

--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -64,7 +64,7 @@
 			</variable>
 			<!-- The following have not yet made it to Basic -->
 			<variable id='$languageNonTcLtBasic' type='choice'>
-				 aa ab ady agq ak an ann apc arn ary asa
+				 aa ab ady agq ak an ann apc apw arn ary asa
 				 ba bal bas bem bew bez bgn blt bm bo bqi brh bss byn bua
 				 cad cch ccp ce cgg cho cic ckb co cop cu
 				 dav dje dua dv dyo dz
@@ -76,13 +76,13 @@
 				 jbo jgo jmc
 				 kaa kab kaj kam kbd kcg kde kek ken khq ki kkj kl kln kpe ksb ksf ksh kw
 				 la lag lg lkt lld ln lrc ltg lu luo luy lzz
-				 mas mdf mer mfe mhn mg mgh mgo mic moh mrh mua mus mww myv mzn
-				 nan naq nb nd nmg nnh nr nso nus nv ny nyn om
+				 mas mdf mer mfe mhn mg mgh mgo mic mid moh mrh mua mus mww myv mzn
+				 nan naq nb nd nmg nnh nnp nr nso nus nv ny nyn om
 				 oka os osa
 				 pap pi pis pms
 				 quc
-				 rhg rif rn rof rw rwk
-				 saq sbp scn sdh se seh ses sg sgs shi shn sid skr sma smj smn sms sn ss ssy st sus suz
+				 rej rhg rif rn rof rw rwk
+				 saq sbp scn sdh se seh ses sg sgs shi shn sid sjd sje sju skr sma smj smn sms sn ss ssy st sus suz
 				 teo tig tn tok tpi trv trw ts twq tyv tzm
 				 vai ve vo vun
 				 wa wae wal wbp


### PR DESCRIPTION
CLDR-18314

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Adding 7 language names to en.xml that are needed for keyboard name localization. These languages have keyboards in Apple platforms but their names were missing from CLDR, causing them to appear unlocalized.

Languages added: Western Apache (apw), Mandaic (mid), Wancho (nnp), Rejang (rej), Kildin Sami (sjd), Pite Sami (sje), Ume Sami (sju).

Also added these codes to attributeValueValidity.xml so they pass CLDR validation.

Chickasaw (cic) and Osage (osa) were already present. Lushootseed (lut) is deferred pending TC discussion since its locale doesn't exist in CLDR yet.

Per TC decision 2025-05-06: approved at comprehensive coverage level.

ALLOW_MANY_COMMITS=true
