### PR TITLE
CLDR-19353 Revise display of tags (chits)

### DIFF
--- a/docs/site/translation/getting-started/guide.md
+++ b/docs/site/translation/getting-started/guide.md
@@ -167,6 +167,8 @@ That lets them insert a character at the current insertion point in the text.
 Hovering over the items in that menu shows details about their usage, as you see in the image
 — so it can also be used to decode the meaning of the abbreviations used in the chits.
 
+Some easily confusible characters (" “ ” ″ ʼ ‘ ’ ′) are not included in the insert-character menu, but are displayed with chits to enable differentiating them by hovering.
+
 NOTE: For alphabetic information (such as exemplar characters), an older mechanism is still in place.
 We hope to update it during the submission phase. More details on how to [**input** these from the keyboard][],
 and for a key to **all** the escapes, see [Key to Escapes][] for a list with some of the escape characters.

--- a/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
@@ -14,11 +14,6 @@ import AddValue from "../views/AddValue.vue";
 import ValueTags from "../views/ValueTags.vue";
 
 /**
- * Should ASCII space (U+0020) be displayed as a tag?
- */
-const SPACES_HAVE_TAGS = false;
-
-/**
  * Is the "Add Value" form currently visible?
  */
 let formIsVisible = false;
@@ -106,7 +101,7 @@ function getTrFromXpathStringId(xpstrid) {
  * @param {Array} tagArray - the given tag array
  * @returns the text string
  *
- * Example: ["abc", " ", "xyz"] becomes "abc xyz".
+ * Example: ["abc", "–", "xyz"] becomes "abc–xyz".
  */
 function convertTagsToText(tagArray) {
   return tagArray.join("");
@@ -118,15 +113,16 @@ function convertTagsToText(tagArray) {
  * @param {String} text - the given text string
  * @returns the tag array
  *
- * Each special character becomes a tag. Each sequence of other characters is combined into a tag.
- * Example: "abc xyz" becomes three tags: ["abc", " ", "xyz"].
+ * Each special character becomes a tag. Each sequence of other characters is combined into a tag (although
+ * such a sequence is displayed as ordinary characters, not as a tag).
+ * Example: "abc–xyz" becomes three tags: ["abc", "–", "xyz"]. (Here "–" is U+2013 EN DASH.)
  */
 function convertTextToTags(text) {
   const tags = [];
   let combined = "";
   const charArray = cldrChar.split(text);
   for (let c of charArray) {
-    if (cldrChar.isSpecial(c)) {
+    if (cldrChar.shouldDisplayAsTag(c)) {
       if (combined.length != 0) {
         tags.push(combined);
         combined = "";
@@ -152,15 +148,6 @@ function addTagsReadyOnly(containerEl, value) {
   }
 }
 
-function shouldDisplayAsTag(tag) {
-  const c = cldrChar.firstChar(tag);
-  if (SPACES_HAVE_TAGS) {
-    return cldrChar.isSpecial(c);
-  } else {
-    return c !== " " && cldrChar.isSpecial(c);
-  }
-}
-
 function textForTag(tag) {
   const c = cldrChar.firstChar(tag);
   const shortName = cldrEscaper.getShortName(c);
@@ -176,12 +163,16 @@ function tagTooltipPlusClick(tag) {
 
 function tagTooltip(tag) {
   const c = cldrChar.firstChar(tag);
-  const info = cldrEscaper.getCharInfo(c);
   const codePoint = cldrChar.firstCodePoint(tag);
   const usv = cldrChar.uPlus(codePoint);
-  return (
-    info.name + " = " + info.shortName + " " + usv + ": " + info.description
-  );
+  const info = cldrEscaper.getCharInfo(c);
+  if (info) {
+    return (
+      info.name + " = " + info.shortName + " " + usv + ": " + info.description
+    );
+  } else {
+    return cldrChar.name(codePoint) + " = " + usv;
+  }
 }
 
 export {
@@ -194,7 +185,6 @@ export {
   isFormVisible,
   sendRequest,
   setFormIsVisible,
-  shouldDisplayAsTag,
   tagTooltip,
   tagTooltipPlusClick,
   textForTag,

--- a/tools/cldr-apps/js/src/esm/cldrChar.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrChar.mjs
@@ -6,6 +6,32 @@ import { unicodeName } from "unicode-name";
 
 import * as cldrEscaper from "./cldrEscaper.mjs";
 
+/*
+  For clarity, these characters are displayed as tags, but they are not included
+  in the Insert menu. They are not invisibles, so the characters themselves, rather
+  than their names, are displayed in the tags. Users can see their names by hovering.
+
+  ◦	" U+0022 QUOTATION MARK
+  ◦	“ U+201C LEFT DOUBLE QUOTATION MARK
+  ◦	” U+201D RIGHT DOUBLE QUOTATION MARK
+  ◦	″ U+2033 DOUBLE PRIME
+  ◦	ʼ U+02BC MODIFIER LETTER APOSTROPHE
+  ◦	‘ U+2018 LEFT SINGLE QUOTATION MARK
+  ◦	’ U+2019 RIGHT SINGLE QUOTATION MARK
+  ◦	′ U+2032 PRIME
+*/
+const tagWithNoName = [
+  0x0022, 0x201c, 0x201d, 0x2033, 0x02bc, 0x2018, 0x2019, 0x2032,
+];
+
+function shouldDisplayAsTag(s) {
+  const c = firstChar(s);
+  if (c == " ") {
+    return false;
+  }
+  return isSpecial(c) || tagWithNoName.indexOf(firstCodePoint(c)) >= 0;
+}
+
 /**
  * Get the first code point in the given string
  *
@@ -114,6 +140,7 @@ export {
   isSpecial,
   isWhiteSpace,
   name,
+  shouldDisplayAsTag,
   split,
   uPlus,
 };

--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -8,6 +8,7 @@ const staticInfo = {
     "\u0020": { name: "SP" },
     "\u200e": { name: "LRM" },
     "\u200f": { name: "RLM" },
+    "–": { name: "EN DASH" } /* Needed for tests */,
   },
   namesForMenu: ["LRM", "RLM", "SP"],
 }; // start from static info - useful for tests

--- a/tools/cldr-apps/js/src/esm/cldrLocales.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLocales.mjs
@@ -101,7 +101,13 @@ function parseHash(pieces) {
   }
 }
 
-function isValid(loc) {
+/**
+ *
+ * @param {string} loc the locale ID
+ * @param {string} test optional second argument, set to "quiet" for testing to suppress logging
+ * @returns true if loc is valid, else false
+ */
+function isValid(loc, test) {
   // It seems safest to require the canonical id here. If canonicalizeLocaleId were
   // called here, a caller of isValid might go on to use a non-canonical id in other contexts,
   // maybe leading to errors such as treating the same locale as two different locales.
@@ -113,7 +119,9 @@ function isValid(loc) {
   if (typeof loc == "string" && map?.locmap?.locales[loc]) {
     return true;
   }
-  notifyUnusableLocale(map, loc);
+  if (test !== "quiet") {
+    notifyUnusableLocale(map, loc);
+  }
   return false;
 }
 

--- a/tools/cldr-apps/js/src/views/AddValue.vue
+++ b/tools/cldr-apps/js/src/views/AddValue.vue
@@ -272,7 +272,7 @@ function showHiddenIfSpecial() {
   if (!userTurnedOffTags.value && !useTags.value) {
     const charArray = cldrChar.split(newValue.value);
     for (let c of charArray) {
-      if (c != " " && cldrChar.isSpecial(c)) {
+      if (cldrChar.shouldDisplayAsTag(c)) {
         useTags.value = true;
         handleTagsCheckboxChange();
         break;

--- a/tools/cldr-apps/js/src/views/AddValueTags.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTags.vue
@@ -104,7 +104,7 @@ function handleChooseCharacter() {
     otherwise be similar */
   margin: 1px;
   padding: 1px;
-  border: 2px solid black; /* override ant-tag 1px solid #d9d9d9 */
+  border: 2px solid midnightblue; /* override ant-tag 1px solid #d9d9d9 */
   border-radius: 3px; /* override ant-tag 2px */
 }
 

--- a/tools/cldr-apps/js/src/views/AddValueTags.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTags.vue
@@ -59,7 +59,7 @@ function updateParent() {
 }
 
 function shouldDisplayAsTag(tag) {
-  return cldrAddValue.shouldDisplayAsTag(tag);
+  return cldrChar.shouldDisplayAsTag(tag);
 }
 
 function displayTag(tag) {
@@ -72,7 +72,7 @@ function tagTooltip(tag) {
 
 function handleClickTag(event, index) {
   const c = cldrChar.firstChar(tagArray.value[index]);
-  if (!cldrChar.isSpecial(c)) {
+  if (!cldrChar.shouldDisplayAsTag(c)) {
     return;
   }
   chosenChar.value = c;
@@ -100,8 +100,12 @@ function handleChooseCharacter() {
 
 <style scoped>
 .regular-tag {
+  /* Compare regular-tag in ValueTags.vue, which has different margin/padding but should
+    otherwise be similar */
   margin: 1px;
   padding: 1px;
+  border: 2px solid black; /* override ant-tag 1px solid #d9d9d9 */
+  border-radius: 3px; /* override ant-tag 2px */
 }
 
 /* Prevent the text to the right of the menu moving when the menu is opened */

--- a/tools/cldr-apps/js/src/views/AddValueTagsEdit.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTagsEdit.vue
@@ -169,7 +169,7 @@ const chosenIndex = ref(undefined);
 
 function handleClickTag(event, index) {
   const c = cldrChar.firstChar(tagArray.value[index]);
-  if (!cldrChar.isSpecial(c)) {
+  if (!cldrChar.shouldDisplayAsTag(c)) {
     return;
   }
   chosenIndex.value = index;

--- a/tools/cldr-apps/js/src/views/ValueTags.vue
+++ b/tools/cldr-apps/js/src/views/ValueTags.vue
@@ -30,6 +30,7 @@
 import { ref } from "vue";
 
 import * as cldrAddValue from "../esm/cldrAddValue.mjs";
+import * as cldrChar from "../esm/cldrChar.mjs";
 
 const tagArray = ref([]);
 
@@ -38,7 +39,7 @@ function setValue(s) {
 }
 
 function shouldDisplayAsTag(tag) {
-  return cldrAddValue.shouldDisplayAsTag(tag);
+  return cldrChar.shouldDisplayAsTag(tag);
 }
 
 function displayTag(tag) {
@@ -56,8 +57,12 @@ defineExpose({
 
 <style scoped>
 .regular-tag {
+  /* Compare regular-tag in AddValueTags.vue, which has different margin/padding but should
+    otherwise be similar */
   margin: 0 1px; /* top right (bottom left) */
   padding: 0 1px;
+  border: 2px solid black; /* override ant-tag 1px solid #d9d9d9 */
+  border-radius: 3px; /* override ant-tag 2px */
 }
 
 .tag-area {

--- a/tools/cldr-apps/js/src/views/ValueTags.vue
+++ b/tools/cldr-apps/js/src/views/ValueTags.vue
@@ -61,7 +61,7 @@ defineExpose({
     otherwise be similar */
   margin: 0 1px; /* top right (bottom left) */
   padding: 0 1px;
-  border: 2px solid black; /* override ant-tag 1px solid #d9d9d9 */
+  border: 2px solid midnightblue; /* override ant-tag 1px solid #d9d9d9 */
   border-radius: 3px; /* override ant-tag 2px */
 }
 

--- a/tools/cldr-apps/js/test/TestCldrAddValue.mjs
+++ b/tools/cldr-apps/js/test/TestCldrAddValue.mjs
@@ -9,8 +9,8 @@ export const TestCldrAddValue = "ok";
 const assert = chai.assert;
 
 describe("cldrAddValue.convertTagsToText", function () {
-  const tags = ["abc", " ", "xyz"];
-  const textExpected = "abc xyz";
+  const tags = ["abc", "–", "xyz"];
+  const textExpected = "abc–xyz";
   const text = cldrAddValue.convertTagsToText(tags);
 
   it("should convert tags to text", function () {
@@ -19,11 +19,22 @@ describe("cldrAddValue.convertTagsToText", function () {
 });
 
 describe("cldrAddValue.convertTextToTags", function () {
-  const text = "abc xyz";
-  const tagsExpected = ["abc", " ", "xyz"];
+  // Here "–" is U+2013 EN DASH, which is special per cldrEscaper.
+  const text = "abc–xyz";
+  const tagsExpected = ["abc", "–", "xyz"];
   const tags = cldrAddValue.convertTextToTags(text);
 
   it("should convert text to tags", function () {
     assert.deepEqual(tags, tagsExpected, "tags are equal");
+  });
+
+  // Here ″ is U+2033 DOUBLE PRIME, for which cldrChar.shouldDisplayAsTag returns true
+  // although it is not special per cldrEscaper.
+  const text2 = "123″789";
+  const tagsExpected2 = ["123", "″", "789"];
+  const tags2 = cldrAddValue.convertTextToTags(text2);
+
+  it("should convert more text to tags", function () {
+    assert.deepEqual(tags2, tagsExpected2, "tags are equal");
   });
 });

--- a/tools/cldr-apps/js/test/TestCldrLocales.mjs
+++ b/tools/cldr-apps/js/test/TestCldrLocales.mjs
@@ -18,17 +18,20 @@ describe("cldrLocales.isValid", function () {
   };
   cldrLoad.setTheLocaleMap(lm);
   it("should reject null", function () {
-    assert(cldrLocales.isValid(null) === false, "null is invalid");
+    assert(cldrLocales.isValid(null, "quiet") === false, "null is invalid");
   });
   it("should reject empty", function () {
-    assert(cldrLocales.isValid("") === false, "empty string is invalid");
+    assert(
+      cldrLocales.isValid("", "quiet") === false,
+      "empty string is invalid"
+    );
   });
   it("should reject number", function () {
-    assert(cldrLocales.isValid(123) === false, "123 is invalid");
+    assert(cldrLocales.isValid(123, "quiet") === false, "123 is invalid");
   });
   it("should reject bogus_locale", function () {
     assert(
-      cldrLocales.isValid("bogus_locale") === false,
+      cldrLocales.isValid("bogus_locale", "quiet") === false,
       "bogus_locale is invalid"
     );
   });


### PR DESCRIPTION
-Make the borders thicker and darker

-Show some additional characters (quotes/apostrophes/primes) as tags but do not include them in the Insert menu

-Add documentation for the additional characters in getting-started/guide.md

-Minor related refactoring and comments

-(Unrelated:) Suppress distracting console warnings for intentionally invalid locale IDs in TestCldrLocales

CLDR-19353

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
