### PR TITLE
CLDR-19353 Remove U+0022 QUOTATION MARK from set

### DIFF
--- a/docs/site/translation/getting-started/guide.md
+++ b/docs/site/translation/getting-started/guide.md
@@ -167,7 +167,7 @@ That lets them insert a character at the current insertion point in the text.
 Hovering over the items in that menu shows details about their usage, as you see in the image
 — so it can also be used to decode the meaning of the abbreviations used in the chits.
 
-Some easily confusible characters (" “ ” ″ ʼ ‘ ’ ′) are not included in the insert-character menu, but are displayed with chits to enable differentiating them by hovering.
+Some easily confusible characters (“ ” ″ ʼ ‘ ’ ′) are not included in the insert-character menu, but are displayed with chits to enable differentiating them by hovering.
 
 NOTE: For alphabetic information (such as exemplar characters), an older mechanism is still in place.
 We hope to update it during the submission phase. More details on how to [**input** these from the keyboard][],

--- a/tools/cldr-apps/js/src/esm/cldrChar.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrChar.mjs
@@ -11,7 +11,6 @@ import * as cldrEscaper from "./cldrEscaper.mjs";
   in the Insert menu. They are not invisibles, so the characters themselves, rather
   than their names, are displayed in the tags. Users can see their names by hovering.
 
-  ◦	" U+0022 QUOTATION MARK
   ◦	“ U+201C LEFT DOUBLE QUOTATION MARK
   ◦	” U+201D RIGHT DOUBLE QUOTATION MARK
   ◦	″ U+2033 DOUBLE PRIME
@@ -21,7 +20,7 @@ import * as cldrEscaper from "./cldrEscaper.mjs";
   ◦	′ U+2032 PRIME
 */
 const tagWithNoName = [
-  0x0022, 0x201c, 0x201d, 0x2033, 0x02bc, 0x2018, 0x2019, 0x2032,
+  0x201c, 0x201d, 0x2033, 0x02bc, 0x2018, 0x2019, 0x2032,
 ];
 
 function shouldDisplayAsTag(s) {


### PR DESCRIPTION
- Remove U+0022 QUOTATION MARK from the set of easily confusible characters (“ ” ″ ʼ ‘ ’ ′) that are not included in the insert-character menu, but are displayed with chits to enable differentiating them by hovering

CLDR-19353

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
