### PR TITLE
CLDR-13465 complete "TestAll should test all tests"

### DIFF
--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
@@ -16,12 +16,17 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.ShimmedMain;
 import org.unicode.cldr.web.CLDRProgressIndicator;
 import org.unicode.cldr.web.DBUtils;
 import org.unicode.cldr.web.SurveyLog;
 
 /** Top level test used to run all other tests as a batch. */
 public class TestAll extends TestGroup {
+    private static String[] getTestClassNames() {
+        return ShimmedMain.findAllTests(TestAll.class.getPackage());
+    }
+
     private static final Logger logger = SurveyLog.forClass(TestAll.class);
 
     private static final String CLDR_TEST_JDBC = TestAll.class.getPackage().getName() + ".jdbcurl";
@@ -100,18 +105,7 @@ public class TestAll extends TestGroup {
     }
 
     public TestAll() {
-        super(
-                new String[] {
-                    // use class.getName so we are in sync with name changes and
-                    // removals (if not additions)
-                    TestIntHash.class.getName(),
-                    TestXPathTable.class.getName(),
-                    TestMiscWeb.class.getName(),
-                    TestUserSettingsData.class.getName(),
-                    TestAnnotationVotes.class.getName(),
-                    TestUserRegistry.class.getName(),
-                },
-                "All tests in CLDR Web");
+        super(getTestClassNames(), "All tests in CLDR Web");
     }
 
     public static final String CLASS_TARGET_NAME = "CLDR.Web";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
@@ -22,7 +22,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.XPathParts;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestAlt extends TestFmwk {
     static CLDRConfig testInfo = CLDRConfig.getInstance();
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBcp47Numbers.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBcp47Numbers.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.util.CLDRConfig;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestBcp47Numbers extends TestFmwk {
     public static void main(String[] args) {
         new TestBcp47Numbers().run(args);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFileWrite.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFileWrite.java
@@ -23,7 +23,7 @@ import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.XMLFileReader;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestCldrFileWrite extends TestFmwkPlus {
     private static final CLDRConfig CONFIG = CLDRConfig.getInstance();
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollators.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollators.java
@@ -18,7 +18,7 @@ import org.unicode.cldr.util.ChainedMap.M3;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.PatternCache;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestCollators extends TestFmwk {
     public static void main(String[] args) {
         new TestCollators().run(args);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompatibility.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompatibility.java
@@ -11,7 +11,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestCompatibility extends TestFmwkPlus {
     private static final File ARCHIVE = new File(CLDRPaths.ARCHIVE_DIRECTORY);
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -22,7 +22,7 @@ import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestCoverage extends TestFmwkPlus {
     private static final boolean DEBUG = false;
     private static final boolean SHOW_LSR_DATA = false;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
@@ -147,7 +147,7 @@ public class TestDateOrder extends TestFmwk {
     static final String intervalFormatPathPrefix =
             "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/intervalFormats/";
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void TestIso8601() {
         List<String> printout = null;
         if (isVerbose()) {
@@ -734,7 +734,7 @@ public class TestDateOrder extends TestFmwk {
         return result;
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testDatetimeUtilities() {
         // basic test
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestIcuPersonNames.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestIcuPersonNames.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Disabled;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestIcuPersonNames extends TestFmwk {
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
@@ -21,7 +21,7 @@ import org.unicode.cldr.util.LanguageGroup;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestLanguageGroup extends TestFmwk {
     static CLDRConfig CONF = CLDRConfig.getInstance();
     static CLDRFile ENGLISH = CONF.getEnglish();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -84,7 +84,7 @@ public class TestLsrvCanonicalizer extends TestFmwk {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void TestAgainstLanguageSubtagRegistry() {
         Map<String, String> exceptions =
                 ImmutableMap.<String, String>builder()

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPerf.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPerf.java
@@ -136,7 +136,7 @@ public class TestPerf extends TestFmwkPlus {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void TestPathComparison() {
         DtdData dtdData = DtdData.getInstance(DtdType.ldml);
         AttributeValueComparator avc =

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
@@ -297,7 +297,7 @@ public class TestPluralRuleGeneration extends TestFmwkPlus {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void TestDecimalQuantity() {
         ImmutableSet<String> tests =
                 ImmutableSet.of(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUExtension.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUExtension.java
@@ -7,7 +7,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.UExtension;
 
-@Disabled
+@Disabled("CLDR-19472 failing test wasn’t being run")
 public class TestUExtension extends TestFmwk {
 
     static SupplementalDataInfo data =

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestURLs.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestURLs.java
@@ -66,12 +66,12 @@ public class TestURLs extends TestFmwk {
 
     static final Path BASE = Path.of(CLDRPaths.BASE_DIRECTORY);
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testSiteFiles() {
         checkSiteFiles(SiteType.SITE, Path.of(CLDRPaths.BASE_DIRECTORY, "docs/site"));
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testSpecFiles() {
         checkSiteFiles(SiteType.SPEC, Path.of(CLDRPaths.BASE_DIRECTORY, "docs/ldml"));
     }
@@ -91,7 +91,7 @@ public class TestURLs extends TestFmwk {
         System.out.println("\nDomains\n" + JOIN_LF.join(domains));
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testFile() {
         Path p = Path.of(CLDRPaths.BASE_DIRECTORY, "docs/site/development/adding-locales.md");
         Set<LineChecker> results = new LinkedHashSet<>();
@@ -134,7 +134,7 @@ public class TestURLs extends TestFmwk {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testLineChecker() {
         String[][] tests = {
             {"SITE", "../index/downloads.md#cldr-releasesdownloads", "BAD_LOCAL HAS_MD"},
@@ -150,7 +150,7 @@ public class TestURLs extends TestFmwk {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testIssueExamples() {
         for (Issue issue : Issue.values()) {
             if (DISABLE_BROKEN & issue == Issue.BROKEN) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestXMLSource.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestXMLSource.java
@@ -64,7 +64,7 @@ public class TestXMLSource extends TestFmwk {
         new TestXMLSource().run(args);
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void TestGetPathsWithValue() {
         XMLSource source = new DummyXMLSource();
         source.putValueAtDPath("//ldml/foo", "x");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
@@ -222,7 +222,7 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
         // UnicodeSet("[{\\u200D\\u200e}]"), false);
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testSimpleUnicodeSetFormatterWithLocales() {
         havePrintln = false;
         StringBuilder needsEscapeReport = new StringBuilder();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleDistanceTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleDistanceTest.java
@@ -56,7 +56,7 @@ public class XLocaleDistanceTest extends TestFmwk {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testTiming() {
         List<Arguments> testArgs = new ArrayList<>();
         for (List<String> line : tfh.getLines()) {
@@ -166,7 +166,7 @@ public class XLocaleDistanceTest extends TestFmwk {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testDataDriven() throws IOException {
         tfh.test();
         if (REFORMAT) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
@@ -179,7 +179,7 @@ public class XLocaleMatcherTest extends TestFmwk {
         }
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testPerf() {
         if (LANGUAGE_MATCHER_DATA == null) {
             return; // skip except when testing data
@@ -316,7 +316,7 @@ public class XLocaleMatcherTest extends TestFmwk {
         return (delta / iterations);
     }
 
-    @Disabled
+    @Disabled("CLDR-19472 failing test wasn’t being run")
     public void testDataDriven() throws IOException {
         DataDrivenTestHelper tfh =
                 new MyTestFileHandler()


### PR DESCRIPTION
CLDR-13465

- add a `@Disabled` annotation implicating [CLDR-19472](https://unicode-org.atlassian.net/browse/CLDR-19472) for a number of the disabled tests. (The annotation value isn't shown as a log known issue, but running the test does list `@Disabled` as the reason it is skipped)
- apply the new scanning logic to cldr-apps. This gets rid of all lists of tests-to-run. 

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true


[CLDR-19472]: https://unicode-org.atlassian.net/browse/CLDR-19472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ