### PR TITLE
CLDR-19547 LOCALES_ALLOW_ADDING_IN_VETTING

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -2935,7 +2935,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                             + currentExtendedPhase);
             logger.info(
                     "CLDR_EXTENDED_SUBMISSION="
-                            + String.join(" ", SubmissionLocales.ADDITIONAL_EXTENDED_SUBMISSION));
+                            + String.join(" ", SubmissionLocales.CLDR_EXTENDED_SUBMISSION));
             progress.update("Setup props..");
             newVersion = survprops.getProperty(CLDR_NEWVERSION, CLDR_NEWVERSION);
             oldVersion = survprops.getProperty(CLDR_OLDVERSION, CLDR_OLDVERSION);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -284,9 +284,9 @@ public abstract class CheckCLDR implements CheckAccessor {
                         : StatusAction.ALLOW_VOTING_AND_TICKET;
             }
 
-            // locales in CLDR_ADD_ITEMS_IN_VETTING_LOCALES may continue to be added
+            // locales in LOCALES_ALLOW_ADDING_IN_VETTING may continue to be added
             if (pathValueInfo != null
-                    && SubmissionLocales.CLDR_ADD_ITEMS_IN_VETTING_LOCALES.contains(
+                    && SubmissionLocales.LOCALES_ALLOW_ADDING_IN_VETTING.contains(
                             pathValueInfo.getLocale().toString())) {
                 return StatusAction.ALLOW;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -284,6 +284,13 @@ public abstract class CheckCLDR implements CheckAccessor {
                         : StatusAction.ALLOW_VOTING_AND_TICKET;
             }
 
+            // locales in CLDR_ADD_ITEMS_IN_VETTING_LOCALES may continue to be added
+            if (pathValueInfo != null
+                    && SubmissionLocales.CLDR_ADD_ITEMS_IN_VETTING_LOCALES.contains(
+                            pathValueInfo.getLocale().toString())) {
+                return StatusAction.ALLOW;
+            }
+
             // No warnings, so allow just voting.
             return StatusAction.ALLOW_VOTING_BUT_NO_ADD;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -64,11 +64,23 @@ public final class SubmissionLocales {
     /** Space-separated list of TC locales to extend submission */
     public static final String DEFAULT_EXTENDED_SUBMISSION = "";
 
-    /** Additional TC locales which have extended submission. Do not add non-tc locales here. */
+    /**
+     * Additional TC locales which have extended submission. Do not add non-tc locales here, which
+     * are already included by default.
+     */
     public static final Set<String> ADDITIONAL_EXTENDED_SUBMISSION =
             ImmutableSet.copyOf(
                     CLDRConfig.getInstance()
                             .getProperty("CLDR_EXTENDED_SUBMISSION", "")
+                            .split(" "));
+
+    /**
+     * This is a slightly different list of locales that allow adding items through VETTING phase.
+     */
+    public static final Set<String> CLDR_ADD_ITEMS_IN_VETTING_LOCALES =
+            ImmutableSet.copyOf(
+                    CLDRConfig.getInstance()
+                            .getProperty("CLDR_ADD_ITEMS_IN_VETTING_LOCALES", "")
                             .split(" "));
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -68,7 +68,7 @@ public final class SubmissionLocales {
      * Additional TC locales which have extended submission. Do not add non-tc locales here, which
      * are already included by default.
      */
-    public static final Set<String> ADDITIONAL_EXTENDED_SUBMISSION =
+    public static final Set<String> CLDR_EXTENDED_SUBMISSION =
             ImmutableSet.copyOf(
                     CLDRConfig.getInstance()
                             .getProperty("CLDR_EXTENDED_SUBMISSION", "")
@@ -77,10 +77,10 @@ public final class SubmissionLocales {
     /**
      * This is a slightly different list of locales that allow adding items through VETTING phase.
      */
-    public static final Set<String> CLDR_ADD_ITEMS_IN_VETTING_LOCALES =
+    public static final Set<String> LOCALES_ALLOW_ADDING_IN_VETTING =
             ImmutableSet.copyOf(
                     CLDRConfig.getInstance()
-                            .getProperty("CLDR_ADD_ITEMS_IN_VETTING_LOCALES", "")
+                            .getProperty("LOCALES_ALLOW_ADDING_IN_VETTING", "")
                             .split(" "));
 
     /**
@@ -288,7 +288,7 @@ public final class SubmissionLocales {
     public static boolean isOpenForExtendedSubmission(CLDRLocale loc) {
         if (loc == CLDRLocale.ROOT) {
             return false; // root is never open
-        } else if (SubmissionLocales.ADDITIONAL_EXTENDED_SUBMISSION.contains(loc.getBaseName())) {
+        } else if (SubmissionLocales.CLDR_EXTENDED_SUBMISSION.contains(loc.getBaseName())) {
             // explicitly listed locale is a open for additional
             return true;
         } else if (SubmissionLocales.TC_ORG_LOCALES.contains(loc.getBaseName())) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -251,7 +251,7 @@ public class ICUServiceBuilder {
     public SimpleDateFormat getDateFormat(String calendar, String pattern, String numberingSystem) {
         String key = makeDateFormatCacheKey(calendar, pattern, numberingSystem);
         SimpleDateFormat result = cachingIsEnabled ? cacheDateFormats.get(key) : null;
-        if (result != null) return result.clone();
+        if (result != null) return (SimpleDateFormat) result.clone();
         result = getFullFormat(calendar, pattern, numberingSystem);
         if (cachingIsEnabled) {
             cacheDateFormats.put(key, result);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
@@ -122,14 +122,14 @@ public class TestSubmissionLocales {
     @Test
     public void textAdditionalVsTcLocale() {
         final List<CLDRLocale> extendedSubmissionButNotTcLocales =
-                SubmissionLocales.ADDITIONAL_EXTENDED_SUBMISSION.stream()
+                SubmissionLocales.CLDR_EXTENDED_SUBMISSION.stream()
                         .map(l -> CLDRLocale.getInstance(l))
                         .filter(l -> !SubmissionLocales.isTcLocale(l))
                         .collect(Collectors.toList());
         assertTrue(
                 extendedSubmissionButNotTcLocales.isEmpty(),
                 () ->
-                        "Locales in SubmissionLocales.ADDITIONAL_EXTENDED_SUBMISSION that should be removed as they are not TC locales: "
+                        "Locales in SubmissionLocales.CLDR_EXTENDED_SUBMISSION that should be removed as they are not TC locales: "
                                 + String.join(
                                         " ",
                                         extendedSubmissionButNotTcLocales.stream()


### PR DESCRIPTION
CLDR-19547

- [X] This PR completes the ticket.

<img width="1139" height="592" alt="image" src="https://github.com/user-attachments/assets/5aae4661-8b0c-43e9-994f-5351660867b2" />

doesn't add anything to UI, except that the + is available in VETTING
(similar locale not listed was not included)

activate with

```properties
CLDR_ADD_ITEMS_IN_VETTING_LOCALES=ta
```

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
