### PR TITLE
CLDR-19513 Add Tajik (tg) plural rules

### DIFF
--- a/common/main/tg.xml
+++ b/common/main/tg.xml
@@ -5552,7 +5552,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="other" draft="contributed">{0} рӯз</pluralMinimalPairs>
+			<pluralMinimalPairs count="one">{0} бача омад.</pluralMinimalPairs>
+			<pluralMinimalPairs count="other">{0} бача омаданд.</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">{0}-умро рост кунед.</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>

--- a/common/supplemental/ordinals.xml
+++ b/common/supplemental/ordinals.xml
@@ -13,7 +13,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
         <!-- 1: other -->
 
-        <pluralRules locales="am an ar ast bs ce cs cv da de dsb el et eu fa fi fy gl gsw he hr hsb ia id ie in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te th tpi tr ur uz yue zh zu">
+        <pluralRules locales="am an ar ast bs ce cs cv da de dsb el et eu fa fi fy gl gsw he hr hsb ia id ie in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te tg th tpi tr ur uz yue zh zu">
             <pluralRule count="other"> @integer 0~15, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
 

--- a/common/supplemental/pluralRanges.xml
+++ b/common/supplemental/pluralRanges.xml
@@ -50,7 +50,7 @@
 			<pluralRange start="other" end="one"   result="other"/>
 			<pluralRange start="other" end="other" result="other"/>
 		</pluralRanges>
-		<pluralRanges locales="ak fa or sd">
+		<pluralRanges locales="ak fa or sd tg">
 			<pluralRange start="one"   end="one"   result="other"/>
 			<pluralRange start="one"   end="other" result="other"/>
 			<pluralRange start="other" end="one"   result="one"/>

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -19,7 +19,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
         <!-- 2: one,other -->
 
-        <pluralRules locales="am as bn doi fa gu hi kn kok kok_Latn pcm vi zu">
+        <pluralRules locales="am as bn doi fa gu hi kn kok kok_Latn pcm tg vi zu">
             <pluralRule count="one">i = 0 or n = 1 @integer 0, 1 @decimal 0.0~1.0, 0.00~0.04</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 1.1~2.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>


### PR DESCRIPTION
CLDR-19513 

## Summary

Tajik (`tg`) has locale data in CLDR (`common/main/tg.xml`) but is completely missing from plural rules (`plurals.xml`, `ordinals.xml`, `pluralRanges.xml`).

This means **all** i18n libraries that derive plural rules from CLDR (ICU, go-i18n, JS Intl, Python Babel, PHP intl, FormatJS, etc.) cannot provide correct pluralization for Tajik content.

Tajik is the official language of Tajikistan (~10 million speakers) and is linguistically a variety of Persian written in Cyrillic script. Its plural system is identical to Persian (`fa`).

## Changes

- **`plurals.xml`**: added `tg` to the `am as bn doi fa gu hi kn kok kok_Latn pcm vi zu` group (`one: i = 0 or n = 1`, `other`)
- **`ordinals.xml`**: added `tg` to the "other only" group (no ordinal distinction, same as `fa`)
- **`pluralRanges.xml`**: added `tg` to the `ak fa or sd` group (same range behavior as `fa`)
- **`main/tg.xml`**: added `pluralMinimalPairs` for `count="one"` and updated `count="other"`

## Linguistic evidence

Cardinal plural rules — identical to Persian (`fa`):
- **one**: `i = 0 or n = 1`
- **other**: everything else

Minimal pairs:
- one: «1 бача омад» (1 boy came — singular verb)
- other: «2 бача омаданд» (2 boys came — plural verb)

Sources:
- Gettext l10n-guide: `nplurals=2; plural=(n != 1)`
- Tajik and Persian share mutual intelligibility (~90%) and identical plural morphology

## References

- JIRA: https://unicode-org.atlassian.net/browse/CLDR-19513
- Downstream: https://github.com/nicksnyder/go-i18n/issues/389