### PR TITLE
CLDR-19515 fix ExtraPaths to handle bootstrap condition with parseLenient

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -435,21 +435,16 @@ public class ExtraPaths {
 
     public static void addLocaleDependent(
             Set<String> toAddTo, Iterable<String> file, String localeID) {
+        if (localeID == null)
+            return; // no locale ID is set, so do not attempt any locale specific processing.
         SupplementalDataInfo.PluralInfo plurals =
                 supplementalData.getPlurals(SupplementalDataInfo.PluralType.cardinal, localeID);
         SupplementalDataInfo.PluralInfo ordinals =
                 supplementalData.getPlurals(SupplementalDataInfo.PluralType.ordinal, localeID);
-        if (DEBUG && (plurals == null || ordinals == null)) {
-            System.err.println(
-                    "No "
-                            + SupplementalDataInfo.PluralType.cardinal
-                            + "  plurals for "
-                            + localeID
-                            + " in "
-                            + supplementalData.getDirectory().getAbsolutePath());
-        }
 
+        if (ordinals == null) return;
         addDayOfMonthPaths(toAddTo, ordinals);
+        if (plurals == null) return;
         addMinimalPairs(toAddTo, plurals, ordinals);
         Set<SupplementalDataInfo.PluralInfo.Count> pluralCounts =
                 Count.LOCALES_USING_OTHER_ONLY_HACK.contains(localeID)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFileMore.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFileMore.java
@@ -11,6 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -172,11 +175,58 @@ public class TestCLDRFileMore {
     final File rootfile = new File(testcommonmain, "root.xml");
     final File[] dirs = {testcommonmain};
 
-    Factory getTestDataFactory() {
+    public Factory getTestDataFactory() {
         // Note: Uses the special test data in
         // tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/data/common/main/hy.xml
         Factory myFactory = SimpleFactory.make(dirs, ".*");
         return myFactory;
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"root", "hy", "hsb"})
+    public void testMakeFileLenient(String localeID) throws FileNotFoundException, IOException {
+        // Try loading from common data
+        {
+            final Factory myFactory = CLDRConfig.getInstance().getCldrFactory();
+            final CLDRFile myFile = myFactory.make(localeID, true);
+            Set<String> rawExtraPaths = myFile.getRawExtraPaths();
+            assertNotNull(rawExtraPaths);
+            assertFalse(rawExtraPaths.isEmpty());
+        }
+        // Now, try a makeFileLenient load of common data
+        {
+            final String fileName = localeID + ".xml";
+            try (FileInputStream fis =
+                    new FileInputStream(new File(CLDRPaths.MAIN_DIRECTORY, fileName))) {
+                CLDRFile fileLenient =
+                        SimpleFactory.makeFileLenient(fileName, fis, DraftStatus.unconfirmed);
+                assertNotNull(fileLenient);
+                Set<String> rawExtraPaths = fileLenient.getRawExtraPaths();
+                assertNotNull(rawExtraPaths);
+                assertFalse(rawExtraPaths.isEmpty());
+            }
+        }
+
+        // Next, try a regular load
+        {
+            final Factory myFactory = getTestDataFactory();
+            final CLDRFile myFile = myFactory.make(localeID, true);
+            Set<String> rawExtraPaths = myFile.getRawExtraPaths();
+            assertNotNull(rawExtraPaths);
+            assertFalse(rawExtraPaths.isEmpty());
+        }
+        // Now, try a makeFileLenient load
+        {
+            final String fileName = localeID + ".xml";
+            try (FileInputStream fis = new FileInputStream(new File(testcommonmain, fileName))) {
+                CLDRFile fileLenient =
+                        SimpleFactory.makeFileLenient(fileName, fis, DraftStatus.unconfirmed);
+                assertNotNull(fileLenient);
+                Set<String> rawExtraPaths = fileLenient.getRawExtraPaths();
+                assertNotNull(rawExtraPaths);
+                assertFalse(rawExtraPaths.isEmpty());
+            }
+        }
     }
 
     @Test

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
@@ -24,7 +24,7 @@ public class TestExtraPaths {
     }
 
     @ParameterizedTest(name = "{index} locale={0}")
-    @ValueSource(strings = {"de", "ru"})
+    @ValueSource(strings = {"de", "ru", "hsb"})
     public void testKeys(final String localeId) {
         final Set<String> paths = getExtraPathsFor(localeId);
         final String keys[] = {

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/data/common/main/hsb.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/data/common/main/hsb.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ ____  _____    _    ____    __  __ _____
+|  _ \| ____|  / \  |  _ \  |  \/  | ____|
+| |_) |  _|   / _ \ | | | | | |\/| |  _|
+|  _ <| |___ / ___ \| |_| | | |  | | |___
+|_| \_\_____/_/   \_\____/  |_|  |_|_____|
+
+
+This is not CLDR Locale Data.
+
+This is test data for TestCLDRFileMore.java
+
+-->
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<ldml>
+    <identity>
+        <version number="$Revision$" />
+        <language type="hsb" />
+    </identity>
+</ldml>
+
+
+<!--
+
+ ____  _____    _    ____    __  __ _____
+|  _ \| ____|  / \  |  _ \  |  \/  | ____|
+| |_) |  _|   / _ \ | | | | | |\/| |  _|
+|  _ <| |___ / ___ \| |_| | | |  | | |___
+|_| \_\_____/_/   \_\____/  |_|  |_|_____|
+
+
+This is not CLDR Locale Data.
+
+This is test data for TestCLDRFileMore.java
+
+-->


### PR DESCRIPTION
- ExtraPaths.addLocaleDependent should just return if no locale ID is set yet
- this path is via SimpleFactory.makeFileLenient() and uses CLDRFile.getLocaleIDFromIdentity() - this function was apparently not in any unit tests.
- Tested the enclosed ppath, it now succeeds
- ALL bulk upload would have been broken.

```
Checking upload...
Locale:hsb - Upper Sorbian
Please review these 0 entries.
…
```

CLDR-19515

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
