### PR TITLE
CLDR-19035 Fix generation of example dependencies

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -85,6 +85,7 @@ import org.unicode.cldr.util.PatternPlaceholders.PlaceholderInfo;
 import org.unicode.cldr.util.PluralSamples;
 import org.unicode.cldr.util.Rational;
 import org.unicode.cldr.util.Rational.FormatStyle;
+import org.unicode.cldr.util.RecordingCLDRFile;
 import org.unicode.cldr.util.ScriptToExemplars;
 import org.unicode.cldr.util.SimpleUnicodeSetFormatter;
 import org.unicode.cldr.util.SupplementalCalendarData;
@@ -444,11 +445,14 @@ public class ExampleGenerator {
                 supplementalDataInfo.getGrammarInfo(localeId); // getGrammarInfo can return null
         this.englishFile = englishFile;
         this.typeIsEnglish = (resolvedCldrFile == englishFile);
-        boolean locIsFake =
+        boolean locIsExceptional =
                 LocaleNames.XX_TEST.equals(localeId) || LocaleNames.MUL.equals(localeId);
+        // GenerateExampleDependencies needs the ICUServiceBuilder instance to use the
+        // RecordingCLDRFile if one is provided, rather than a pre-existing ordinary CLDRFile.
+        boolean fileIsRecording = cldrFile.getClass() == RecordingCLDRFile.class;
         this.icuServiceBuilder =
-                locIsFake
-                        ? new ICUServiceBuilder(resolvedCldrFile, locIsFake)
+                (locIsExceptional || fileIsRecording)
+                        ? new ICUServiceBuilder(resolvedCldrFile, locIsExceptional)
                         : ICUServiceBuilder.forLocale(CLDRLocale.getInstance(localeId));
 
         bestMinimalPairSamples = new BestMinimalPairSamples(cldrFile, icuServiceBuilder, false);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateExampleDependencies.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateExampleDependencies.java
@@ -134,7 +134,7 @@ public class GenerateExampleDependencies {
                 "If it looks OK, you can move it to the proper location, replacing the old version.");
     }
 
-    private void addDependenciesForLocale(Multimap<String, String> dependencies, String localeId) {
+    public void addDependenciesForLocale(Multimap<String, String> dependencies, String localeId) {
         RecordingCLDRFile cldrFile = makeRecordingCldrFile(localeId);
         cldrFile.disableCaching();
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -51,23 +51,23 @@ public class ICUServiceBuilder {
      * @param cldrFile the CLDRFile
      */
     private ICUServiceBuilder(CLDRFile cldrFile) {
-        this(cldrFile, false /* locIsFake */);
+        this(cldrFile, false /* locIsExceptional */);
     }
 
     /**
-     * This constructor is meant to be called only by the private constructor (with locIsFake =
-     * false) and by unit tests with fictional locale ID such as "xx" or "mul" (with locIsFake =
-     * true) for which ICUServiceBuilder.forLocale won't work
+     * This constructor is meant to be called only by the private constructor (with locIsExceptional
+     * = false) and by unit tests with exceptional locale ID such as "xx" or "mul" (with
+     * locIsExceptional = true) for which ICUServiceBuilder.forLocale won't work
      *
      * @param cldrFile the CLDRFile
-     * @param locIsFake true if cldrFile has a fictional locale ID (can't call forLocale)
+     * @param locIsExceptional true if cldrFile has an exceptional locale ID (can't call forLocale)
      */
-    public ICUServiceBuilder(CLDRFile cldrFile, boolean locIsFake) {
+    public ICUServiceBuilder(CLDRFile cldrFile, boolean locIsExceptional) {
         if (!cldrFile.isResolved()) {
             throw new IllegalArgumentException("CLDRFile must be resolved");
         }
         this.cldrFile = cldrFile;
-        if (locIsFake) {
+        if (locIsExceptional) {
             this.collationFile = null;
         } else {
             this.collationFile =

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRPaths.java
@@ -1,10 +1,14 @@
 package org.unicode.cldr.util;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
 import java.io.File;
+import java.util.regex.Matcher;
 import org.junit.jupiter.api.Test;
+import org.unicode.cldr.tool.GenerateExampleDependencies;
 
 public class TestCLDRPaths {
     public static String HAS_CLDR_ARCHIVE = "HAS_CLDR_ARCHIVE";
@@ -49,5 +53,32 @@ public class TestCLDRPaths {
                 SupplementalDataInfo.getInstance(
                         CLDRPaths.LAST_RELEASE_DIRECTORY + "common/supplemental/");
         assertNotNull(SDI_LAST);
+    }
+
+    @Test
+    void testGenerateExampleDependencies() {
+        // There was a bug involving GenerateExampleDependencies. A test case involved these two
+        // paths. When working correctly, dependencies should include a mapping from pathA to pathB,
+        // in multiple locales including "aa". (This means that an example for pathB may depend on
+        // the value for pathA.) (The bug was fixed by ensuring that the ExampleGenerator used by
+        // GenerateExampleDependencies creates its ICUServiceBuilder instance using the provided
+        // RecordingCLDRFile, not an ordinary CLDRFile.) It is possible that in the future, this
+        // dependency might no longer be required, and then this test should be revised accordingly
+        // to test different paths and/or a different locale.
+        final String pathA =
+                "//ldml/dates/calendars/calendar[@type=\"([^\"]*+)\"]/eras/eraAbbr/era[@type=\"([^\"]*+)\"]";
+        final String pathB =
+                "//ldml/dates/calendars/calendar[@type=\"([^\"]*+)\"]/dateFormats/dateFormatLength[@type=\"([^\"]*+)\"]/dateFormat[@type=\"([^\"]*+)\"]/pattern[@type=\"([^\"]*+)\"]";
+        final String localeId = "aa";
+
+        final Multimap<String, String> dependencies = TreeMultimap.create();
+        final Matcher fileFilter = PatternCache.get("^" + localeId + "$").matcher("");
+        new GenerateExampleDependencies(fileFilter, false /* not verbose */)
+                .addDependenciesForLocale(dependencies, localeId);
+        assertFalse(dependencies.isEmpty(), "Dependencies should not be empty");
+        assertTrue(dependencies.containsKey(pathA), "Dependencies should contain " + pathA);
+        assertTrue(
+                dependencies.get(pathA).contains(pathB),
+                "Dependencies for " + pathA + " should contain " + pathB);
     }
 }


### PR DESCRIPTION
-Ensure that the ExampleGenerator used by GenerateExampleDependencies creates its ICUServiceBuilder instance using the provided RecordingCLDRFile, not an ordinary CLDRFile

-Add a test TestCLDRPaths.testGenerateExampleDependencies that would fail without the fix in ExampleGenerator

-Rename locIsFake to locIsExceptional, to avoid implying that locales like mul are fake

-Comments

CLDR-19035

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
