### PR TITLE
CLDR-17854 Show multiple numbering systems in charts

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -2,6 +2,7 @@ package org.unicode.cldr.json;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -426,12 +427,12 @@ class LdmlConvertRules {
     public static final Pattern NUMBERING_SYSTEM_PATTERN =
             Pattern.compile(
                     "//ldml/numbers/(symbols|miscPatterns|(decimal|percent|scientific|currency|rational)Formats)\\[@numberSystem=\"([^\"]++)\"\\]/.*");
-    public static final String[] ACTIVE_NUMBERING_SYSTEM_XPATHS = {
-        CLDRFile.NumberingSystem.defaultSystem.path,
-        CLDRFile.NumberingSystem.nativeSystem.path,
-        CLDRFile.NumberingSystem.traditional.path,
-        CLDRFile.NumberingSystem.finance.path,
-    };
+    public static final List<String> ACTIVE_NUMBERING_SYSTEM_XPATHS =
+            Arrays.asList(
+                    CLDRFile.NumberingSystem.defaultSystem.path,
+                    CLDRFile.NumberingSystem.nativeSystem.path,
+                    CLDRFile.NumberingSystem.traditional.path,
+                    CLDRFile.NumberingSystem.finance.path);
 
     /** resolved identity should be discarded if inherited, known issue CLDR-17790 */
     public static final Pattern ROOT_IDENTITY_PATTERN = Pattern.compile("//ldml/identity.*");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodeFallback.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodeFallback.java
@@ -223,11 +223,11 @@ public class CodeFallback {
         for (String[] typeDisplayName : typeDisplayNames) {
             constructedItems.putValueAtPath(
                     "//ldml/localeDisplayNames/types/type"
-                            + "[@key=\""
-                            + typeDisplayName[1]
-                            + "\"]"
                             + "[@type=\""
                             + typeDisplayName[0]
+                            + "\"]"
+                            + "[@key=\""
+                            + typeDisplayName[1]
                             + "\"]",
                     typeDisplayName[0]);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1155,13 +1155,7 @@ public class DateTimeFormats {
                             + "</h1>"
                             + "<p><a href='index.html'>Index</a></p>\n"
                             + "<p>The following chart shows typical usage of date and time formatting with the Gregorian calendar and default number system.</p>\n");
-            // TODO: loop through numbering systems for this locale
-            // Reference: https://unicode-org.atlassian.net/browse/CLDR-17854
-            String numberingSystem =
-                    cldrFile.getStringValue("//ldml/numbers/defaultNumberingSystem");
-            formats.addTable(english, out, numberingSystem);
-            formats.addDateTable(englishFile, out, numberingSystem);
-            formats.addDayPeriods(englishFile, out, numberingSystem);
+            generateChartOrReport(cldrFile, english, englishFile, formats, out);
             out.println(
                     "<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>"
                             + "<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>");
@@ -1465,6 +1459,17 @@ public class DateTimeFormats {
         DateTimeFormats formats = new DateTimeFormats(fac, nativeFile, calendarType);
         DateTimeFormats english = new DateTimeFormats(fac, englishFile, calendarType);
 
+        generateChartOrReport(nativeFile, english, englishFile, formats, out);
+    }
+
+    private static void generateChartOrReport(
+            CLDRFile nativeFile,
+            DateTimeFormats english,
+            CLDRFile englishFile,
+            DateTimeFormats formats,
+            Writer out)
+            throws IOException {
+        // Loop through numbering systems for this locale
         LinkedHashMap<String, String> numberingSystems = getNumberingSystems(nativeFile);
         Set<String> systems = numberingSystems.keySet();
         if (systems.size() > 1) {
@@ -1505,7 +1510,15 @@ public class DateTimeFormats {
             String link = numberingSystemLinkId(numberingSystem);
             String onClick = "document.getElementById('" + link + "').scrollIntoView()";
             String kind = numberingSystems.get(numberingSystem);
-            out.write("<a onclick=\"" + onClick + "\">" + numberingSystem + " (" + kind + ")</a>");
+            // For some reason, in the chart, this link lacks underline unless added here explicitly
+            out.write(
+                    "<a style=\"text-decoration: underline;\" onclick=\""
+                            + onClick
+                            + "\">"
+                            + numberingSystem
+                            + " ("
+                            + kind
+                            + ")</a>");
             needComma = true;
         }
         out.write(".");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -307,6 +307,9 @@ public class ICUServiceBuilder {
         result.setNumberFormat(numberFormat.clone());
         // Need to put the field specific number format override formatters back in place, since
         // the previous result.setNumberFormat above nukes them.
+        // Support numberingSystem attributes with "=".
+        // Example: <pattern numbers="d=thai;m=hans;y=deva">dd/mm/yyyy</pattern>
+        // See: https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
         if (numberingSystem != null && numberingSystem.contains("=")) {
             String[] overrides = numberingSystem.split(",");
             for (String override : overrides) {


### PR DESCRIPTION
-Loop through numbering systems for charts as was already done for reports

-In CodeFallback, fix the ordering of type and key in //ldml/localeDisplayNames/types/type/... (it got normalized anyway, but better to generate correctly in the first place)

-Refactor ACTIVE_NUMBERING_SYSTEM_XPATHS by making it a List (since Array is mutable)

-Add comment in ICUServiceBuilder about numberingSystem attributes containing equals signs

CLDR-17854

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
