### PR TITLE
CLDR-18980 Turn some more errors into warnings

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -2005,7 +2005,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</timeFormats>
 				<dateTimeFormats>
 					<numericSeparators>
-						<alias source="locale" path="../../../calendar[@type='gregorian']/dateTimeFormats/numericSeparators"/>
+						<numericDateSeparator>-</numericDateSeparator>
+						<numericTimeSeparator>:</numericTimeSeparator>
 					</numericSeparators>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -766,9 +766,6 @@ public class CheckDates extends FactoryCheckCLDR {
         }
     }
 
-    static final Set<String> FORCE_DATE_WARNINGS = Set.of("brx", "rw");
-    static final Set<String> FORCE_TIME_WARNINGS = Set.of("fr_CA");
-
     private enum IdOrStock {
         id,
         stock;
@@ -822,16 +819,12 @@ public class CheckDates extends FactoryCheckCLDR {
             String baseValue = cldrFile.getWinningValue(basePath);
             Set<String> separatorFromBase = extractNumericSeparator(basePath, baseValue);
             if (!separatorFromBase.contains(value)) {
-                String joined = Joiners.COMMA_SP.join(separatorFromBase);
+                String separatorsFromBase = Joiners.COMMA_SP.join(separatorFromBase);
                 CheckStatus.Type errorType = getErrorTypeButWarningInBuild();
                 if (errorType == CheckStatus.errorType) {
-                    if (joined.isEmpty()
-                            || dateOrTime == DateOrTime.date
-                                    && FORCE_DATE_WARNINGS.contains(localeID)
-                            || dateOrTime == DateOrTime.time
-                                    && FORCE_TIME_WARNINGS.contains(localeID)
-                            || !tcLocaleModeratePlus(localeID)
-                                    && !isContributedPlus(cldrFile, parts)) {
+                    if (separatorsFromBase.isEmpty()
+                            || numericDatetimeSeparatorErrorShouldBeWarning(
+                                    parts.toString(), cldrFile, dateOrTime)) {
                         errorType = CheckStatus.warningType;
                     }
                 }
@@ -844,20 +837,36 @@ public class CheckDates extends FactoryCheckCLDR {
                                         "Numeric {0} separator conflicts with «{1}» from the base «{3}» at {2}"
                                                 + LINKTO_VETTER_INFO,
                                         dateOrTime,
-                                        joined,
+                                        separatorsFromBase,
                                         getPathReferenceForMessage(basePath),
                                         baseValue));
             }
         }
     }
 
-    private boolean isContributedPlus(CLDRFile cldrFile, XPathParts parts) {
-        String winningPath = cldrFile.getWinningPath(parts.toString());
-        String fullWinningPath = cldrFile.getFullXPath(winningPath);
-        return DraftStatus.forXpath(fullWinningPath).compareTo(DraftStatus.contributed) >= 0;
+    static final Set<String> FORCE_DATE_WARNINGS = Set.of("brx", "rw");
+    static final Set<String> FORCE_TIME_WARNINGS = Set.of("fr_CA");
+
+    boolean numericDatetimeSeparatorErrorShouldBeWarning(
+            String ntdsPath, CLDRFile cldrFile, DateOrTime dateOrTime) {
+        String localeID = cldrFile.getLocaleID();
+        return dateOrTime == DateOrTime.date && FORCE_DATE_WARNINGS.contains(localeID)
+                || dateOrTime == DateOrTime.time && FORCE_TIME_WARNINGS.contains(localeID)
+                //                || !tcLocaleModeratePlus(localeID) &&
+                || pathIsProvisional(cldrFile, ntdsPath) && pathIsComprehensive(ntdsPath, localeID);
     }
 
-    private boolean tcLocaleModeratePlus(String localeID) {
+    boolean pathIsComprehensive(String ntdsPath, String localeID) {
+        return sdi.getCoverageLevel(ntdsPath, localeID) == Level.COMPREHENSIVE;
+    }
+
+    boolean pathIsProvisional(CLDRFile cldrFile, String path) {
+        String winningPath = cldrFile.getWinningPath(path);
+        String fullWinningPath = cldrFile.getFullXPath(winningPath);
+        return DraftStatus.forXpath(fullWinningPath).compareTo(DraftStatus.provisional) <= 0;
+    }
+
+    boolean tcLocaleModeratePlus(String localeID) {
         Level cldrCoverageTarget =
                 StandardCodes.make().getLocaleCoverageLevel(Organization.cldr, localeID);
         return cldrCoverageTarget.compareTo(Level.BASIC) > 0;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -38,6 +38,7 @@ import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.util.ApproximateWidth;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRURLS;
@@ -61,6 +62,7 @@ import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LogicalGrouping;
+import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.PreferredAndAllowedHour;
@@ -807,6 +809,7 @@ public class CheckDates extends FactoryCheckCLDR {
     private void checkNumericSeparators(XPathParts parts, String value, List<CheckStatus> result) {
         String calendar = DatetimeUtilities.getCalendar(parts);
         CLDRFile cldrFile = getCldrFileToCheck();
+        String localeID = getLocaleID();
         DateOrTime dateOrTime =
                 parts.containsElement("numericDateSeparator") ? DateOrTime.date : DateOrTime.time;
         for (IdOrStock idOrStock : IdOrStock.values()) {
@@ -815,20 +818,23 @@ public class CheckDates extends FactoryCheckCLDR {
                 continue; // fix this in the future, by enforcing consistency of available IDs
                 // across calendars
             }
-            String xpath = CldrPathUtilities.dateTypePattern(calendar, base);
-            String winningValue = cldrFile.getWinningValue(xpath);
-            Set<String> separatorFromBase = extractNumericSeparator(xpath, winningValue);
+            String basePath = CldrPathUtilities.dateTypePattern(calendar, base);
+            String baseValue = cldrFile.getWinningValue(basePath);
+            Set<String> separatorFromBase = extractNumericSeparator(basePath, baseValue);
             if (!separatorFromBase.contains(value)) {
                 String joined = Joiners.COMMA_SP.join(separatorFromBase);
-                CheckStatus.Type errorType =
-                        (joined.isEmpty()
-                                                || dateOrTime == DateOrTime.date
-                                                        && FORCE_DATE_WARNINGS.contains(
-                                                                getLocaleID()))
-                                        || (dateOrTime == DateOrTime.time
-                                                && FORCE_TIME_WARNINGS.contains(getLocaleID()))
-                                ? CheckStatus.warningType
-                                : getErrorTypeButWarningInBuild();
+                CheckStatus.Type errorType = getErrorTypeButWarningInBuild();
+                if (errorType == CheckStatus.errorType) {
+                    if (joined.isEmpty()
+                            || dateOrTime == DateOrTime.date
+                                    && FORCE_DATE_WARNINGS.contains(localeID)
+                            || dateOrTime == DateOrTime.time
+                                    && FORCE_TIME_WARNINGS.contains(localeID)
+                            || !tcLocaleModeratePlus(localeID)
+                                    && !isContributedPlus(cldrFile, parts)) {
+                        errorType = CheckStatus.warningType;
+                    }
+                }
                 result.add(
                         new CheckStatus()
                                 .setCause(this)
@@ -839,10 +845,22 @@ public class CheckDates extends FactoryCheckCLDR {
                                                 + LINKTO_VETTER_INFO,
                                         dateOrTime,
                                         joined,
-                                        getPathReferenceForMessage(xpath),
-                                        winningValue));
+                                        getPathReferenceForMessage(basePath),
+                                        baseValue));
             }
         }
+    }
+
+    private boolean isContributedPlus(CLDRFile cldrFile, XPathParts parts) {
+        String winningPath = cldrFile.getWinningPath(parts.toString());
+        String fullWinningPath = cldrFile.getFullXPath(winningPath);
+        return DraftStatus.forXpath(fullWinningPath).compareTo(DraftStatus.contributed) >= 0;
+    }
+
+    private boolean tcLocaleModeratePlus(String localeID) {
+        Level cldrCoverageTarget =
+                StandardCodes.make().getLocaleCoverageLevel(Organization.cldr, localeID);
+        return cldrCoverageTarget.compareTo(Level.BASIC) > 0;
     }
 
     private void checkForNumericSeparator(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1332,7 +1332,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                             "DayPeriods",
                                             "Formats");
                             final List<String> calendarFormatTypes =
-                                    Arrays.asList("Standard", "Flexible", "Intervals");
+                                    Arrays.asList("Numeric", "Standard", "Flexible", "Intervals");
                             final List<String> calendarContextTypes =
                                     Arrays.asList("none", "format", "stand-alone");
                             final List<String> calendarFormatSubtypes =

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -117,6 +117,9 @@
 //ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="%A"]/dayPeriodWidth[@type="%A"]/dayPeriod[@type="%A"]  ; DateTime ; &calendar(gregorian) ; &calField(DayPeriods:$2:$1) ; &dayPeriod($3)
 //ldml/dates/calendars/calendar[@type="%A"]/dayPeriods/dayPeriodContext[@type="%A"]/dayPeriodWidth[@type="%A"]/dayPeriod[@type="%A"]  ; Special  ; Suppress ; &calendar($1) ; &calField(DayPeriods:$3:$2)-&dayPeriod($4) ; HIDE
 
+//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/numericSeparators/numericDateSeparator       ; DateTime ; &calendar($1) ; &calField(Formats:Numeric:separator); Date
+//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/numericSeparators/numericTimeSeparator       ; DateTime ; &calendar($1) ; &calField(Formats:Numeric:separator); Time
+
 //ldml/dates/calendars/calendar[@type="%N"]/dateFormats/dateFormatLength[@type="%A"]/dateFormat[@type="%A"]/pattern[@type="%A"][@count="%A"]       ; DateTime ; &calendar($1) ; &calField(Formats:Standard:date) ; $2-$5 ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/dateFormats/dateFormatLength[@type="%A"]/dateFormat[@type="%A"]/pattern[@type="%A"][@count="%A"]       ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Standard:date)-$2 ; HIDE
 //ldml/dates/calendars/calendar[@type="%N"]/dateFormats/dateFormatLength[@type="%A"]/dateFormat[@type="%A"]/pattern[@type="%A"]       ; DateTime ; &calendar($1) ; &calField(Formats:Standard:date) ; $2 ; LTR_ALWAYS
@@ -127,9 +130,6 @@
 //ldml/dates/calendars/calendar[@type="(gregorian|iso8601)"]/timeFormats/timeFormatLength[@type="%A"]/timeFormat[@type="%A"]/pattern[@type="%A"]       ; DateTime ; &calendar($1) ; &calField(Formats:Standard:time) ; $2 ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/timeFormats/timeFormatLength[@type="%A"]/timeFormat[@type="%A"]/pattern[@type="%A"]       ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Standard:time)-$2 ; HIDE
 //ldml/dates/calendars/calendar[@type="%A"]/timeFormats/timeFormatLength[@type="%A"]/timeFormat[@type="%A"]/datetimeSkeleton       ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Standard:time)-$2 ; HIDE
-
-//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/numericSeparators/numericDateSeparator       ; DateTime ; &calendar($1) ; Numeric separator; Date
-//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/numericSeparators/numericTimeSeparator       ; DateTime ; &calendar($1) ; Numeric separator; Time
 
 //ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/dateTimeFormatLength[@type="%A"]/dateTimeFormat[@type="(standard)"]/pattern[@type="%A"]       ; DateTime ; &calendar($1) ; &calField(Formats:Standard:dateTime) ; $2 ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/dateTimeFormatLength[@type="%A"]/dateTimeFormat[@type="%A"]/pattern[@type="%A"]       ; DateTime ; &calendar($1) ; &calField(Formats:Standard:dateTime) ; $2-$3 ; LTR_ALWAYS


### PR DESCRIPTION
CLDR-18980

The wording in the TC agenda was: "Turn errors into warnings only if one or more of the items in the new date separator test has a value at contributed or higher if it is not in their coverage level, or it’s a CLDR locale with a target level of moderate or higher"

* I renamed some items for clarity (to basePath and baseValue)
* Reorganized the code from an inline if statement to make it clearer.
* Added two new helper functions, also for clarity.
* Changed the position of the Numeric Separators on the calendar page to be more logical (after the lists of eras, quarters, months, etc. and just before the standard formats (full, long ...)

The wording in the agreement was a bit tricky (we were editing quickly), so this is my take on what we meant. I'd asked for the CLDR locale clause to be added, but I don't think that is necessary. 

| Locale | **TC** coverage target | NS Path | Draft Status | Result |
| -- | -- | -- | -- | -- |
| French | Modern | Comprehensive |  provisional |  **warning** |
| French | Modern | Not Comp. |  provisional |  error |
| French | Modern | Comprehensive |  approved |  error |
| French | Modern | Not Comp. |  approved |  error |
<!--
| Volopuk | none (not TC) | Comprehensive |  provisional |  **warning** |
| Volopuk | none (not TC) | Not Comp. |  provisional |  **warning** |
| Volopuk | none (not TC) | Comprehensive |  approved |  **warning** |
| Volopuk | none (not TC) | Not Comp. |  approved |  error |
| Manipuri | Basic | Comprehensive |  provisional |  **warning** |
| Manipuri | Basic | Not Comp. |  provisional |  **warning** |
| Manipuri | Basic | Comprehensive |  approved |  **warning** |
| Manipuri | Basic | Not Comp. |  approved |  error |
-->

Once I get that right I can incorporate the logic into the check.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
