### PR TITLE
CLDR-17854 Show multiple numbering systems in date report

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrChar.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrChar.mjs
@@ -19,9 +19,7 @@ import * as cldrEscaper from "./cldrEscaper.mjs";
   ◦	’ U+2019 RIGHT SINGLE QUOTATION MARK
   ◦	′ U+2032 PRIME
 */
-const tagWithNoName = [
-  0x201c, 0x201d, 0x2033, 0x02bc, 0x2018, 0x2019, 0x2032,
-];
+const tagWithNoName = [0x201c, 0x201d, 0x2033, 0x02bc, 0x2018, 0x2019, 0x2032];
 
 function shouldDisplayAsTag(s) {
   const c = firstChar(s);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -50,6 +50,7 @@ import org.unicode.cldr.util.GrammarInfo;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
+import org.unicode.cldr.util.ICUServiceBuilder;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.SpecialLocales;
 import org.unicode.cldr.util.SupplementalDataInfo;
@@ -2989,24 +2990,11 @@ public class SurveyAjax extends HttpServlet {
      */
     private static void generateDateTimesReport(Writer out, SurveyMain sm, CLDRLocale l)
             throws IOException {
-
-        final String calendarType = "gregorian";
-        final String title =
-                com.ibm.icu.lang.UCharacter.toTitleCase(
-                        SurveyMain.TRANS_HINT_LOCALE.toLocale(), calendarType, null);
-
-        out.write("<h3>Calendar : " + title + "</h3>");
-
         STFactory fac = sm.getSTFactory();
-        CLDRFile englishFile = fac.make("en", true);
         CLDRFile nativeFile = fac.make(l, true);
-
-        DateTimeFormats formats = new DateTimeFormats(fac, nativeFile, calendarType);
-        DateTimeFormats english = new DateTimeFormats(fac, englishFile, calendarType);
-
-        formats.addTable(english, out);
-        formats.addDateTable(englishFile, out);
-        formats.addDayPeriods(englishFile, out);
+        CLDRFile englishFile = fac.make(SurveyMain.TRANS_HINT_ID, true);
+        DateTimeFormats.generateReport(
+                fac, SurveyMain.TRANS_HINT_LOCALE.toLocale(), nativeFile, englishFile, out);
     }
 
     /**
@@ -3023,7 +3011,12 @@ public class SurveyAjax extends HttpServlet {
         CLDRFile nativeFile = sm.getSTFactory().make(l, true);
 
         org.unicode.cldr.util.VerifyZones.showZones(
-                sm.getSTFactory(), null, englishFile, nativeFile, out);
+                sm.getSTFactory(),
+                null,
+                englishFile,
+                nativeFile,
+                ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT,
+                out);
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -427,10 +427,10 @@ class LdmlConvertRules {
             Pattern.compile(
                     "//ldml/numbers/(symbols|miscPatterns|(decimal|percent|scientific|currency|rational)Formats)\\[@numberSystem=\"([^\"]++)\"\\]/.*");
     public static final String[] ACTIVE_NUMBERING_SYSTEM_XPATHS = {
-        "//ldml/numbers/defaultNumberingSystem",
-        "//ldml/numbers/otherNumberingSystems/native",
-        "//ldml/numbers/otherNumberingSystems/traditional",
-        "//ldml/numbers/otherNumberingSystems/finance"
+        CLDRFile.NumberingSystem.defaultSystem.path,
+        CLDRFile.NumberingSystem.nativeSystem.path,
+        CLDRFile.NumberingSystem.traditional.path,
+        CLDRFile.NumberingSystem.finance.path,
     };
 
     /** resolved identity should be discarded if inherited, known issue CLDR-17790 */

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -776,7 +776,6 @@ public class CheckDates extends FactoryCheckCLDR {
          * @param calendar The main reason we need this is because of the inconsistency between
          *     different calendars
          * @param dateOrTime
-         * @param idOrStock
          * @return
          */
         public String getBaseForNumericSeparator(String calendar, DateOrTime dateOrTime) {
@@ -1783,9 +1782,19 @@ public class CheckDates extends FactoryCheckCLDR {
                             IntervalDiff.compare(
                                     value, constructedPattern, actualIF, constructedIF);
                     String actualSample =
-                            actualIF.format(sampleStartDate, sampleEndDate, isb, timeZone);
+                            actualIF.format(
+                                    sampleStartDate,
+                                    sampleEndDate,
+                                    isb,
+                                    timeZone,
+                                    ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                     String constructedSample =
-                            constructedIF.format(sampleStartDate, sampleEndDate, isb, timeZone);
+                            constructedIF.format(
+                                    sampleStartDate,
+                                    sampleEndDate,
+                                    isb,
+                                    timeZone,
+                                    ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
 
                     result.add(
                             new CheckStatus()
@@ -2163,7 +2172,9 @@ public class CheckDates extends FactoryCheckCLDR {
     private void checkPattern2(String path, String value, List<CheckStatus> result) {
         XPathParts pathParts = XPathParts.getFrozenInstance(path);
         String calendar = pathParts.findAttributeValue("calendar", "type");
-        SimpleDateFormat x = icuServiceBuilder.getDateFormat(calendar, value);
+        SimpleDateFormat x =
+                icuServiceBuilder.getDateFormat(
+                        calendar, value, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
         x.setTimeZone(ExampleGenerator.ZONE_SAMPLE);
         result.add(
                 new MyCheckStatus().setFormat(x).setCause(this).setMainType(CheckStatus.demoType));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -282,13 +282,6 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         return this;
     }
 
-    private UnicodeSet getNumberSystemExemplars() {
-        String numberSystem =
-                getCldrFileToCheck().getStringValue("//ldml/numbers/defaultNumberingSystem");
-        String digits = sdi.getDigits(numberSystem);
-        return new UnicodeSet().addAll(digits);
-    }
-
     private UnicodeSet safeGetExemplars(
             ExemplarType type,
             List<CheckStatus> possibleErrors,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
@@ -106,7 +106,7 @@ public class CheckNumbers extends FactoryCheckCLDR {
 
         CLDRFile resolvedFile = getResolvedCldrFileToCheck();
         String defaultNumberingSystem =
-                resolvedFile.getWinningValue("//ldml/numbers/defaultNumberingSystem");
+                resolvedFile.getWinningValue(CLDRFile.NumberingSystem.defaultSystem.path);
         if (defaultNumberingSystem == null
                 || !validNumberingSystems.contains(defaultNumberingSystem)) {
             defaultNumberingSystem = "latn";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -419,7 +419,7 @@ public class ExampleGenerator {
      * Create an Example Generator. If this is shared across threads, it must be synchronized.
      *
      * @param resolvedCldrFile
-     * @param englishFile
+     * @param cldrFactory
      */
     public ExampleGenerator(CLDRFile resolvedCldrFile, Factory cldrFactory) {
         if (!resolvedCldrFile.isResolved()) {
@@ -552,6 +552,9 @@ public class ExampleGenerator {
     }
 
     private void constructExampleHtmlExtended(String xpath, String value, List<String> examples) {
+        // TODO: enable constructing examples for non-default numbering systems
+        // Reference: https://unicode-org.atlassian.net/browse/CLDR-17854
+        final String numberingSystem = ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT;
         boolean showContexts =
                 isRTL || BIDI_MARKS.containsSome(value); // only used for certain example types
         /*
@@ -562,28 +565,28 @@ public class ExampleGenerator {
         if (parts.contains("dateRangePattern")) { // {0} - {1}
             handleDateRangePattern(value, examples);
         } else if (parts.contains("timeZoneNames")) {
-            handleTimeZoneName(parts, value, examples);
+            handleTimeZoneName(parts, value, examples, numberingSystem);
         } else if (parts.contains("localeDisplayNames")) {
             handleDisplayNames(xpath, parts, value, examples);
         } else if (parts.contains("currency")) {
             handleCurrency(xpath, parts, value, examples);
         } else if (parts.contains("eras")) {
-            handleEras(parts, value, examples);
+            handleEras(parts, value, examples, numberingSystem);
         } else if (parts.contains("quarters")) {
-            handleQuarters(parts, value, examples);
+            handleQuarters(parts, value, examples, numberingSystem);
         } else if (parts.contains("relative")
                 || parts.contains("relativeTime")
                 || parts.contains("relativePeriod")) {
-            handleRelative(xpath, parts, value, examples);
+            handleRelative(xpath, parts, value, examples, numberingSystem);
         } else if (parts.contains("dayPeriods")) {
-            handleDayPeriod(parts, value, examples);
+            handleDayPeriod(parts, value, examples, numberingSystem);
         } else if (parts.contains("dayOfMonths")) {
-            handleDayOfMonths(parts, value, examples);
+            handleDayOfMonths(parts, value, examples, numberingSystem);
         } else if (parts.contains("monthContext")) {
-            handleDateSymbol(parts, value, examples);
+            handleDateSymbol(parts, value, examples, numberingSystem);
         } else if (parts.contains("pattern") || parts.contains("dateFormatItem")) {
             if (parts.contains("calendar")) {
-                handleDateFormatItem(xpath, value, showContexts, examples);
+                handleDateFormatItem(xpath, value, showContexts, examples, numberingSystem);
             } else if (parts.contains("miscPatterns")) {
                 handleMiscPatterns(parts, value, examples);
             } else if (parts.contains("numbers")) {
@@ -618,9 +621,9 @@ public class ExampleGenerator {
         } else if (parts.getElement(-2).equals("minimalPairs")) {
             handleMinimalPairs(parts, value, examples);
         } else if (parts.getElement(-1).equals("durationUnitPattern")) {
-            handleDurationUnit(value, examples);
+            handleDurationUnit(value, examples, numberingSystem);
         } else if (parts.contains("intervalFormats")) {
-            handleIntervalFormats(parts, value, examples);
+            handleIntervalFormats(parts, value, examples, numberingSystem);
         } else if (parts.getElement(1).equals("delimiters")) {
             handleDelimiters(parts, xpath, value, examples);
         } else if (parts.getElement(1).equals("listPatterns")) {
@@ -630,7 +633,7 @@ public class ExampleGenerator {
         } else if (parts.getElement(-1).equals("monthPattern")) {
             handleMonthPatterns(parts, value, examples);
         } else if (parts.getElement(-1).equals("appendItem")) {
-            handleAppendItems(parts, value, examples);
+            handleAppendItems(parts, value, examples, numberingSystem);
         } else if (parts.getElement(-1).equals("annotation")) {
             handleAnnotationName(parts, value, examples);
         } else if (parts.getElement(-1).equals("characterLabel")) {
@@ -1145,7 +1148,8 @@ public class ExampleGenerator {
                                         initialPattern.format(personName, skinName), hairName)));
     }
 
-    private void handleDayPeriod(XPathParts parts, String value, List<String> examples) {
+    private void handleDayPeriod(
+            XPathParts parts, String value, List<String> examples, String numberingSystem) {
         // ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="morning1"]
         // ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="stand-alone"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="morning1"]
         final String dayPeriodType = parts.getAttributeValue(5, "type");
@@ -1174,13 +1178,16 @@ public class ExampleGenerator {
                 int time = (((info.get0() + info.get1()) % DayPeriodInfo.DAY_LIMIT) / 2);
                 String timeFormatString =
                         icuServiceBuilder.formatDayPeriod(
-                                time, backgroundStartSymbol + value + backgroundEndSymbol);
+                                time,
+                                backgroundStartSymbol + value + backgroundEndSymbol,
+                                numberingSystem);
                 examples.add(invertBackground(timeFormatString));
             }
         }
     }
 
-    private void handleDateSymbol(XPathParts parts, String value, List<String> examples) {
+    private void handleDateSymbol(
+            XPathParts parts, String value, List<String> examples, String numberingSystem) {
         // Currently only called for month names, can expand in the future to handle other symbols.
         // The idea is to show format months in a yMMMM?d date format, and stand-alone months in a
         // yMMMM? format.
@@ -1191,8 +1198,6 @@ public class ExampleGenerator {
         String context = parts.findAttributeValue("monthContext", "type"); // format, stand-alone
         String calendarId =
                 parts.findAttributeValue("calendar", "type"); // gregorian, islamic, hebrew, ...
-        String monthNumId =
-                parts.findAttributeValue("month", "type"); // 1-based: 1, 2, 3, ... 12 or 13
 
         final String[] skeletons = {"yMMMMd", "yMMMd", "yMMMM", "yMMM"};
         int skeletonIndex = (length.equals("wide")) ? 0 : 1;
@@ -1206,7 +1211,7 @@ public class ExampleGenerator {
                         + skeletons[skeletonIndex]
                         + "\"]";
         String dateFormat = cldrFile.getWinningValue(checkPath);
-        if (dateFormat == null || dateFormat.indexOf("MMM") < 0) {
+        if (dateFormat == null || !dateFormat.contains("MMM")) {
             // If we do not have the desired width (might be missing for MMMM) or
             // the desired format does not have alpha months (in some locales liks 'cs'
             // skeletons for MMM have pattern with M), then try the other width for same
@@ -1223,7 +1228,8 @@ public class ExampleGenerator {
         if (dateFormat == null) {
             return;
         }
-        SimpleDateFormat sdf = icuServiceBuilder.getDateFormat(calendarId, dateFormat);
+        SimpleDateFormat sdf =
+                icuServiceBuilder.getDateFormat(calendarId, dateFormat, numberingSystem);
         sdf.setTimeZone(ZONE_SAMPLE);
         DateFormatSymbols dfs = sdf.getDateFormatSymbols();
         // We do not know whether dateFormat is using MMMM, MMM, LLLL or LLL so
@@ -1245,7 +1251,8 @@ public class ExampleGenerator {
         examples.add(sdf.format(DATE_SAMPLE));
     }
 
-    private void handleDayOfMonths(XPathParts parts, String value, List<String> examples) {
+    private void handleDayOfMonths(
+            XPathParts parts, String value, List<String> examples, String numberSystem) {
         // ldml/dates/☹calendars/calendar[@type="gregorian"]/dayOfMonths/dayOfMonthContext[@type="format"]/dayOfMonthWidth[@type="abbreviated"]/dayOfMonth[@ordinal="few"]
         String rawOrdinal = parts.getAttributeValue(-1, "ordinal");
         if (rawOrdinal == null) {
@@ -1292,7 +1299,8 @@ public class ExampleGenerator {
                                                             + "'")
                                             + backgroundEndSymbol;
                             SimpleDateFormat format =
-                                    icuServiceBuilder.getDateFormat(calendarId, pattern2);
+                                    icuServiceBuilder.getDateFormat(
+                                            calendarId, pattern2, numberSystem);
                             examples.add(format.format(DATE_SAMPLE));
                         });
     }
@@ -1817,7 +1825,8 @@ public class ExampleGenerator {
         }
     }
 
-    private void handleIntervalFormats(XPathParts parts, String value, List<String> examples) {
+    private void handleIntervalFormats(
+            XPathParts parts, String value, List<String> examples, String numberingSystem) {
         switch (parts.getElement(6)) {
             case "intervalFormatFallback":
                 {
@@ -1847,8 +1856,20 @@ public class ExampleGenerator {
                 break;
             default:
                 {
-                    addIntervalExample(FIRST_INTERVAL, SECOND_INTERVAL, parts, value, examples);
-                    addIntervalExample(FIRST_INTERVAL2, SECOND_INTERVAL2, parts, value, examples);
+                    addIntervalExample(
+                            FIRST_INTERVAL,
+                            SECOND_INTERVAL,
+                            parts,
+                            value,
+                            examples,
+                            numberingSystem);
+                    addIntervalExample(
+                            FIRST_INTERVAL2,
+                            SECOND_INTERVAL2,
+                            parts,
+                            value,
+                            examples,
+                            numberingSystem);
                     Set<String> relatedPatterns =
                             RelatedDatePathValues.getRelatedPathValues(cldrFile, parts);
                     if (!relatedPatterns.isEmpty()) {
@@ -1858,7 +1879,8 @@ public class ExampleGenerator {
                                     icuServiceBuilder.getDateFormat(
                                             parts.getAttributeValue(
                                                     RelatedDatePathValues.calendarElement, "type"),
-                                            pattern);
+                                            pattern,
+                                            numberingSystem);
                             examples.add(sdf.format(FIRST_INTERVAL));
                             examples.add(sdf.format(FIRST_INTERVAL2));
                         }
@@ -1884,7 +1906,8 @@ public class ExampleGenerator {
             Map<String, Date> laterMap,
             XPathParts parts,
             String value,
-            List<String> examples) {
+            List<String> examples,
+            String numberingSystem) {
         String greatestDifference = parts.getAttributeValue(-1, "id");
 
         // Choose an example interval suitable for the symbol. If testing years, use an interval
@@ -1900,7 +1923,7 @@ public class ExampleGenerator {
         // Example:
         // ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="yMd"]/greatestDifference[@id="y"]
         // Find where to split the value
-        intervalFormat.setPattern(parts, value);
+        intervalFormat.setPattern(parts, value, numberingSystem);
         Date later = laterMap.get(greatestDifference);
         if (later != null) {
 
@@ -2140,7 +2163,6 @@ public class ExampleGenerator {
      *
      * @param parts
      * @param value
-     * @return
      */
     private void handleMonthPatterns(XPathParts parts, String value, List<String> examples) {
         String calendar = parts.getAttributeValue(3, "type");
@@ -2155,7 +2177,8 @@ public class ExampleGenerator {
         examples.add(invertBackground(format(setBackground(value), month)));
     }
 
-    private void handleAppendItems(XPathParts parts, String value, List<String> examples) {
+    private void handleAppendItems(
+            XPathParts parts, String value, List<String> examples, String numberingSystem) {
         // Example parts:
         // //ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/appendItems/appendItem[@request="Timezone"]
         String request = parts.getAttributeValue(-1, "request");
@@ -2163,7 +2186,7 @@ public class ExampleGenerator {
         // what we append to
         int dateIndex = 0;
         int timeIndex = 0;
-        String toAppend = "";
+        String toAppend;
         switch (request) {
             case "Era":
                 dateIndex = DateFormat.MEDIUM;
@@ -2195,7 +2218,8 @@ public class ExampleGenerator {
                         getGMTFormat(
                                 null,
                                 cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtFormat"),
-                                8);
+                                8,
+                                numberingSystem);
                 break;
             case "Date-Timezone":
                 dateIndex = DateFormat.MEDIUM;
@@ -2203,7 +2227,8 @@ public class ExampleGenerator {
                         getGMTFormat(
                                 null,
                                 cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtFormat"),
-                                8);
+                                8,
+                                numberingSystem);
                 break;
             default:
                 return;
@@ -2243,7 +2268,7 @@ public class ExampleGenerator {
         }
 
         @SuppressWarnings("deprecation")
-        public IntervalFormat setPattern(XPathParts parts, String pattern) {
+        public IntervalFormat setPattern(XPathParts parts, String pattern, String numberingSystem) {
             if (formatParser == null || pattern == null) {
                 return this;
             }
@@ -2286,17 +2311,21 @@ public class ExampleGenerator {
                 }
             }
             String calendar = parts.findAttributeValue("calendar", "type");
-            firstFormat = icuServiceBuilder.getDateFormat(calendar, first.toString());
+            firstFormat =
+                    icuServiceBuilder.getDateFormat(calendar, first.toString(), numberingSystem);
             firstFormat.setTimeZone(GMT_ZONE_SAMPLE);
 
-            secondFormat = icuServiceBuilder.getDateFormat(calendar, second.toString());
+            secondFormat =
+                    icuServiceBuilder.getDateFormat(calendar, second.toString(), numberingSystem);
             secondFormat.setTimeZone(GMT_ZONE_SAMPLE);
             return this;
         }
     }
 
-    private void handleDurationUnit(String value, List<String> examples) {
-        DateFormat df = this.icuServiceBuilder.getDateFormat("gregorian", value.replace('h', 'H'));
+    private void handleDurationUnit(String value, List<String> examples, String numberingSystem) {
+        DateFormat df =
+                this.icuServiceBuilder.getDateFormat(
+                        "gregorian", value.replace('h', 'H'), numberingSystem);
         df.setTimeZone(TimeZone.GMT_ZONE);
         long time = ((5 * 60 + 37) * 60 + 23) * 1000;
         try {
@@ -2479,7 +2508,7 @@ public class ExampleGenerator {
 
     private String addExampleResult(String resultItem, String resultToAddTo, boolean showContexts) {
         if (!showContexts) {
-            if (resultToAddTo.length() != 0) {
+            if (!resultToAddTo.isEmpty()) {
                 resultToAddTo += exampleSeparatorSymbol;
             }
             resultToAddTo += resultItem;
@@ -2613,7 +2642,8 @@ public class ExampleGenerator {
         examples.add(x.format(NUMBER_SAMPLE_WHOLE));
     }
 
-    private void handleTimeZoneName(XPathParts parts, String value, List<String> examples) {
+    private void handleTimeZoneName(
+            XPathParts parts, String value, List<String> examples, String numberingSystem) {
         String result = null;
         if (parts.contains("exemplarCity")) {
             // ldml/dates/timeZoneNames/zone[@type="America/Los_Angeles"]/exemplarCity
@@ -2633,7 +2663,7 @@ public class ExampleGenerator {
                 try {
                     String hourOffset = timezone.substring(timezone.contains("+") ? 8 : 7);
                     int hours = Integer.parseInt(hourOffset);
-                    result = getGMTFormat(null, null, hours);
+                    result = getGMTFormat(null, null, hours, numberingSystem);
                 } catch (RuntimeException e) {
                     return; // fail, skip
                 }
@@ -2670,13 +2700,13 @@ public class ExampleGenerator {
                                     "//ldml/dates/timeZoneNames/zone[@type=\"America/Cancun\"]/exemplarCity"));
             result = format(value, cancun, central);
         } else if (parts.contains("gmtFormat")) { // GMT{0}
-            result = getGMTFormat(null, value, -8);
+            result = getGMTFormat(null, value, -8, numberingSystem);
         } else if (parts.contains("hourFormat")) { // +HH:mm;-HH:mm
-            result = getGMTFormat(value, null, -8);
+            result = getGMTFormat(value, null, -8, numberingSystem);
         } else if (parts.contains("metazone")
                 && !parts.contains("commonlyUsed")) { // Metazone string
-            if (value != null && value.length() > 0) {
-                result = getMZTimeFormat() + " " + value;
+            if (value != null && !value.isEmpty()) {
+                result = getMZTimeFormat(numberingSystem) + " " + value;
             } else {
                 // TODO check for value
                 if (parts.contains("generic")) {
@@ -2693,7 +2723,9 @@ public class ExampleGenerator {
                                             + "\"]");
                     result =
                             setBackground(
-                                    getMZTimeFormat() + " " + format(regionFormat, countryName));
+                                    getMZTimeFormat(numberingSystem)
+                                            + " "
+                                            + format(regionFormat, countryName));
                 } else {
                     String gmtFormat =
                             cldrFile.getWinningValue("//ldml/dates/timeZoneNames/gmtFormat");
@@ -2713,13 +2745,14 @@ public class ExampleGenerator {
                                     / DateConstants.MILLIS_PER_MINUTE;
                     result =
                             setBackground(
-                                    getMZTimeFormat()
+                                    getMZTimeFormat(numberingSystem)
                                             + " "
                                             + getGMTFormat(
                                                     hourFormat,
                                                     gmtFormat,
                                                     (int) tm_hrs,
-                                                    (int) tm_mins));
+                                                    (int) tm_mins,
+                                                    numberingSystem));
                 }
             }
         } else if (parts.getElement(-1).equals("dualOffsetFormat")) {
@@ -2730,7 +2763,11 @@ public class ExampleGenerator {
 
     @SuppressWarnings("deprecation")
     private void handleDateFormatItem(
-            String xpath, String value, boolean showContexts, List<String> examples) {
+            String xpath,
+            String value,
+            boolean showContexts,
+            List<String> examples,
+            String numberingSystem) {
         // Get here if parts contains "calendar" and either of "pattern", "dateFormatItem"
 
         String fullpath = cldrFile.getFullXPath(xpath);
@@ -2804,7 +2841,8 @@ public class ExampleGenerator {
                                 setBackground(tlfResult),
                                 calendar,
                                 value,
-                                icuServiceBuilder));
+                                icuServiceBuilder,
+                                numberingSystem));
 
                 // Handle date plus a single short time.
                 examples.add(
@@ -2813,7 +2851,8 @@ public class ExampleGenerator {
                                 setBackground(tsfResult),
                                 calendar,
                                 value,
-                                icuServiceBuilder));
+                                icuServiceBuilder,
+                                numberingSystem));
             }
             if (formatType.contentEquals("standard")) {
                 // Examples for standard pattern
@@ -2840,7 +2879,8 @@ public class ExampleGenerator {
                                     setBackground(timeRange),
                                     calendar,
                                     value,
-                                    icuServiceBuilder));
+                                    icuServiceBuilder,
+                                    numberingSystem));
 
                     // Handle relative date plus short time range
                     examples.add(
@@ -2849,7 +2889,8 @@ public class ExampleGenerator {
                                     setBackground(timeRange),
                                     calendar,
                                     value,
-                                    icuServiceBuilder));
+                                    icuServiceBuilder,
+                                    numberingSystem));
                 }
             }
             if (formatType.contentEquals("relative")) {
@@ -2862,7 +2903,8 @@ public class ExampleGenerator {
                                 setBackground(tsfResult),
                                 calendar,
                                 value,
-                                icuServiceBuilder));
+                                icuServiceBuilder,
+                                numberingSystem));
             }
 
             return;
@@ -2872,9 +2914,13 @@ public class ExampleGenerator {
                 examples.add(startItalicSymbol + "n/a" + endItalicSymbol);
                 return;
             } else {
-                String numbersOverride = parts.findAttributeValue("pattern", "numbers");
+                String numberingSystemOverride = parts.findAttributeValue("pattern", "numbers");
+                // numberingSystemOverride may get null here; equivalent to
+                // ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT.
+                // Note that handleDateFormatItem also has numberingSystem as a parameter, but it is
+                // not used here.
                 SimpleDateFormat sdf =
-                        icuServiceBuilder.getDateFormat(calendar, value, numbersOverride);
+                        icuServiceBuilder.getDateFormat(calendar, value, numberingSystemOverride);
                 String defaultNumberingSystem =
                         cldrFile.getWinningValue("//ldml/numbers/defaultNumberingSystem");
                 String timeSeparator =
@@ -2891,7 +2937,7 @@ public class ExampleGenerator {
                     if (value.contains("MMM") || value.contains("LLL")) {
                         // alpha month, do not need context examples
                         examples.add(formatWithOrdinalHack(sdf, calendar, DATE_SAMPLE));
-                        addRelatedAvailable(parts, calendar, numbersOverride, dfs, examples);
+                        addRelatedAvailable(parts, calendar, numberingSystem, dfs, examples);
                         return;
                     } else {
                         // Use contextExamples if showContexts T
@@ -2909,7 +2955,7 @@ public class ExampleGenerator {
                             example = addExampleResult(sub_ten_example, example, showContexts);
                         }
                         examples.add(example);
-                        addRelatedAvailable(parts, calendar, numbersOverride, dfs, examples);
+                        addRelatedAvailable(parts, calendar, numberingSystem, dfs, examples);
                         return;
                     }
                 } else {
@@ -2946,7 +2992,7 @@ public class ExampleGenerator {
     private void addRelatedAvailable(
             XPathParts parts,
             String calendar,
-            String numbersOverride,
+            String numberingSystem,
             DateFormatSymbols dfs,
             List<String> examples) {
         Set<String> related = RelatedDatePathValues.getRelatedPathValues(cldrFile, parts);
@@ -2957,7 +3003,7 @@ public class ExampleGenerator {
                             x -> {
                                 SimpleDateFormat sdf2 =
                                         icuServiceBuilder.getDateFormat(
-                                                calendar, x, numbersOverride);
+                                                calendar, x, numberingSystem);
                                 sdf2.setDateFormatSymbols(dfs);
                                 sdf2.setTimeZone(ZONE_SAMPLE);
                                 String example2 =
@@ -3086,7 +3132,7 @@ public class ExampleGenerator {
         if (!typeIsEnglish) {
             loc = CLDRLocale.getInstance(cldrFile.getLocaleID());
             territory = loc.getCountry();
-            if (territory == null || territory.length() == 0) {
+            if (territory == null || territory.isEmpty()) {
                 loc = supplementalDataInfo.getDefaultContentFromBase(loc);
                 if (loc != null) {
                     territory = loc.getCountry();
@@ -3097,7 +3143,7 @@ public class ExampleGenerator {
                     }
                 }
             }
-            if (territory == null || territory.length() == 0) {
+            if (territory == null || territory.isEmpty()) {
                 territory = "US";
             }
         }
@@ -3167,7 +3213,7 @@ public class ExampleGenerator {
 
         switch (element) {
             case "rationalPattern":
-                Pair<String, String> simpleFractionPair = null;
+                Pair<String, String> simpleFractionPair;
                 List<Pair<String, String>> fractionPairs = new ArrayList<>();
                 Pair<String, String> extraPair = null;
                 if (isLatin) {
@@ -3287,7 +3333,7 @@ public class ExampleGenerator {
         String temp = String.valueOf(numberSample);
         int fractionLength = temp.endsWith(".0") ? 0 : temp.length() - temp.indexOf('.') - 1;
         if (fractionLength != numberFormat.getMaximumFractionDigits()) {
-            numberFormat = (DecimalFormat) numberFormat.clone(); // for safety
+            numberFormat = numberFormat.clone(); // for safety
             numberFormat.setMinimumFractionDigits(fractionLength);
             numberFormat.setMaximumFractionDigits(fractionLength);
         }
@@ -3361,7 +3407,8 @@ public class ExampleGenerator {
     }
 
     /** Add examples for eras. Generates a sample date based on this info and formats it */
-    private void handleEras(XPathParts parts, String value, List<String> examples) {
+    private void handleEras(
+            XPathParts parts, String value, List<String> examples, String numberingSystem) {
         String calendarId = parts.getAttributeValue(3, "type");
         String type = parts.getAttributeValue(-1, "type");
         String id = calendarId;
@@ -3412,7 +3459,7 @@ public class ExampleGenerator {
             endCal.setTimeInMillis(endCal.getTimeInMillis() - (DateConstants.MILLIS_PER_DAY));
         }
 
-        GregorianCalendar sampleDate = null;
+        GregorianCalendar sampleDate;
 
         if (startCal != null && endCal != null) {
             // roll back a day to not hit the edge
@@ -3445,7 +3492,8 @@ public class ExampleGenerator {
         String checkPath = getAvailablePath(calendarId, skeleton);
 
         String dateFormat = cldrFile.getWinningValue(checkPath);
-        SimpleDateFormat sdf = icuServiceBuilder.getDateFormat(calendarId, dateFormat);
+        SimpleDateFormat sdf =
+                icuServiceBuilder.getDateFormat(calendarId, dateFormat, numberingSystem);
         DateFormatSymbols dfs = sdf.getDateFormatSymbols();
         String[] eraNames = dfs.getEras();
         eraNames[typeIndex] = value; // overwrite era to current value
@@ -3466,7 +3514,8 @@ public class ExampleGenerator {
      * Add examples for quarters for the gregorian calendar, matching each quarter type (1, 2, 3, 4)
      * to a corresponding sample month and formatting an example with that date
      */
-    void handleQuarters(XPathParts parts, String value, List<String> examples) {
+    void handleQuarters(
+            XPathParts parts, String value, List<String> examples, String numberingSystem) {
         String calendarId = parts.getAttributeValue(3, "type");
         if (!calendarId.equals("gregorian")) {
             return;
@@ -3475,13 +3524,13 @@ public class ExampleGenerator {
         if (width.equals("narrow")) {
             return;
         }
-        String context = parts.findAttributeValue("quarterContext", "type");
         String type = parts.getAttributeValue(-1, "type"); // 1-indexed
         int quarterIndex = Integer.parseInt(type) - 1;
         String skeleton = (width.equals("wide")) ? "yQQQQ" : "yQQQ";
         String checkPath = getAvailablePath(calendarId, skeleton);
         String dateFormat = cldrFile.getWinningValue(checkPath);
-        SimpleDateFormat sdf = icuServiceBuilder.getDateFormat(calendarId, dateFormat);
+        SimpleDateFormat sdf =
+                icuServiceBuilder.getDateFormat(calendarId, dateFormat, numberingSystem);
         DateFormatSymbols dfs = sdf.getDateFormatSymbols();
         int widthVal = width.equals("abbreviated") ? 0 : 1;
         String[] quarterNames = dfs.getQuarters(0, widthVal); // 0 for formatting
@@ -3502,7 +3551,11 @@ public class ExampleGenerator {
      * numeric example corresponds to the count represented by the item.
      */
     private void handleRelative(
-            String xpath, XPathParts parts, String value, List<String> examples) {
+            String xpath,
+            XPathParts parts,
+            String value,
+            List<String> examples,
+            String numberingSystem) {
         String skeleton;
         String type = parts.findAttributeValue("field", "type");
         if (type.startsWith("hour")) {
@@ -3521,7 +3574,8 @@ public class ExampleGenerator {
                         + skeleton
                         + "\"]";
         String dateFormat = cldrFile.getWinningValue(availableFormatPath);
-        SimpleDateFormat sdf = icuServiceBuilder.getDateFormat("gregorian", dateFormat);
+        SimpleDateFormat sdf =
+                icuServiceBuilder.getDateFormat("gregorian", dateFormat, numberingSystem);
         String sampleDate = formatWithOrdinalHack(sdf, "gregorian", DATE_SAMPLE);
 
         String contextTransformPath =
@@ -4040,11 +4094,17 @@ public class ExampleGenerator {
      * @param hours
      * @return
      */
-    private String getGMTFormat(String gmtHourString, String gmtFormat, int hours) {
-        return getGMTFormat(gmtHourString, gmtFormat, hours, 0);
+    private String getGMTFormat(
+            String gmtHourString, String gmtFormat, int hours, String numberingSystem) {
+        return getGMTFormat(gmtHourString, gmtFormat, hours, 0, numberingSystem);
     }
 
-    private String getGMTFormat(String gmtHourString, String gmtFormat, int hours, int minutes) {
+    private String getGMTFormat(
+            String gmtHourString,
+            String gmtFormat,
+            int hours,
+            int minutes,
+            String numberingSystem) {
         boolean hoursBackground = false;
         if (gmtHourString == null) {
             hoursBackground = true;
@@ -4055,7 +4115,7 @@ public class ExampleGenerator {
             gmtFormat =
                     setBackground(cldrFile.getWinningValue("//ldml/dates/timeZoneNames/gmtFormat"));
         }
-        String hourString = getHourString(gmtHourString, hours, minutes);
+        String hourString = getHourString(gmtHourString, hours, minutes, numberingSystem);
         if (hoursBackground) {
             hourString = setBackground(hourString);
         }
@@ -4063,11 +4123,13 @@ public class ExampleGenerator {
         return result;
     }
 
-    private String getHourString(String gmtHourString, int hours, int minutes) {
+    private String getHourString(
+            String gmtHourString, int hours, int minutes, String numberingSystem) {
         String[] plusMinus = gmtHourString.split(";");
 
         SimpleDateFormat dateFormat =
-                icuServiceBuilder.getDateFormat("gregorian", plusMinus[hours >= 0 ? 0 : 1]);
+                icuServiceBuilder.getDateFormat(
+                        "gregorian", plusMinus[hours >= 0 ? 0 : 1], numberingSystem);
         dateFormat.setTimeZone(ZONE_SAMPLE);
         calendar.set(1999, 9, 27, Math.abs(hours), minutes, 0); // 1999-09-13 13:25:59
         Date sample = calendar.getTime();
@@ -4092,7 +4154,7 @@ public class ExampleGenerator {
         return formattedWithGmt;
     }
 
-    private String getMZTimeFormat() {
+    private String getMZTimeFormat(String numberingSystem) {
         String timeFormat =
                 cldrFile.getWinningValue(
                         "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/timeFormats/timeFormatLength[@type=\"short\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
@@ -4100,7 +4162,8 @@ public class ExampleGenerator {
             timeFormat = "HH:mm";
         }
         // the following is <= because the TZDB inverts the hours
-        SimpleDateFormat dateFormat = icuServiceBuilder.getDateFormat("gregorian", timeFormat);
+        SimpleDateFormat dateFormat =
+                icuServiceBuilder.getDateFormat("gregorian", timeFormat, numberingSystem);
         dateFormat.setTimeZone(ZONE_SAMPLE);
         calendar.set(1999, 9, 13, 13, 25, 59); // 1999-09-13 13:25:59
         Date sample = calendar.getTime();
@@ -4220,7 +4283,6 @@ public class ExampleGenerator {
      * Convenience function for getting a formatted path from the current file. Example use:
      * getStringValue("//ldml/%s", "localeDisplayNames")
      *
-     * @param file CLDRFile to use
      * @param path Example: "//ldml/%s"
      * @param args
      * @return result or null
@@ -4233,7 +4295,6 @@ public class ExampleGenerator {
      * Convenience function for getting a formatted path from the current file, fallign back to
      * English Example use: getStringValue("//ldml/%s", "localeDisplayNames")
      *
-     * @param file CLDRFile to use
      * @param path Example: "//ldml/%s"
      * @param args
      * @return result or null

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
@@ -119,7 +119,9 @@ class FlexibleDateFromCLDR {
                 String pat = gen.getBestPattern(item);
                 String sample = "<can't format>";
                 try {
-                    DateFormat df = icuServiceBuilder.getDateFormat("gregorian", pat);
+                    DateFormat df =
+                            icuServiceBuilder.getDateFormat(
+                                    "gregorian", pat, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                     sample = df.format(new Date());
                 } catch (RuntimeException e) {
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
@@ -367,7 +367,8 @@ public class GenerateDateTimeTestData {
                             calendar,
                             dateLength,
                             dateTimeGluePatternFormatType,
-                            icuServiceBuilder);
+                            icuServiceBuilder,
+                            ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
         }
 
         return formattedDateTime;
@@ -1111,7 +1112,9 @@ public class GenerateDateTimeTestData {
             //   glue pattern rather than use ICU to get it
             DateTimeFormats formats =
                     new DateTimeFormats(CLDR_FACTORY, localeCldrFile, calendarStr, false);
-            SimpleDateFormat formatterForSkeleton = formats.getDateFormatFromSkeleton(skeleton);
+            SimpleDateFormat formatterForSkeleton =
+                    formats.getDateFormatFromSkeleton(
+                            skeleton, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
             formatterForSkeleton.setCalendar(testCaseInput.calendar);
             formatterForSkeleton.setTimeZone(testCaseInput.timeZone);
             String timeZoneIdStr = testCaseInput.timeZone.getID();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -160,19 +160,13 @@ public class GeneratePluralRanges {
         final ICUServiceBuilder icusb =
                 CLDRConfig.getInstance().getCldrFactory().getICUServiceBuilder(loc);
         DecimalFormat nf = icusb.getNumberFormat(1);
-        // String decimal =
-        // cldrFile.getWinningValue("//ldml/numbers/symbols[@numberSystem=\"latn\"]/decimal");
         String defaultNumberingSystem =
-                cldrFile.getWinningValue("//ldml/numbers/defaultNumberingSystem");
+                cldrFile.getWinningValue(CLDRFile.NumberingSystem.defaultSystem.path);
         String range =
                 cldrFile.getWinningValue(
                         "//ldml/numbers/miscPatterns[@numberSystem=\""
                                 + defaultNumberingSystem
                                 + "\"]/pattern[@type=\"range\"]");
-
-        //            if (decimal == null) {
-        //                throw new IllegalArgumentException();
-        //            }
         for (Count s : counts) {
             for (Count e : counts) {
                 if (!pluralInfo.rangeExists(s, e, minSample, maxSample)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -585,6 +585,7 @@ public class GenerateProductionData {
 
     private static final String[] SPECIAL_PATHS =
             new String[] {
+                // Cf. CLDRFile.NumberingSystem.defaultSystem.path
                 "//ldml/numbers/defaultNumberingSystem",
                 "//ldml/numbers/defaultNumberingSystem[@alt=\"latn\"]"
             };

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
@@ -8,6 +8,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.DateTimeFormats;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.ICUServiceBuilder;
 
 public class GenerateSeedDurations {
     /*
@@ -52,7 +53,9 @@ public class GenerateSeedDurations {
             DateTimeFormats formats = new DateTimeFormats(cldrFactory, cldrFile, "gregorian");
             System.out.println("    <numericUnits>");
             for (String numericUnit : numericUnits) {
-                SimpleDateFormat pattern = formats.getDateFormatFromSkeleton(numericUnit);
+                SimpleDateFormat pattern =
+                        formats.getDateFormatFromSkeleton(
+                                numericUnit, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                 String patternString = pattern.toPattern();
                 if (numericUnit.contains("H")) {
                     if (!patternString.contains("H")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -1324,13 +1324,14 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             String calendar,
             String length,
             String formatType,
-            ICUServiceBuilder icuServiceBuilder) {
+            ICUServiceBuilder icuServiceBuilder,
+            String numberingSystem) {
         // calls getDateTimeFormatXpath, load the glue pattern, then call
         // glueDateTimeFormatWithGluePattern
         String xpath = this.getDateTimeFormatXpath(calendar, length, formatType);
         String gluePattern = this.getWinningValue(xpath);
         return this.glueDateTimeFormatWithGluePattern(
-                date, time, calendar, gluePattern, icuServiceBuilder);
+                date, time, calendar, gluePattern, icuServiceBuilder, numberingSystem);
     }
 
     public String glueDateTimeFormatWithGluePattern(
@@ -1338,9 +1339,11 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             String time,
             String calendar,
             String gluePattern,
-            ICUServiceBuilder icuServiceBuilder) {
+            ICUServiceBuilder icuServiceBuilder,
+            String numberingSystem) {
         // uses SimpleDateFormat to get rid of quotes
-        SimpleDateFormat temp = icuServiceBuilder.getDateFormat(calendar, gluePattern, null);
+        SimpleDateFormat temp =
+                icuServiceBuilder.getDateFormat(calendar, gluePattern, numberingSystem);
         TimeZone tempTimeZone = TimeZone.GMT_ZONE;
         Calendar tempCalendar = Calendar.getInstance(tempTimeZone, ULocale.ENGLISH);
         Date tempDate = tempCalendar.getTime();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrDateTimePatternGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrDateTimePatternGenerator.java
@@ -139,7 +139,7 @@ public class CldrDateTimePatternGenerator {
     }
 
     private void initDecimal() {
-        String ns = file.getStringValueWithBailey("//ldml/numbers/defaultNumberingSystem");
+        String ns = file.getStringValueWithBailey(CLDRFile.NumberingSystem.defaultSystem.path);
         if (ns == null) {
             ns = "latn";
         }
@@ -809,7 +809,7 @@ public class CldrDateTimePatternGenerator {
     /**
      * Checks if a field with a given character and length is numeric or text.
      *
-     * @param field the field string, like "MMM"
+     * @param fieldString the field string, like "MMM"
      * @return true if numeric, false if text
      */
     private static boolean isNumeric(CharSequence fieldString) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrIntervalFormat.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrIntervalFormat.java
@@ -46,7 +46,11 @@ public class CldrIntervalFormat {
     }
 
     public String format(
-            Date earlier, Date later, ICUServiceBuilder icuServiceBuilder, TimeZone timezone) {
+            Date earlier,
+            Date later,
+            ICUServiceBuilder icuServiceBuilder,
+            TimeZone timezone,
+            String numberingSystem) {
         if (earlier == null || later == null) {
             return null;
         }
@@ -59,10 +63,12 @@ public class CldrIntervalFormat {
             earlier = later;
             later = tmp;
         }
-        DateFormat firstFormat = icuServiceBuilder.getDateFormat(calendar, firstPattern);
+        DateFormat firstFormat =
+                icuServiceBuilder.getDateFormat(calendar, firstPattern, numberingSystem);
         firstFormat.setTimeZone(timezone);
 
-        DateFormat secondFormat = icuServiceBuilder.getDateFormat(calendar, secondPattern);
+        DateFormat secondFormat =
+                icuServiceBuilder.getDateFormat(calendar, secondPattern, numberingSystem);
         firstFormat.setTimeZone(timezone);
 
         String formatted1 = firstFormat.format(earlier);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -16,14 +16,14 @@ import com.ibm.icu.util.GregorianCalendar;
 import com.ibm.icu.util.ICUUncheckedIOException;
 import com.ibm.icu.util.Output;
 import com.ibm.icu.util.TimeZone;
-import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.unicode.cldr.draft.FileUtilities;
+import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.tool.ChartDelta;
 import org.unicode.cldr.tool.FormattedFileWriter;
 import org.unicode.cldr.tool.Option;
@@ -72,7 +73,6 @@ public class DateTimeFormats {
     private static final String TIMES_24H_TITLE = "Times 24h";
     private static final boolean DEBUG = false;
     private static final String DEBUG_SKELETON = "y";
-    private static final ULocale DEBUG_LIST_PATTERNS = ULocale.JAPANESE; // or null;
 
     private static final String FIELDS_TITLE = "Fields";
 
@@ -200,7 +200,7 @@ public class DateTimeFormats {
      * @return the request name, e.g., "Era", or null if not found
      */
     public static String getAppendRequestName(char fieldChar) {
-        int field = -1;
+        int field;
         try {
             field =
                     new com.ibm.icu.text.DateTimePatternGenerator.VariableField(
@@ -223,7 +223,7 @@ public class DateTimeFormats {
      * @return the field name key, e.g., "era", or null if not found
      */
     public static String getFieldDisplayNameKey(char fieldChar) {
-        int field = -1;
+        int field;
         try {
             field =
                     new com.ibm.icu.text.DateTimePatternGenerator.VariableField(
@@ -248,8 +248,6 @@ public class DateTimeFormats {
     };
     private static final Date SAMPLE_DATE = new Date(2012 - 1900, 0, 13, 14, 45, 59);
 
-    private static final String SAMPLE_DATE_STRING = CldrUtility.isoFormat(SAMPLE_DATE);
-
     private static final Map<String, Date> SAMPLE_DATE_END =
             ImmutableMap.<String, Date>builder()
                     .put("G", SAMPLE_DATE_DEFAULT_END)
@@ -266,18 +264,6 @@ public class DateTimeFormats {
                     .put("H", new Date(2012 - 1900, 0, 13, 15, 45, 59))
                     .put("m", new Date(2012 - 1900, 0, 13, 14, 46, 59))
                     .build();
-    //        // "G", "y", "M",
-    //        null, new Date(2013 - 1900, 0, 13, 14, 45, 59), new Date(2012 - 1900, 1, 13, 14, 45,
-    // 59),
-    //        // "w", "W", "d",
-    //        null, null, new Date(2012 - 1900, 0, 14, 14, 45, 59),
-    //        // "D", "E", "F",
-    //        null, new Date(2012 - 1900, 0, 14, 14, 45, 59), null,
-    //        // "a", "h", "H",
-    //        new Date(2012 - 1900, 0, 13, 2, 45, 59), new Date(2012 - 1900, 0, 13, 15, 45, 59),
-    //        new Date(2012 - 1900, 0, 13, 15, 45, 59),
-    //        // "m",
-    //        new Date(2012 - 1900, 0, 13, 14, 46, 59)
 
     private final CldrDateTimePatternGenerator generator;
     private final ICUServiceBuilder icuServiceBuilder;
@@ -303,12 +289,10 @@ public class DateTimeFormats {
      *
      * @param file
      * @param calendarID
-     * @return
      */
     public DateTimeFormats(Factory f, CLDRFile file, String calendarID, boolean useStock) {
         this.file = file;
         final String localeId = file.getLocaleID();
-        ULocale locale = new ULocale(localeId);
         CLDRLocale loc = CLDRLocale.getInstance(localeId);
         CLDRLocale locEn = CLDRLocale.getInstance("en");
         this.icuServiceBuilder = f.getICUServiceBuilder(loc);
@@ -508,7 +492,7 @@ public class DateTimeFormats {
     };
 
     private class Diff {
-        Set<String> availablePatterns = generator.getBaseSkeletons(new LinkedHashSet<String>());
+        Set<String> availablePatterns = generator.getBaseSkeletons(new LinkedHashSet<>());
 
         {
             for (Entry<String, Set<String>> pat : dateIntervalInfo.getPatterns().entrySet()) {
@@ -529,14 +513,13 @@ public class DateTimeFormats {
      *
      * @param comparison
      * @param output
+     * @param numberingSystem
      */
-    public void addTable(DateTimeFormats comparison, Appendable output) {
+    public void addTable(DateTimeFormats comparison, Appendable output, String numberingSystem) {
         UnicodeSet allEscapedCharactersFound = new UnicodeSet();
         try {
             output.append(
-                    "<h2>"
-                            + hackDoubleLinked("Patterns")
-                            + "</h2>"
+                    "<h2>Patterns</h2>"
                             + "<p>Normally, there is a single line containing an example in each Native Example cell. "
                             + (!isRTL
                                     ? ""
@@ -590,8 +573,11 @@ public class DateTimeFormats {
                             RowStyle.normal,
                             name,
                             skeleton,
-                            comparison.getExample(skeleton, allEscapedCharactersFound),
-                            getExample(skeleton, allEscapedCharactersFound),
+                            comparison.getExample(
+                                    skeleton,
+                                    allEscapedCharactersFound,
+                                    ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT),
+                            getExample(skeleton, allEscapedCharactersFound, numberingSystem),
                             diff.isPresent(skeleton));
                 }
             }
@@ -629,8 +615,11 @@ public class DateTimeFormats {
                             RowStyle.normal,
                             skeleton,
                             skeleton,
-                            comparison.getExample(skeleton, allEscapedCharactersFound),
-                            getExample(skeleton, allEscapedCharactersFound),
+                            comparison.getExample(
+                                    skeleton,
+                                    allEscapedCharactersFound,
+                                    ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT),
+                            getExample(skeleton, allEscapedCharactersFound, numberingSystem),
                             true);
                 }
             }
@@ -654,12 +643,14 @@ public class DateTimeFormats {
      *
      * @param skeleton
      * @param escapedCharactersFound Any characters that were escaped are added to this.
-     * @return
+     * @param numberingSystem the numbering system, or ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT
+     * @return the example as an HTML string
      */
-    private String getExample(String skeleton, UnicodeSet escapedCharactersFound) {
+    private String getExample(
+            String skeleton, UnicodeSet escapedCharactersFound, String numberingSystem) {
         String example;
         if (skeleton.contains("®")) {
-            example = getRelativeExampleFromSkeleton(skeleton);
+            example = getRelativeExampleFromSkeleton(skeleton, numberingSystem);
         } else {
             int slashPos = skeleton.indexOf('/');
             if (slashPos >= 0) {
@@ -669,10 +660,10 @@ public class DateTimeFormats {
                                 mainSkeleton,
                                 dateIntervalInfo,
                                 icuServiceBuilder.getDateFormat(
-                                        calendarID, generator.getBestPattern(mainSkeleton)));
+                                        calendarID,
+                                        generator.getBestPattern(mainSkeleton),
+                                        numberingSystem));
                 String diffString = skeleton.substring(slashPos + 1).replace('j', 'H');
-                //                int diffNumber = find(CALENDAR_FIELD_TO_PATTERN_LETTER,
-                // diffString);
                 Date endDate = SAMPLE_DATE_END.get(diffString);
                 try {
                     example =
@@ -685,7 +676,7 @@ public class DateTimeFormats {
                 if (skeleton.equals(DEBUG_SKELETON)) {
                     int debug = 0;
                 }
-                SimpleDateFormat format = getDateFormatFromSkeleton(skeleton);
+                SimpleDateFormat format = getDateFormatFromSkeleton(skeleton, numberingSystem);
                 format.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
                 example =
                         ICUServiceBuilder.formatWithOrdinalHack(
@@ -746,7 +737,7 @@ public class DateTimeFormats {
             Matcher m = RELATIVE_DATE.matcher(skeleton);
             if (m.matches()) {
                 type = m.group(1);
-                String length = m.group(2);
+                // String length = m.group(2);
                 offset = Integer.parseInt(m.group(3));
                 String temp = m.group(4);
                 time =
@@ -782,7 +773,7 @@ public class DateTimeFormats {
         }
     }
 
-    private String getRelativeExampleFromSkeleton(String skeleton) {
+    private String getRelativeExampleFromSkeleton(String skeleton, String numberingSystem) {
         RelativePattern rp = new RelativePattern(file, skeleton);
         String value = rp.value;
         if (value == null) {
@@ -794,13 +785,9 @@ public class DateTimeFormats {
         if (rp.time == null) {
             return value;
         } else {
-            SimpleDateFormat format2 = getDateFormatFromSkeleton(rp.time);
+            SimpleDateFormat format2 = getDateFormatFromSkeleton(rp.time, numberingSystem);
             format2.setTimeZone(GMT);
             String formattedTime = format2.format(SAMPLE_DATE);
-            //                String length = skeleton.contains("MMMM") ? skeleton.contains("E") ?
-            // "full" : "long"
-            //                    : skeleton.contains("MMM") ? "medium" : "short";
-            String path2 = getDTSeparator("full", "atType");
             String datetimePattern =
                     file.getStringValue(
                             getDTSeparator("full", "atType")); // prefer the atType variant here
@@ -813,31 +800,29 @@ public class DateTimeFormats {
     }
 
     private String getDTSeparator(String length, String type) {
-        String path =
-                "//ldml/dates/calendars/calendar[@type=\""
-                        + calendarID
-                        + "\"]/dateTimeFormats/dateTimeFormatLength[@type=\""
-                        + length
-                        + "\"]/dateTimeFormat[@type=\""
-                        + type
-                        + "\"]/pattern[@type=\"standard\"]";
-        return path;
+        return "//ldml/dates/calendars/calendar[@type=\""
+                + calendarID
+                + "\"]/dateTimeFormats/dateTimeFormatLength[@type=\""
+                + length
+                + "\"]/dateTimeFormat[@type=\""
+                + type
+                + "\"]/pattern[@type=\"standard\"]";
     }
 
-    public SimpleDateFormat getDateFormatFromSkeleton(String skeleton) {
+    public SimpleDateFormat getDateFormatFromSkeleton(String skeleton, String numberingSystem) {
         String pattern = getBestPattern(skeleton);
-        return getDateFormat(pattern);
+        return getDateFormat(pattern, numberingSystem);
     }
 
-    private SimpleDateFormat getDateFormat(String pattern) {
-        SimpleDateFormat format = icuServiceBuilder.getDateFormat(calendarID, pattern);
+    private SimpleDateFormat getDateFormat(String pattern, String numberingSystem) {
+        SimpleDateFormat format =
+                icuServiceBuilder.getDateFormat(calendarID, pattern, numberingSystem);
         format.setTimeZone(GMT);
         return format;
     }
 
     public String getBestPattern(String skeleton) {
-        String pattern = generator.getBestPattern(skeleton);
-        return pattern;
+        return generator.getBestPattern(skeleton);
     }
 
     enum RowStyle {
@@ -870,10 +855,7 @@ public class DateTimeFormats {
         output.append("<tr>");
         switch (rowStyle) {
             case separator:
-                String link = name.replace(' ', '_');
-                output.append("<th colSpan='3' class='dtf-sep'>")
-                        .append(hackDoubleLinked(link, name))
-                        .append("</th>");
+                output.append("<th colSpan='3' class='dtf-sep'>").append(name).append("</th>");
                 break;
             case header:
             case normal:
@@ -888,11 +870,7 @@ public class DateTimeFormats {
                         indent = "&nbsp;&nbsp;&nbsp;";
                         name = name.trim();
                     }
-                    output.append(
-                            "<th class='dtf-left'>"
-                                    + indent
-                                    + hackDoubleLinked(skeleton, name)
-                                    + "</th>");
+                    output.append("<th class='dtf-left'>" + indent + name + "</th>");
                 }
                 // .append(startCell).append(skeleton).append(endCell)
                 output.append(startCell)
@@ -967,8 +945,7 @@ public class DateTimeFormats {
      * @returns a HTML snippet that links to view a specfic XPath
      */
     public String getFixFromPath(String path) {
-        String result = PathHeader.getLinkedView(surveyUrl, file, path);
-        return result == null ? "" : result;
+        return PathHeader.getLinkedView(surveyUrl, file, path);
     }
 
     /**
@@ -985,13 +962,14 @@ public class DateTimeFormats {
      *
      * @param english
      * @param output
+     * @param numberingSystem
      */
-    public void addDateTable(CLDRFile english, Appendable output) {
+    public void addDateTable(CLDRFile english, Appendable output, String numberingSystem) {
         // ldml/dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]/month[@type="1"]
         // ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="stand-alone"]/quarterWidth[@type="wide"]/quarter[@type="1"]
         // ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="stand-alone"]/dayWidth[@type="abbreviated"]/day[@type="sun"]
         try {
-            output.append("<h2>" + hackDoubleLinked("Weekdays") + "</h2>\n");
+            output.append("<h2>Weekdays</h2>\n");
             addDateSubtable(
                     "//ldml/dates/calendars/calendar[@type=\"CALENDAR\"]/days/dayContext[@type=\"FORMAT\"]/dayWidth[@type=\"WIDTH\"]/day[@type=\"TYPE\"]",
                     english,
@@ -1003,10 +981,10 @@ public class DateTimeFormats {
                     "thu",
                     "fri",
                     "sat");
-            output.append("<h2>" + hackDoubleLinked("Ordinal Dates") + "</h2>\n");
-            addOrdinalDateSubtable(output);
+            output.append("<h2>Ordinal Dates</h2>\n");
+            addOrdinalDateSubtable(output, numberingSystem);
 
-            output.append("<h2>" + hackDoubleLinked("Months") + "</h2>\n");
+            output.append("<h2>Months</h2>\n");
             addDateSubtable(
                     "//ldml/dates/calendars/calendar[@type=\"CALENDAR\"]/months/monthContext[@type=\"FORMAT\"]/monthWidth[@type=\"WIDTH\"]/month[@type=\"TYPE\"]",
                     english,
@@ -1023,7 +1001,7 @@ public class DateTimeFormats {
                     "10",
                     "11",
                     "12");
-            output.append("<h2>" + hackDoubleLinked("Quarters") + "</h2>\n");
+            output.append("<h2>Quarters</h2>\n");
             addDateSubtable(
                     "//ldml/dates/calendars/calendar[@type=\"CALENDAR\"]/quarters/quarterContext[@type=\"FORMAT\"]/quarterWidth[@type=\"WIDTH\"]/quarter[@type=\"TYPE\"]",
                     english,
@@ -1118,7 +1096,8 @@ public class DateTimeFormats {
         final Set<String> availableLocales =
                 hasFilter ? factory.getAvailable() : factory.getAvailableLanguages();
         System.out.println("Total locales: " + availableLocales.size());
-        DateTimeFormats english = new DateTimeFormats(factory, englishFile, "gregorian");
+        DateTimeFormats english =
+                new DateTimeFormats(factory, englishFile, LDMLConstants.GREGORIAN);
 
         new File(DIR).mkdirs();
         FileCopier.copy(ShowData.class, "verify-index.html", CLDRPaths.VERIFY_DIR, "index.html");
@@ -1143,15 +1122,16 @@ public class DateTimeFormats {
         }
 
         writeCss(DIR);
-        System.out.println(String.format("Writing %d locale(s) to %s", sorted.size(), DIR));
+        System.out.printf("Writing %d locale(s) to %s%n", sorted.size(), DIR);
         PrintWriter out;
         // http://st.unicode.org/cldr-apps/survey?_=LOCALE&x=r_datetime&calendar=gregorian
         int oldFirst = 0;
         for (Entry<String, String> nameAndLocale : sorted.entrySet()) {
             String name = nameAndLocale.getKey();
             String localeID = nameAndLocale.getValue();
+            CLDRFile cldrFile = factory.make(localeID, true);
             DateTimeFormats formats =
-                    new DateTimeFormats(factory, factory.make(localeID, true), "gregorian");
+                    new DateTimeFormats(factory, cldrFile, LDMLConstants.GREGORIAN);
             String filename = localeID + ".html";
             out = FileUtilities.openUTF8Writer(DIR, filename);
             String redirect =
@@ -1175,9 +1155,13 @@ public class DateTimeFormats {
                             + "</h1>"
                             + "<p><a href='index.html'>Index</a></p>\n"
                             + "<p>The following chart shows typical usage of date and time formatting with the Gregorian calendar and default number system.</p>\n");
-            formats.addTable(english, out);
-            formats.addDateTable(englishFile, out);
-            formats.addDayPeriods(englishFile, out);
+            // TODO: loop through numbering systems for this locale
+            // Reference: https://unicode-org.atlassian.net/browse/CLDR-17854
+            String numberingSystem =
+                    cldrFile.getStringValue("//ldml/numbers/defaultNumberingSystem");
+            formats.addTable(english, out, numberingSystem);
+            formats.addDateTable(englishFile, out, numberingSystem);
+            formats.addDayPeriods(englishFile, out, numberingSystem);
             out.println(
                     "<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>"
                             + "<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>");
@@ -1238,9 +1222,9 @@ public class DateTimeFormats {
         out.close();
     }
 
-    public void addDayPeriods(CLDRFile englishFile, Appendable output) {
+    public void addDayPeriods(CLDRFile englishFile, Appendable output, String numberingSystem) {
         try {
-            output.append("<h2>" + hackDoubleLinked("Day Periods") + "</h2>\n");
+            output.append("<h2>Day Periods</h2>\n");
             output.append(
                     "<p>Please review these and correct if needed. The Wide fields are the most important. "
                             + "To correct them, go to "
@@ -1284,17 +1268,15 @@ public class DateTimeFormats {
                     sdi.getDayPeriods(DayPeriodInfo.Type.format, file.getLocaleID());
             Set<DayPeriodInfo.DayPeriod> dayPeriods =
                     new LinkedHashSet<>(dayPeriodInfo.getPeriods());
-            DayPeriodInfo dayPeriodInfo2 = sdi.getDayPeriods(DayPeriodInfo.Type.format, "en");
             DayPeriodInfo dayPeriodInfoRoot = sdi.getDayPeriods(DayPeriodInfo.Type.format, "root");
             final boolean isRootPeriods =
                     dayPeriodInfoRoot.equals(dayPeriodInfo); // true if it's the root periods
-            Set<DayPeriodInfo.DayPeriod> eDayPeriods = EnumSet.copyOf(dayPeriodInfo2.getPeriods());
             Output<Boolean> real = new Output<>();
             Output<Boolean> realEnglish = new Output<>();
 
             output.append("<tbody>\n");
             for (DayPeriodInfo.DayPeriod period : dayPeriods) {
-                outputPeriod(output, dayPeriodInfo, real, realEnglish, period);
+                outputPeriod(output, dayPeriodInfo, real, realEnglish, period, numberingSystem);
             }
             output.append("</tbody>\n");
 
@@ -1309,10 +1291,22 @@ public class DateTimeFormats {
 
                 // we double check, just in case AM/PM were already shown above.
                 if (!dayPeriodInfo.has(DayPeriod.am)) {
-                    outputPeriod(output, dayPeriodInfo, real, realEnglish, DayPeriod.am);
+                    outputPeriod(
+                            output,
+                            dayPeriodInfo,
+                            real,
+                            realEnglish,
+                            DayPeriod.am,
+                            numberingSystem);
                 }
                 if (!dayPeriodInfo.has(DayPeriod.pm)) {
-                    outputPeriod(output, dayPeriodInfo, real, realEnglish, DayPeriod.pm);
+                    outputPeriod(
+                            output,
+                            dayPeriodInfo,
+                            real,
+                            realEnglish,
+                            DayPeriod.pm,
+                            numberingSystem);
                 }
                 output.append("</tbody>");
             } else {
@@ -1343,7 +1337,8 @@ public class DateTimeFormats {
             DayPeriodInfo dayPeriodInfo,
             Output<Boolean> real,
             Output<Boolean> realEnglish,
-            DayPeriodInfo.DayPeriod period)
+            DayPeriodInfo.DayPeriod period,
+            String numberingSystem)
             throws IOException {
         R3<Integer, Integer, Boolean> first = dayPeriodInfo.getFirstDayPeriodInfo(period);
         int midPoint = (first.get0() + first.get1()) / 2;
@@ -1363,7 +1358,8 @@ public class DateTimeFormats {
                     String englishValue;
                     if (context == Context.format) {
                         englishValue =
-                                icuServiceBuilderEnglish.formatDayPeriod(midPoint, context, width);
+                                icuServiceBuilderEnglish.formatDayPeriod(
+                                        midPoint, context, width, numberingSystem);
                         realEnglish.value = true;
                     } else {
                         englishValue =
@@ -1380,7 +1376,9 @@ public class DateTimeFormats {
                 }
                 String nativeValue = icuServiceBuilder.getDayPeriodValue(dayPeriodPath, "�", real);
                 if (context == Context.format) {
-                    nativeValue = icuServiceBuilder.formatDayPeriod(midPoint, nativeValue);
+                    nativeValue =
+                            icuServiceBuilder.formatDayPeriod(
+                                    midPoint, nativeValue, numberingSystem);
                 }
                 output.append("<td class='dtf-left" + (real.value ? "" : " dtf-gray") + "'>")
                         .append(getCleanValue(nativeValue, width, "<i>missing</i>"))
@@ -1395,32 +1393,6 @@ public class DateTimeFormats {
         String qevalue =
                 evalue != null ? TransliteratorUtilities.toHTML.transform(evalue) : replacement;
         return qevalue.replace("�", replacement);
-    }
-
-    //    static final String SHORT_PATH =
-    // "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/timeFormats/timeFormatLength[@type=\"short\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]";
-    //    static final String HM_PATH =
-    // "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"hm\"]";
-    //
-    //    private String format(CLDRFile file, String evalue, int timeInDay) {
-    //        String pattern = file.getStringValue(HM_PATH);
-    //        if (pattern == null) {
-    //            pattern = "h:mm \uE000";
-    //        } else {
-    //            pattern = pattern.replace('a', '\uE000');
-    //        }
-    //        SimpleDateFormat df = icuServiceBuilder.getDateFormat("gregorian", pattern);
-    //        String formatted = df.format(timeInDay);
-    //        String result = formatted.replace("\uE000", evalue);
-    //        return result;
-    //    }
-
-    private String hackDoubleLinked(String link, String name) {
-        return name;
-    }
-
-    private String hackDoubleLinked(String string) {
-        return string;
     }
 
     static void writeIndexMap(Map<String, String> nameToFile, PrintWriter index) {
@@ -1441,7 +1413,7 @@ public class DateTimeFormats {
         index.println("</div></body></html>");
     }
 
-    void addOrdinalDateSubtable(Appendable output) throws IOException {
+    void addOrdinalDateSubtable(Appendable output, String numberingSystem) throws IOException {
         output.append(
                 String.format(
                         "<p>%s To fix, see: %s.</p>\n",
@@ -1451,9 +1423,12 @@ public class DateTimeFormats {
                                 "//ldml/dates/calendars/calendar[@type=\"generic\"]/dayOfMonths/dayOfMonthContext[@type=\"format\"]/dayOfMonthWidth[@type=\"abbreviated\"]/dayOfMonth[@ordinal=\"other\"]s")));
         final String pat = "MMMddd"; // Jan 4th
         final String patString = generator.getBestPattern(pat);
-        final SimpleDateFormat df = icuServiceBuilder.getDateFormat("gregorian", patString);
+        final SimpleDateFormat df =
+                icuServiceBuilder.getDateFormat(
+                        LDMLConstants.GREGORIAN, patString, numberingSystem);
         final SimpleDateFormat detailDf =
-                icuServiceBuilderEnglish.getDateFormat("gregorian", "E, MMM d"); // Wed, Mar 4
+                icuServiceBuilderEnglish.getDateFormat(
+                        LDMLConstants.GREGORIAN, "E, MMM d", numberingSystem); // Wed, Mar 4
         df.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
         // we'll use Mar 2026
         output.append("<table class='dtf-table dtf-highlight-cell'><tbody>\n <tr>\n");
@@ -1461,9 +1436,11 @@ public class DateTimeFormats {
         for (int i = 1; i <= 31; i++) {
             c.set(2026, Calendar.MARCH, i, 12, 0, 0);
             final Date d = c.getTime();
-            String fmt = ICUServiceBuilder.formatWithOrdinalHack(df, "gregorian", d, file);
+            String fmt =
+                    ICUServiceBuilder.formatWithOrdinalHack(df, LDMLConstants.GREGORIAN, d, file);
             String detailDate =
-                    ICUServiceBuilder.formatWithOrdinalHack(detailDf, "gregorian", d, file);
+                    ICUServiceBuilder.formatWithOrdinalHack(
+                            detailDf, LDMLConstants.GREGORIAN, d, file);
             output.append(
                             String.format(
                                     "  <td style='padding: .25em;' title='English: %s'>",
@@ -1475,5 +1452,85 @@ public class DateTimeFormats {
             }
         }
         output.append(" </tr>\n</tbody></table>\n");
+    }
+
+    public static void generateReport(
+            Factory fac, Locale transHintLoc, CLDRFile nativeFile, CLDRFile englishFile, Writer out)
+            throws IOException {
+        final String calendarType = LDMLConstants.GREGORIAN;
+        final String title =
+                com.ibm.icu.lang.UCharacter.toTitleCase(transHintLoc, calendarType, null);
+        out.write("<h3>Calendar : " + title + "</h3>");
+
+        DateTimeFormats formats = new DateTimeFormats(fac, nativeFile, calendarType);
+        DateTimeFormats english = new DateTimeFormats(fac, englishFile, calendarType);
+
+        LinkedHashMap<String, String> numberingSystems = getNumberingSystems(nativeFile);
+        Set<String> systems = numberingSystems.keySet();
+        if (systems.size() > 1) {
+            writeNumberingSystemLinks(out, numberingSystems);
+        }
+        for (String numberingSystem : systems) {
+            if (systems.size() > 1) {
+                String kind = numberingSystems.get(numberingSystem);
+                out.write(
+                        "<h1 style=\"padding-top: 1em\" id=\""
+                                + numberingSystemLinkId(numberingSystem)
+                                + "\">Numbering System: "
+                                + numberingSystem
+                                + " ("
+                                + kind
+                                + ")</h1>");
+            }
+            formats.addTable(english, out, numberingSystem);
+            formats.addDateTable(englishFile, out, numberingSystem);
+            formats.addDayPeriods(englishFile, out, numberingSystem);
+        }
+    }
+
+    private static void writeNumberingSystemLinks(
+            Writer out, LinkedHashMap<String, String> numberingSystems) throws IOException {
+        out.write(
+                "This report is displayed below once for each of "
+                        + numberingSystems.keySet().size()
+                        + " numbering systems used for this locale: ");
+        boolean needComma = false;
+        for (String numberingSystem : numberingSystems.keySet()) {
+            if (needComma) {
+                out.write(", ");
+            }
+            // Enable clicking on the numbering system to scroll to it. Use onclick and
+            // scrollIntoView instead of simple "href", which would fail in Survey Tool
+            // due to its special handling of anchors.
+            String link = numberingSystemLinkId(numberingSystem);
+            String onClick = "document.getElementById('" + link + "').scrollIntoView()";
+            String kind = numberingSystems.get(numberingSystem);
+            out.write("<a onclick=\"" + onClick + "\">" + numberingSystem + " (" + kind + ")</a>");
+            needComma = true;
+        }
+        out.write(".");
+    }
+
+    private static String numberingSystemLinkId(String numberingSystem) {
+        return "numbering-system-" + numberingSystem;
+    }
+
+    private static LinkedHashMap<String, String> getNumberingSystems(CLDRFile cldrFile) {
+        final String LATN = "latn";
+        TreeMap<String, String> m = new TreeMap<>();
+        m.put(LDMLConstants.DEFAULT, CLDRFile.NumberingSystem.defaultSystem.path);
+        m.put("Latin", LATN);
+        m.put(LDMLConstants.NATIVE, CLDRFile.NumberingSystem.nativeSystem.path);
+        m.put(LDMLConstants.TRADITIONAL, CLDRFile.NumberingSystem.traditional.path);
+        m.put(LDMLConstants.FINANCE, CLDRFile.NumberingSystem.finance.path);
+        LinkedHashMap<String, String> systems = new LinkedHashMap<>();
+        for (String kind : m.keySet()) {
+            String path = m.get(kind);
+            String system = LATN.equals(path) ? LATN : cldrFile.getStringValue(path);
+            if (system != null && !systems.containsKey(system)) {
+                systems.put(system, kind);
+            }
+        }
+        return systems;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -31,6 +31,13 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 
 public class ICUServiceBuilder {
 
+    /**
+     * As a parameter, call for using the default numbering system. This needs to be null for
+     * compatibility with ICU classes such as com.ibm.icu.text.SimpleDateFormat (whose constructor
+     * includes a parameter named "override" which is a numbering system name or null for default).
+     */
+    public static final String NUMBERING_SYSTEM_DEFAULT = null;
+
     private static final Factory defaultCollationFactory =
             CLDRConfig.getInstance().getAllCollationFactory();
 
@@ -195,14 +202,14 @@ public class ICUServiceBuilder {
     }
 
     public SimpleDateFormat getDateFormat(
-            String calendar, int dateIndex, int timeIndex, String numbersOverride) {
-        String key = cldrFile.getLocaleID() + "," + calendar + "," + dateIndex + "," + timeIndex;
+            String calendar, int dateIndex, int timeIndex, String numberingSystem) {
+        String key = makeDateFormatCacheKey(calendar, dateIndex, timeIndex, numberingSystem);
         SimpleDateFormat result = cachingIsEnabled ? cacheDateFormats.get(key) : null;
         if (result != null) return result.clone();
 
         String pattern = getPattern(calendar, dateIndex, timeIndex);
 
-        result = getFullFormat(calendar, pattern, numbersOverride);
+        result = getFullFormat(calendar, pattern, numberingSystem);
         if (cachingIsEnabled) {
             cacheDateFormats.put(key, result);
         }
@@ -241,12 +248,11 @@ public class ICUServiceBuilder {
         return sdf2.format(date);
     }
 
-    public SimpleDateFormat getDateFormat(String calendar, String pattern, String numbersOverride) {
-        String key =
-                cldrFile.getLocaleID() + "," + calendar + ",," + pattern + ",,," + numbersOverride;
+    public SimpleDateFormat getDateFormat(String calendar, String pattern, String numberingSystem) {
+        String key = makeDateFormatCacheKey(calendar, pattern, numberingSystem);
         SimpleDateFormat result = cachingIsEnabled ? cacheDateFormats.get(key) : null;
         if (result != null) return result.clone();
-        result = getFullFormat(calendar, pattern, numbersOverride);
+        result = getFullFormat(calendar, pattern, numberingSystem);
         if (cachingIsEnabled) {
             cacheDateFormats.put(key, result);
         }
@@ -254,16 +260,29 @@ public class ICUServiceBuilder {
         return result.clone();
     }
 
-    public SimpleDateFormat getDateFormat(String calendar, String pattern) {
-        return getDateFormat(calendar, pattern, null);
+    private String makeDateFormatCacheKey(
+            String calendar, int dateIndex, int timeIndex, String numberingSystem) {
+        return cldrFile.getLocaleID()
+                + ","
+                + calendar
+                + ","
+                + dateIndex
+                + ","
+                + timeIndex
+                + ","
+                + numberingSystem;
+    }
+
+    private String makeDateFormatCacheKey(String calendar, String pattern, String numberingSystem) {
+        return cldrFile.getLocaleID() + "," + calendar + ",," + pattern + ",,," + numberingSystem;
     }
 
     private SimpleDateFormat getFullFormat(
-            String calendar, String pattern, String numbersOverride) {
+            String calendar, String pattern, String numberingSystem) {
         ULocale curLocaleWithCalendar =
                 new ULocale(cldrFile.getLocaleID() + "@calendar=" + calendar);
         SimpleDateFormat result =
-                new SimpleDateFormat(pattern, numbersOverride, curLocaleWithCalendar); // formatData
+                new SimpleDateFormat(pattern, numberingSystem, curLocaleWithCalendar); // formatData
         // TODO Serious Hack, until ICU #4915 is fixed. => It *was* fixed in ICU 3.8, so now use
         // current locale.(?)
         Calendar cal = Calendar.getInstance(curLocaleWithCalendar);
@@ -288,8 +307,8 @@ public class ICUServiceBuilder {
         result.setNumberFormat(numberFormat.clone());
         // Need to put the field specific number format override formatters back in place, since
         // the previous result.setNumberFormat above nukes them.
-        if (numbersOverride != null && numbersOverride.contains("=")) {
-            String[] overrides = numbersOverride.split(",");
+        if (numberingSystem != null && numberingSystem.contains("=")) {
+            String[] overrides = numberingSystem.split(",");
             for (String override : overrides) {
                 String[] fields = override.split("=", 2);
                 if (fields.length == 2) {
@@ -1055,13 +1074,14 @@ public class ICUServiceBuilder {
     }
 
     /** Format a dayPeriod string. The dayPeriodOverride, if null, will be fetched from the file. */
-    public String formatDayPeriod(int timeInDay, Context context, Width width) {
+    public String formatDayPeriod(
+            int timeInDay, Context context, Width width, String numberingSystem) {
         DayPeriodInfo dayPeriodInfo =
                 supplementalData.getDayPeriods(DayPeriodInfo.Type.format, cldrFile.getLocaleID());
         DayPeriod period = dayPeriodInfo.getDayPeriod(timeInDay);
         String dayPeriodFormatString =
                 getDayPeriodValue(getDayPeriodPath(period, context, width), "�", null);
-        return formatDayPeriod(timeInDay, period, dayPeriodFormatString);
+        return formatDayPeriod(timeInDay, period, dayPeriodFormatString, numberingSystem);
     }
 
     public String getDayPeriodValue(String path, String fallback, Output<Boolean> real) {
@@ -1093,11 +1113,13 @@ public class ICUServiceBuilder {
     private static final String BHM_PATH =
             "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"Bhm\"]";
 
-    public String formatDayPeriod(int timeInDay, String dayPeriodFormatString) {
-        return formatDayPeriod(timeInDay, null, dayPeriodFormatString);
+    public String formatDayPeriod(
+            int timeInDay, String dayPeriodFormatString, String numberingSystem) {
+        return formatDayPeriod(timeInDay, null, dayPeriodFormatString, numberingSystem);
     }
 
-    private String formatDayPeriod(int timeInDay, DayPeriod period, String dayPeriodFormatString) {
+    private String formatDayPeriod(
+            int timeInDay, DayPeriod period, String dayPeriodFormatString, String numberingSystem) {
         String pattern = null;
         if ((timeInDay % 6) != 0) { // TODO CLDR-19377: need a better way to test for this
             // dayPeriods other than am, pm, noon, midnight (want patterns with B)
@@ -1133,7 +1155,7 @@ public class ICUServiceBuilder {
         if (pattern == null) {
             pattern = "h:mm \uE000";
         }
-        SimpleDateFormat df = getDateFormat("gregorian", pattern);
+        SimpleDateFormat df = getDateFormat("gregorian", pattern, numberingSystem);
         String formatted = df.format(timeInDay);
         return formatted.replace("\uE000", dayPeriodFormatString);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -287,7 +287,13 @@ public class VerifyZones {
                             + "</h1>\n"
                             + "<p><a href='index.html'>Index</a></p>\n");
 
-            showZones(factory2, timezoneFilter, englishCldrFile, cldrFile, out);
+            showZones(
+                    factory2,
+                    timezoneFilter,
+                    englishCldrFile,
+                    cldrFile,
+                    ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT,
+                    out);
 
             out.println("</body></html>");
             out.close();
@@ -385,6 +391,7 @@ public class VerifyZones {
             Matcher timezoneFilter,
             CLDRFile englishCldrFile,
             CLDRFile nativeCdrFile,
+            String numberingSystem,
             Appendable out)
             throws IOException {
         TablePrinter tablePrinter =
@@ -432,7 +439,13 @@ public class VerifyZones {
                 .setHeaderAttributes("class='dtf-th'")
                 .setCellAttributes("class='dtf-s'");
         ZoneFormats englishZoneFormats = new ZoneFormats(cldrFactory, englishCldrFile);
-        addZones(cldrFactory, englishZoneFormats, nativeCdrFile, timezoneFilter, tablePrinter);
+        addZones(
+                cldrFactory,
+                englishZoneFormats,
+                nativeCdrFile,
+                timezoneFilter,
+                tablePrinter,
+                numberingSystem);
 
         out.append(tablePrinter.toString() + "\n");
     }
@@ -442,7 +455,8 @@ public class VerifyZones {
             ZoneFormats englishZoneFormats,
             CLDRFile cldrFile,
             Matcher timezoneFilter,
-            TablePrinter output)
+            TablePrinter output,
+            String numberingSystem)
             throws IOException {
         CLDRFile englishCldrFile = englishZoneFormats.cldrFile;
         TimezoneFormatter tzformatter = new TimezoneFormatter(cldrFactory, cldrFile);
@@ -464,7 +478,7 @@ public class VerifyZones {
             String metazoneInfo =
                     englishGrouping
                             + "<br>"
-                            + englishZoneFormats.formatGMT(currentZone)
+                            + englishZoneFormats.formatGMT(currentZone, numberingSystem)
                             + "<br>"
                             + "MZ: "
                             + metazone;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneFormats.java
@@ -38,11 +38,11 @@ public class ZoneFormats {
         genericOrStandard
     }
 
-    public String formatGMT(TimeZone currentZone) {
+    public String formatGMT(TimeZone currentZone, String numberingSystem) {
         int tzOffset = currentZone.getRawOffset();
         SimpleDateFormat dateFormat =
                 icuServiceBuilder.getDateFormat(
-                        "gregorian", hourFormatPlusMinus[tzOffset >= 0 ? 0 : 1]);
+                        "gregorian", hourFormatPlusMinus[tzOffset >= 0 ? 0 : 1], numberingSystem);
         String hoursMinutes = dateFormat.format(tzOffset >= 0 ? tzOffset : -tzOffset);
         return MessageFormat.format(gmtFormat, hoursMinutes);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/tool/ListProblemDates.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/tool/ListProblemDates.java
@@ -210,7 +210,8 @@ public class ListProblemDates {
     }
 
     private static String formatDate(ICUServiceBuilder service, String calendar, String pattern) {
-        return service.getDateFormat(calendar, pattern).format(sampleDate);
+        return service.getDateFormat(calendar, pattern, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT)
+                .format(sampleDate);
     }
 
     private static boolean containsWithoutBridges(String container, String containee) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -1347,12 +1347,11 @@ public class TestCoverageLevel extends TestFmwkPlus {
         for (String localeId : factory.getAvailable()) {
             CLDRFile cldrFile = factory.make(localeId, true);
             String defaultNumberSystem =
-                    cldrFile.getStringValue("//ldml/numbers/defaultNumberingSystem");
+                    cldrFile.getStringValue(CLDRFile.NumberingSystem.defaultSystem.path);
             String nativeNumberSystem =
-                    cldrFile.getStringValue("//ldml/numbers/otherNumberingSystems/native");
+                    cldrFile.getStringValue(CLDRFile.NumberingSystem.nativeSystem.path);
             String financeNumberSystem =
-                    cldrFile.getStringValue(
-                            "//ldml/numbers/otherNumberingSystems/finance"); // could be null
+                    cldrFile.getStringValue(CLDRFile.NumberingSystem.finance.path); // could be null
             for (NumPathCoverageItem item : testItems) {
                 String pathForDefault = item.numPath.replace("xxxx", defaultNumberSystem);
                 Level defaultLevel = SDI.getCoverageLevel(pathForDefault, localeId);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
@@ -265,11 +265,17 @@ public class TestDateOrder extends TestFmwk {
 
                 sampleDate = neutralFormat.format(sample);
 
-                SimpleDateFormat gregFormat = isb.getDateFormat("gregorian", gregPat);
+                SimpleDateFormat gregFormat =
+                        isb.getDateFormat(
+                                "gregorian", gregPat, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                 gregFormat.setTimeZone(TimeZone.GMT_ZONE);
-                SimpleDateFormat isoFormat = isb.getDateFormat("iso8601", isoPat);
+                SimpleDateFormat isoFormat =
+                        isb.getDateFormat(
+                                "iso8601", isoPat, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                 isoFormat.setTimeZone(TimeZone.GMT_ZONE);
-                SimpleDateFormat caFormat = isbCan.getDateFormat("gregorian", gregPat);
+                SimpleDateFormat caFormat =
+                        isbCan.getDateFormat(
+                                "gregorian", gregPat, ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                 caFormat.setTimeZone(TimeZone.GMT_ZONE);
 
                 gregFormatted = gregFormat.format(sample);
@@ -368,10 +374,14 @@ public class TestDateOrder extends TestFmwk {
     public String formatInterval(
             ICUServiceBuilder isb, Date sample, Date sample2, String calendar, String pattern) {
         List<String> parts = splitIntervalPattern(pattern);
-        SimpleDateFormat gregFormat1 = isb.getDateFormat(calendar, parts.get(0));
+        SimpleDateFormat gregFormat1 =
+                isb.getDateFormat(
+                        calendar, parts.get(0), ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
         gregFormat1.setTimeZone(TimeZone.GMT_ZONE);
 
-        SimpleDateFormat gregFormat2 = isb.getDateFormat(calendar, parts.get(2));
+        SimpleDateFormat gregFormat2 =
+                isb.getDateFormat(
+                        calendar, parts.get(2), ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
         gregFormat2.setTimeZone(TimeZone.GMT_ZONE);
 
         return gregFormat1.format(sample) + parts.get(1) + gregFormat2.format(sample2);
@@ -621,7 +631,8 @@ public class TestDateOrder extends TestFmwk {
                                 CldrIntervalFormat.getSampleStartDate(),
                                 sampleEndDate,
                                 isb,
-                                timeZone);
+                                timeZone,
+                                ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
             }
 
             OutputInt diffCount = new OutputInt();
@@ -660,13 +671,15 @@ public class TestDateOrder extends TestFmwk {
                                                     CldrIntervalFormat.getSampleStartDate(),
                                                     sampleEndDate,
                                                     isb,
-                                                    timeZone);
+                                                    timeZone,
+                                                    ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                                     String constructedSample =
                                             constructedIF.format(
                                                     CldrIntervalFormat.getSampleStartDate(),
                                                     sampleEndDate,
                                                     isb,
-                                                    timeZone);
+                                                    timeZone,
+                                                    ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
 
                                     Set<IntervalDiff> status =
                                             IntervalDiff.compare(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -2562,7 +2562,13 @@ public class TestExampleGenerator extends TestFmwk {
                                 intf.separator,
                                 intf.secondPattern,
                                 intf.secondFields);
-                String actual2 = intf.format(DATE1, DATE2, isb, TimeZone.GMT_ZONE);
+                String actual2 =
+                        intf.format(
+                                DATE1,
+                                DATE2,
+                                isb,
+                                TimeZone.GMT_ZONE,
+                                ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT);
                 assertEquals(Joiners.COMMA_SP.join(source, DATE1, DATE2), expected2, actual2);
             } catch (Exception e) {
                 actual = e.getMessage();


### PR DESCRIPTION
-Avoid methods that implicitly assume defaultNumberingSystem if numberingSystem is omitted

-New ICUServiceBuilder.NUMBERING_SYSTEM_DEFAULT = null serves as explicit marker for using defaultNumberingSystem

-Move some of the logic from SurveyAjax.generateDateTimesReport to new DateTimeFormats.generateReport

-Refactoring: prefer existing constants like CLDRFile.NumberingSystem.defaultSystem.path in place of repeating string literals like //ldml/numbers/defaultNumberingSystem

-TODO comments for extending beyond date report to show multiple numbering systems also in charts and examples

-Fix compiler warnings; remove dead code

-Comments

CLDR-17854

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
