### PR TITLE
CLDR-19434 Make cursor visible after using insert menu

### DIFF
--- a/tools/cldr-apps/js/src/views/AddValue.vue
+++ b/tools/cldr-apps/js/src/views/AddValue.vue
@@ -19,6 +19,7 @@
     <div>
       <a-config-provider :direction="dir">
         <span class="show-as-text">
+          <!-- https://www.antdv.com/components/input -->
           <a-input
             v-model:value="newValue"
             placeholder="Add a translation"
@@ -142,6 +143,7 @@ import * as cldrAddValue from "../esm/cldrAddValue.mjs";
 import * as cldrChar from "../esm/cldrChar.mjs";
 import * as cldrConstants from "../esm/cldrConstants.mjs";
 import * as cldrLoad from "../esm/cldrLoad.mjs";
+import * as cldrNotify from "../esm/cldrNotify.mjs";
 import * as cldrStatus from "../esm/cldrStatus.mjs";
 
 const DEBUG = false;
@@ -204,18 +206,15 @@ function showModal(event) {
   setValue("");
   formIsVisible.value = true;
   cldrAddValue.setFormIsVisible(true, xpstrid.value);
+  if (DEBUG) {
+    console.log("AddValue.showModal: calling nextTick(focusInput)");
+  }
   nextTick(focusInput);
 }
 
 function setValue(s) {
   newValue.value = s;
   handleTextChange();
-}
-
-function focusInput() {
-  if (inputToFocus.value) {
-    inputToFocus.value.focus();
-  }
 }
 
 function onEnglish() {
@@ -294,11 +293,13 @@ function handleTagsCheckboxChange() {
 }
 
 function openInsertMenu(event) {
-  console.log(
-    "openInsertMenu: insertMenuIsVisible.value = " +
-      insertMenuIsVisible.value +
-      "; setting to true"
-  );
+  if (DEBUG) {
+    console.log(
+      "openInsertMenu: insertMenuIsVisible.value = " +
+        insertMenuIsVisible.value +
+        "; setting to true"
+    );
+  }
   insertMenuIsVisible.value = true;
   componentKeyInsert.value++;
 }
@@ -307,23 +308,23 @@ function insertMenuOnChange() {
   if (!chosenChar.value) {
     if (DEBUG) {
       console.log(
-        "AddValue.insertMenuOnChange: doing nothing since chosenChar.value = " +
-          chosenChar.value
+        "AddValue.insertMenuOnChange: doing nothing since no chosenChar.value"
       );
     }
     return;
   }
-  // Note: inputToFocus.value.input.selectionStart works for getting the offset (in
-  // characters) of the insertion point (cursor) in the string the user is editing.
-  // This was determined by experimentation; it's not clear whether it is a documented
-  // feature of Ant Vue components.
-  const insertionPoint = inputToFocus.value.input.selectionStart;
+  const input = getInputElement();
+  if (!input) {
+    return;
+  }
   const textBefore = newValue.value;
   const textAfter =
-    textBefore.slice(0, insertionPoint) +
+    textBefore.slice(0, input.selectionStart) +
     chosenChar.value +
-    textBefore.slice(insertionPoint);
+    textBefore.slice(input.selectionEnd);
+  input.setRangeText(chosenChar.value);
   setValue(textAfter);
+  const insertionPoint = input.selectionStart + chosenChar.value.length;
   if (DEBUG) {
     console.log(
       "AddValue.insertMenuOnChange: insertionPoint = " +
@@ -334,6 +335,59 @@ function insertMenuOnChange() {
         chosenChar.value
     );
   }
+  nextTick(focusInputAndSetRange(insertionPoint));
+}
+
+function focusInput() {
+  const input = getInputElement();
+  if (input) {
+    input.focus();
+    if (DEBUG) {
+      console.log("AddValue.focusInput: called input.focus");
+    }
+  }
+}
+
+function focusInputAndSetRange(insertionPoint) {
+  const input = getInputElement();
+  if (input) {
+    input.focus();
+    if (DEBUG) {
+      console.log(
+        "AddValue.focusInputAndSetRange: before setSelectionRange, input.selectionStart = " +
+          input.selectionStart +
+          "; input.selectionEnd = " +
+          input.selectionEnd +
+          "; insertionPoint = " +
+          insertionPoint
+      );
+    }
+    input.setSelectionRange(insertionPoint, insertionPoint);
+    if (DEBUG) {
+      console.log(
+        "AddValue.focusInputAndSetRange: after setSelectionRange, input.selectionStart = " +
+          input.selectionStart +
+          "; input.selectionEnd = " +
+          input.selectionEnd +
+          "; insertionPoint = " +
+          insertionPoint
+      );
+    }
+  }
+}
+
+function getInputElement() {
+  // inputToFocus.value.input needs to support standard properties, methods, and
+  // events for HTMLInputElement. Since this support is not very clearly documented
+  // at https://www.antdv.com/components/input we confirm and encapsulate it here.
+  const input = inputToFocus.value?.input;
+  const errMessage = "Input implementation error";
+  if (!input) {
+    cldrNotify.error(errMessage, "Element not found");
+  } else if (!(input instanceof HTMLInputElement)) {
+    cldrNotify.error(errMessage, "Element is not an input element");
+  }
+  return input;
 }
 
 defineExpose({


### PR DESCRIPTION
-Call both setRangeText and setSelectionRange to ensure insertion point is updated correctly

-If a range is highlighted before choosing from the menu, replace that range

-Encapsulate/confirm Ant Vue input element assumption in new method getInputElement

CLDR-19434

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
