### PR TITLE
CLDR-19545 exemplar aux/main an date/time separator conflicts should be warning in submission

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -820,7 +820,7 @@ public class CheckDates extends FactoryCheckCLDR {
             Set<String> separatorFromBase = extractNumericSeparator(basePath, baseValue);
             if (!separatorFromBase.contains(value)) {
                 String separatorsFromBase = Joiners.COMMA_SP.join(separatorFromBase);
-                CheckStatus.Type errorType = getErrorTypeButWarningInBuild();
+                CheckStatus.Type errorType = getErrorTypeButWarningInBuildOrSubmission();
                 if (errorType == CheckStatus.errorType) {
                     if (separatorsFromBase.isEmpty()
                             || numericDatetimeSeparatorErrorShouldBeWarning(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
@@ -163,7 +163,7 @@ public class CheckExemplars extends FactoryCheckCLDR {
                 result.add(
                         new CheckStatus()
                                 .setCause(this)
-                                .setMainType(CheckStatus.errorType)
+                                .setMainType(getErrorTypeButWarningInBuildOrSubmission())
                                 .setSubtype(Subtype.auxiliaryExemplarsOverlap)
                                 .setMessage(
                                         "Auxiliary characters also exist in main: \u200E{0}\u200E",


### PR DESCRIPTION
CLDR-19545

- [X] This PR completes the ticket.

<img width="380" height="135" alt="image" src="https://github.com/user-attachments/assets/b17240f8-25d2-4c2d-9640-8b113ef8f5ab" />

<img width="425" height="129" alt="image" src="https://github.com/user-attachments/assets/7dcc0933-5d04-45d1-9b83-b43a89271f2d" />


<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
