### PR TITLE
CLDR-19258 Fix sorting of available formats in CldrDateTimePatternGenerator

### DIFF
--- a/common/testData/datetime/skeletons.tsv
+++ b/common/testData/datetime/skeletons.tsv
@@ -81,7 +81,7 @@ zh_Hant_TW	chinese	MMMM	LLLL
 zh_Hant_TW	chinese	jjm	Bh:mm
 ko	gregorian	yMd	y. M. d.
 ko	gregorian	yMMMMd	y MMMM d
-ko	gregorian	yMMMMEEEEd	y MMMM d, EEEE
+ko	gregorian	yMMMMEEEEd	y년 MMMM d일 EEEE
 ko	gregorian	GyMd	GGGGG y/M/d
 ko	gregorian	HmsS	H시 m분 s.S초
 ko	gregorian	Cms	a h:mm:ss
@@ -111,7 +111,7 @@ ko	buddhist	MMMM	LLLL
 ko	buddhist	jjm	a h:mm
 ko	chinese	yMd	r. M. d.
 ko	chinese	yMMMMd	r년(U년) MMMM d일
-ko	chinese	yMMMMEEEEd	r년(U년) MMMM d일(EEEE)
+ko	chinese	yMMMMEEEEd	r년(U년) MMMM d일 EEEE
 ko	chinese	GyMd	r년 MMM d일
 ko	chinese	HmsS	HH:mm:ss.S
 ko	chinese	Cms	a h:mm:ss
@@ -161,7 +161,7 @@ eu	chinese	MMMM	LLLL
 eu	chinese	jjm	HH:mm
 ja	gregorian	yMd	y/M/d
 ja	gregorian	yMMMMd	y MMMM d
-ja	gregorian	yMMMMEEEEd	y MMMM d, EEEE
+ja	gregorian	yMMMMEEEEd	y年M月d日EEEE
 ja	gregorian	GyMd	Gy/M/d
 ja	gregorian	HmsS	H:mm:ss.S
 ja	gregorian	Cms	H:mm:ss
@@ -191,7 +191,7 @@ ja	buddhist	MMMM	M月
 ja	buddhist	jjm	H:mm
 ja	chinese	yMd	U-M-d
 ja	chinese	yMMMMd	r(U)年MMMMd日
-ja	chinese	yMMMMEEEEd	r(U)年MMMMd日(EEEE)
+ja	chinese	yMMMMEEEEd	U年MMMMd日EEEE
 ja	chinese	GyMd	U-M-d
 ja	chinese	HmsS	H:mm:ss.S
 ja	chinese	Cms	H:mm:ss

--- a/common/testData/datetime/skeletons_all_calendars.tsv
+++ b/common/testData/datetime/skeletons_all_calendars.tsv
@@ -251,7 +251,7 @@ ko	coptic	MMMM	LLLL
 ko	coptic	jjm	a h:mm
 ko	dangi	yMd	r. M. d.
 ko	dangi	yMMMMd	r년(U년) MMMM d일
-ko	dangi	yMMMMEEEEd	r년(U년) MMMM d일(EEEE)
+ko	dangi	yMMMMEEEEd	r년(U년) MMMM d일 EEEE
 ko	dangi	GyMd	r년 MMM d일
 ko	dangi	HmsS	HH:mm:ss.S
 ko	dangi	Cms	a h:mm:ss
@@ -491,7 +491,7 @@ ja	coptic	MMMM	M月
 ja	coptic	jjm	H:mm
 ja	dangi	yMd	U-M-d
 ja	dangi	yMMMMd	r(U)年MMMMd日
-ja	dangi	yMMMMEEEEd	r(U)年MMMMd日(EEEE)
+ja	dangi	yMMMMEEEEd	U年MMMMd日EEEE
 ja	dangi	GyMd	U-M-d
 ja	dangi	HmsS	H:mm:ss.S
 ja	dangi	Cms	H:mm:ss

--- a/common/testData/datetime/skeletons_all_skeletons.tsv
+++ b/common/testData/datetime/skeletons_all_skeletons.tsv
@@ -1074,7 +1074,7 @@ ko	gregorian	yMEdz	y. M. d. (E) z
 ko	gregorian	yMM	y. M.
 ko	gregorian	yMMM	y년 MMM
 ko	gregorian	yMMMM	y년 MMMM
-ko	gregorian	yMMMMEEEEdvvvv	y MMMM d, EEEE vvvv
+ko	gregorian	yMMMMEEEEdvvvv	y년 MMMM d일 EEEE vvvv
 ko	gregorian	yMMMMM	y년 MMMMM
 ko	gregorian	yMMMMdhmsvvvv	y MMMM d a h:mm:ss vvvv
 ko	gregorian	yMMMMdv	y MMMM d v
@@ -1440,7 +1440,7 @@ ko	chinese	yMEdz	r. M. d. (E) z
 ko	chinese	yMM	r. MM.
 ko	chinese	yMMM	r년(U년) MMM
 ko	chinese	yMMMM	r년(U년) MMMM
-ko	chinese	yMMMMEEEEdvvvv	r년(U년) MMMM d일(EEEE) vvvv
+ko	chinese	yMMMMEEEEdvvvv	r년(U년) MMMM d일 EEEE vvvv
 ko	chinese	yMMMMM	r년(U년) MMMMM
 ko	chinese	yMMMMdhmsvvvv	r년(U년) MMMM d일 a h:mm:ss vvvv
 ko	chinese	yMMMMdv	r년(U년) MMMM d일 v
@@ -2050,7 +2050,7 @@ ja	gregorian	yMEdz	y/M/d(E) z
 ja	gregorian	yMM	y/MM
 ja	gregorian	yMMM	y年M月
 ja	gregorian	yMMMM	y年M月
-ja	gregorian	yMMMMEEEEdvvvv	y MMMM d, EEEE vvvv
+ja	gregorian	yMMMMEEEEdvvvv	y年M月d日EEEE vvvv
 ja	gregorian	yMMMMM	y年M月
 ja	gregorian	yMMMMdhmsvvvv	y MMMM d aK:mm:ss vvvv
 ja	gregorian	yMMMMdv	y MMMM d v
@@ -2416,7 +2416,7 @@ ja	chinese	yMEdz	U年M月d日(E) z
 ja	chinese	yMM	U年MM月
 ja	chinese	yMMM	U年MMM
 ja	chinese	yMMMM	U年MMMM
-ja	chinese	yMMMMEEEEdvvvv	r(U)年MMMMd日(EEEE) vvvv
+ja	chinese	yMMMMEEEEdvvvv	U年MMMMd日EEEE vvvv
 ja	chinese	yMMMMM	U年MMMMM
 ja	chinese	yMMMMdhmsvvvv	r(U)年MMMMd日 aK:mm:ss vvvv
 ja	chinese	yMMMMdv	r(U)年MMMMd日 v

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrDateTimePatternGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrDateTimePatternGenerator.java
@@ -860,35 +860,20 @@ public class CldrDateTimePatternGenerator {
      * can simply take the first matching distance, eliminating the need for runtime tie-breaking.
      */
     private void sortAvailableFormats() {
-        Map<String, char[]> charsMap = new HashMap<>();
-        Map<String, int[]> lengthsMap = new HashMap<>();
-        for (String skel : availableFormats.keySet()) {
-            int limit = DateTimePatternGenerator.TYPE_LIMIT;
-            char[] chars = new char[limit];
-            int[] lengths = new int[limit];
-            populateFields(skel, chars, lengths);
-            charsMap.put(skel, chars);
-            lengthsMap.put(skel, lengths);
-        }
-
         List<Map.Entry<String, String>> entries = new ArrayList<>(availableFormats.entrySet());
         entries.sort(
                 (e1, e2) -> {
-                    char[] chars1 = charsMap.get(e1.getKey());
-                    char[] chars2 = charsMap.get(e2.getKey());
-                    int[] lengths1 = lengthsMap.get(e1.getKey());
-                    int[] lengths2 = lengthsMap.get(e2.getKey());
-
-                    int limit = DateTimePatternGenerator.TYPE_LIMIT;
-                    for (int i = 0; i < limit; i++) {
-                        if (chars1[i] != chars2[i]) {
-                            return chars2[i] - chars1[i];
-                        }
-                        if (lengths1[i] != lengths2[i]) {
-                            return lengths2[i] - lengths1[i];
+                    String k1 = e1.getKey();
+                    String k2 = e2.getKey();
+                    for (int i = 0; i < CANONICAL_ORDER.length(); i++) {
+                        char c = CANONICAL_ORDER.charAt(i);
+                        boolean b1 = k1.indexOf(c) >= 0;
+                        boolean b2 = k2.indexOf(c) >= 0;
+                        if (b1 != b2) {
+                            return b2 ? 1 : -1;
                         }
                     }
-                    return e1.getKey().compareTo(e2.getKey());
+                    return k1.compareTo(k2);
                 });
 
         availableFormats.clear();


### PR DESCRIPTION
CLDR-19258

- [x] This PR completes the ticket.

### Description
This Pull Request simplifies and cleans up the sorting logic in `CldrDateTimePatternGenerator.sortAvailableFormats` to use the `CANONICAL_ORDER` of fields instead of the previous complex and tie-prone logic.

### Impact
This change ensures that when the generator matches skeletons, it resolves ties more consistently. Specifically, it allows localized patterns (or fallbacks built from correct localized pieces) to be preferred over root fallbacks. 

For example, this fixes the `ko` (Korean) `yMMMMEEEEd` skeleton to correctly use Korean characters (`y년 MMMM d일 EEEE`) instead of falling back to the English-style comma pattern from `root.xml` (`y MMMM d, EEEE`).

Affected test data (TSV files) have been regenerated and are included in this PR.

🤖 This pull request was created by an AI agent working with @sffc.

ALLOW_MANY_COMMITS=true


[CLDR-19258]: https://unicode-org.atlassian.net/browse/CLDR-19258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ