### PR TITLE
CLDR-19526 fix peekXPath

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/XPathTable.java
@@ -402,7 +402,7 @@ public class XPathTable {
         if (nid != null) {
             return nid.intValue();
         } else {
-            return addXpath(xpath, false, null).intValue();
+            return XPathTable.NO_XPATH;
         }
     }
 
@@ -418,21 +418,6 @@ public class XPathTable {
             return nid.intValue();
         } else {
             return addXpath(xpath, true, conn).intValue();
-        }
-    }
-
-    /**
-     * Look up xpath id by value. Return -1 if not found
-     *
-     * @param xpath
-     * @return id, or -1 if not found
-     */
-    public final int peekByXpath(String xpath, Connection conn) {
-        Integer nid = stringToId.get(xpath);
-        if (nid != null) {
-            return nid.intValue();
-        } else {
-            return addXpath(xpath, false, conn).intValue();
         }
     }
 

--- a/tools/cldr-code/.settings/org.eclipse.jdt.core.prefs
+++ b/tools/cldr-code/.settings/org.eclipse.jdt.core.prefs
@@ -12,6 +12,7 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.processAnnotations=disabled
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false


### PR DESCRIPTION
peekXPath is supposed to return -1 if an xpath is not found

CLDR-19526

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
