### PR TITLE
CLDR-19335 build: no double build on pushes to head fork

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,11 @@ env:
 
 on:
   push:
+    # only build on main or maint branches
+    # otherwise, pull requests on the head fork get built twice.
+    branches:
+      - main
+      - maint/*
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
CLDR-19335

Don't double-build PRs pushed to the head fork.
Confirm that this PR builds again when merged to main.

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

confirmed on my fork that it builds against main and maint/maint-000 but not feature branches


<img width="835" height="163" alt="image" src="https://github.com/user-attachments/assets/c7b37a77-0082-4874-bade-cd8520d4ac53" />
