### PR TITLE
CLDR-19273 Fix remaining links to tsvs

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -35,6 +35,7 @@ import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.NameGetter;
 
 public class ChartAnnotations extends Chart {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
 
     private static final String LDML_ANNOTATIONS =
             "<a href='https://unicode.org/reports/tr35/tr35-general.html#Annotations'>LDML Annotations</a>";
@@ -50,7 +51,6 @@ public class ChartAnnotations extends Chart {
                     + "For more information, see "
                     + LDML_ANNOTATIONS
                     + ".</p>";
-    private static final boolean DEBUG = false;
     private static final String DIR = CLDRPaths.CHART_DIRECTORY + "annotations/";
 
     public static void main(String[] args) {
@@ -208,7 +208,7 @@ public class ChartAnnotations extends Chart {
                 String locale = pair.get2();
 
                 nameToCode.put(name, locale);
-                System.out.println(pair);
+                if (DEBUG) System.out.println(pair);
             }
             // now build table with right order for columns
             double width = ((int) ((99.0 / (locales.size() + 1)) * 1000)) / 1000.0;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -62,6 +62,8 @@ import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
 public class ChartDelta extends Chart {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
+
     private static final boolean verbose_skipping = false;
 
     private static final String DEFAULT_DELTA_DIR_NAME = "delta";
@@ -130,8 +132,9 @@ public class ChartDelta extends Chart {
     }
 
     public static void main(String[] args, boolean highLevelOnly) {
-        System.out.println(
-                "use -DCHART_VERSION=36.0 -DPREV_CHART_VERSION=34.0 to generate the differences between v36 and v34.");
+        if (DEBUG)
+            System.out.println(
+                    "use -DCHART_VERSION=36.0 -DPREV_CHART_VERSION=34.0 to generate the differences between v36 and v34.");
         MyOptions.parse(args);
         Matcher fileFilter =
                 !MyOptions.fileFilter.option.doesOccur()
@@ -158,11 +161,12 @@ public class ChartDelta extends Chart {
         }
         String dirName = MyOptions.directory.option.getValue();
         if (highLevelOnly && DEFAULT_DELTA_DIR_NAME.equals(dirName)) {
-            System.out.println(
-                    "For highLevelOnly, changing directory from "
-                            + DEFAULT_DELTA_DIR_NAME
-                            + " to "
-                            + DEFAULT_CHURN_DIR_NAME);
+            if (DEBUG)
+                System.out.println(
+                        "For highLevelOnly, changing directory from "
+                                + DEFAULT_DELTA_DIR_NAME
+                                + " to "
+                                + DEFAULT_CHURN_DIR_NAME);
             dirName = DEFAULT_CHURN_DIR_NAME;
         }
         ChartDelta temp = new ChartDelta(fileFilter, coverage, dirName, verbose, highLevelOnly);
@@ -171,9 +175,10 @@ public class ChartDelta extends Chart {
         if (highLevelOnly) {
             HighLevelPaths.reportHighLevelPathUsage();
         }
-        System.out.println("Finished. Files may have been created in these directories:");
-        System.out.println(temp.DIR);
-        System.out.println(getTsvDir(temp.DIR, temp.dirName));
+        if (DEBUG)
+            System.out.println("Finished. Files may have been created in these directories:");
+        if (DEBUG) System.out.println(temp.DIR);
+        if (DEBUG) System.out.println(getTsvDir(temp.DIR, temp.dirName));
     }
 
     private ChartDelta(
@@ -192,7 +197,6 @@ public class ChartDelta extends Chart {
     }
 
     private static final String SEP = "\u0001";
-    private static final boolean DEBUG = false;
     private static final String DEBUG_FILE = null; // "windowsZones.xml";
     static Pattern fileMatcher = PatternCache.get(".*");
 
@@ -355,17 +359,18 @@ public class ChartDelta extends Chart {
                 try {
                     factories.add(Factory.make(current, ".*"));
                 } catch (Exception e1) {
-                    System.out.println("Skipping: " + dir + "\t" + e1.getMessage());
+                    if (DEBUG) System.out.println("Skipping: " + dir + "\t" + e1.getMessage());
                     continue; // skip where the directories don't exist in old versions
                 }
                 try {
                     oldFactories.add(Factory.make(past, ".*"));
                 } catch (Exception e) {
-                    System.out.println("Couldn't open factory: " + past);
+                    if (DEBUG) System.out.println("Couldn't open factory: " + past);
                     past = null;
                     oldFactories.add(null);
                 }
-                System.out.println("Will compare: " + dir + "\t\t" + current + "\t\t" + past);
+                if (DEBUG)
+                    System.out.println("Will compare: " + dir + "\t\t" + current + "\t\t" + past);
             }
             if (factories.isEmpty()) {
                 throw new IllegalArgumentException(
@@ -422,12 +427,12 @@ public class ChartDelta extends Chart {
                         String nameAndLocale = sourceDirLeaf + "/" + locale;
                         if (fileFilter != null && !fileFilter.reset(nameAndLocale).find()) {
                             if (verbose && verbose_skipping) {
-                                System.out.println("SKIPPING: " + nameAndLocale);
+                                if (DEBUG) System.out.println("SKIPPING: " + nameAndLocale);
                             }
                             continue;
                         }
                         if (verbose) {
-                            System.out.println(nameAndLocale);
+                            if (DEBUG) System.out.println(nameAndLocale);
                         }
                         CLDRFile current = makeWithFallback(factory, locale, resolving);
                         CLDRFile old = makeWithFallback(oldFactory, locale, resolving);
@@ -684,9 +689,7 @@ public class ChartDelta extends Chart {
                                 new PathHeaderSegment(ph, size - elementIndex - 1, attribute),
                                 attributeValueOld,
                                 attributeValueCurrent);
-                if (DEBUG) {
-                    System.out.println(row);
-                }
+                if (DEBUG) System.out.println(row);
                 diff2.add(row);
             }
         }
@@ -816,7 +819,7 @@ public class ChartDelta extends Chart {
             Multimap<PathHeader, String> bcp,
             PrintWriter tsvFile) {
         if (bcp.isEmpty()) {
-            System.out.println("\tDeleting: " + DIR + "/" + file);
+            if (DEBUG) System.out.println("\tDeleting: " + DIR + "/" + file);
             new File(DIR + file).delete();
             return;
         }
@@ -863,7 +866,7 @@ public class ChartDelta extends Chart {
         for (Entry<PathHeader, Collection<String>> entry : bcp.asMap().entrySet()) {
             PathHeader ph = entry.getKey();
             if (ph.getPageId() == DEBUG_PAGE_ID) {
-                System.out.println(ph + "\t" + ph.getOriginalPath());
+                if (DEBUG) System.out.println(ph + "\t" + ph.getOriginalPath());
             }
             for (String value : entry.getValue()) {
                 String[] oldNew = value.split(SEP);
@@ -1102,9 +1105,9 @@ public class ChartDelta extends Chart {
                     continue;
                 }
                 File dirOld = new File(PREV_CHART_VERSION_DIRECTORY + "common/" + dir);
-                System.out.println("\tLast dir: " + dirOld);
+                if (DEBUG) System.out.println("\tLast dir: " + dirOld);
                 File dir2 = new File(CHART_VERSION_DIRECTORY + "common/" + dir);
-                System.out.println("\tCurr dir: " + dir2);
+                if (DEBUG) System.out.println("\tCurr dir: " + dir2);
 
                 for (String file : dir2.list()) {
                     if (!file.endsWith(".xml")) {
@@ -1114,7 +1117,7 @@ public class ChartDelta extends Chart {
                     String base = file.substring(0, file.length() - 4);
                     if (fileFilter != null && !fileFilter.reset(dir + "/" + base).find()) {
                         if (verbose) { //  && verbose_skipping
-                            System.out.println("SKIPPING: " + dir + "/" + base);
+                            if (DEBUG) System.out.println("SKIPPING: " + dir + "/" + base);
                         }
                         continue;
                     }
@@ -1122,7 +1125,7 @@ public class ChartDelta extends Chart {
                         continue;
                     }
                     if (verbose) {
-                        System.out.println(file);
+                        if (DEBUG) System.out.println(file);
                     }
                     Relation<PathHeader, String> contentsOld =
                             fillData(dirOld.toString() + "/", file, base);
@@ -1156,7 +1159,7 @@ public class ChartDelta extends Chart {
 
                         if (Objects.equals(setOld, set2)) {
                             if (file.equals(DEBUG_FILE)) { // for debugging
-                                System.out.println("**Same: " + key + "\t" + setOld);
+                                if (DEBUG) System.out.println("**Same: " + key + "\t" + setOld);
                             }
                             addChange(parentAndFile, ChangeType.same, setOld.size());
                             countSame.add(key, 1);
@@ -1296,9 +1299,10 @@ public class ChartDelta extends Chart {
                  * //supplementalData/grammaticalData/grammaticalFeatures[@targets="nominal"][@locales="he"]/grammaticalState[@values="definite indefinite construct"]
                  * Reference: https://unicode-org.atlassian.net/browse/CLDR-13306
                  */
-                System.out.println(
-                        "Caught NullPointerException in fillData calling isMetadata, path = "
-                                + path);
+                if (DEBUG)
+                    System.out.println(
+                            "Caught NullPointerException in fillData calling isMetadata, path = "
+                                    + path);
                 continue;
             }
             Set<String> pathForValues = dtdData.getRegularizedPaths(pathPlain, extras);
@@ -1596,11 +1600,12 @@ public class ChartDelta extends Chart {
             }
             if (!localeIsHighLevel(
                     locale)) { // for efficiency, this should be caught at a higher level
-                System.out.println(
-                        "locale ["
-                                + locale
-                                + "] failed localeIsHighLevel in pathIsHighLevel; path = "
-                                + path);
+                if (DEBUG)
+                    System.out.println(
+                            "locale ["
+                                    + locale
+                                    + "] failed localeIsHighLevel in pathIsHighLevel; path = "
+                                    + path);
                 return false;
             }
             if (pathIsReallyHighLevel(path, locale)) {
@@ -1877,17 +1882,17 @@ public class ChartDelta extends Chart {
                 return;
             }
             if (highLevelPathMatched == null) {
-                System.out.println("Zero high-level paths were matched!");
+                if (DEBUG) System.out.println("Zero high-level paths were matched!");
                 return;
             }
             for (String path : highLevelPaths) {
                 if (!highLevelPathMatched.contains(path)) {
-                    System.out.println("Unmatched high-level path: " + path);
+                    if (DEBUG) System.out.println("Unmatched high-level path: " + path);
                 }
             }
             for (String path : highLevelPathMatched) {
                 if (!highLevelPaths.contains(path)) {
-                    System.out.println("Special matched high-level path: " + path);
+                    if (DEBUG) System.out.println("Special matched high-level path: " + path);
                 }
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDtdDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDtdDelta.java
@@ -38,6 +38,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
  * @author markdavis
  */
 public class ChartDtdDelta extends Chart {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
 
     private static final Splitter SPLITTER_SPACE = Splitter.on(' ');
 
@@ -144,7 +145,7 @@ public class ChartDtdDelta extends Chart {
             if (current.compareTo(CldrVersion.from(ToolConstants.CHART_VERSION)) > 0) {
                 continue;
             }
-            System.out.println("DTD delta: " + current);
+            if (DEBUG) System.out.println("DTD delta: " + current);
             final boolean finalVersion =
                     current.equals(CldrVersion.from(ToolConstants.DEV_VERSION));
             String currentName =
@@ -241,7 +242,6 @@ public class ChartDtdDelta extends Chart {
 
     static final DtdType DEBUG_DTD = null; // set to enable
     static final String DEBUG_ELEMENT = "lias";
-    static final boolean SHOW = false;
 
     @SuppressWarnings("unused")
     private void checkNames(
@@ -274,8 +274,8 @@ public class ChartDtdDelta extends Chart {
         }
 
         seen.add(element);
-        if (SHOW && ToolConstants.CHART_DISPLAY_VERSION.equals(version)) {
-            System.out.println(dtdCurrent.dtdType + "\t" + name);
+        if (ToolConstants.CHART_DISPLAY_VERSION.equals(version)) {
+            if (DEBUG) System.out.println(dtdCurrent.dtdType + "\t" + name);
         }
         if (DEBUG_DTD == dtdCurrent.dtdType && name.contains(DEBUG_ELEMENT)) {
             int debug = 0;
@@ -346,7 +346,8 @@ public class ChartDtdDelta extends Chart {
             }
         }
         if (element.getName().equals("coordinateUnit")) {
-            System.out.println(version + "\toordinateUnit\t" + element.getChildren().keySet());
+            if (DEBUG)
+                System.out.println(version + "\tcoordinateUnit\t" + element.getChildren().keySet());
         }
         Set<Element> oldChildren =
                 oldElement == null ? Collections.emptySet() : oldElement.getChildren().keySet();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
@@ -65,6 +65,7 @@ import org.unicode.cldr.util.XPathParts;
 
 /** Chart the grammatical forms, with unit examples */
 public class ChartGrammaticalForms extends Chart {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
 
     private static final String FORMATTED_SAMPLE = "Formatted Sample";
 
@@ -76,7 +77,6 @@ public class ChartGrammaticalForms extends Chart {
                     + "<a target='spec' href='https://unicode.org/reports/tr35/tr35-general.html#Grammatical_Features'>LDML Grammatical Features</a>.";
 
     private static final String MAIN_HEADER = "<h2>Grammatical Forms</h2>";
-    private static final boolean DEBUG = false;
     private static final String DIR = CLDRPaths.CHART_DIRECTORY + "grammar/";
     public static final PluralRules ENGLISH_PLURAL_RULES = SDI.getPlurals("en").getPluralRules();
 
@@ -130,7 +130,7 @@ public class ChartGrammaticalForms extends Chart {
                     "Needs adjustment for additional GrammaticalTarget.values()");
         }
 
-        System.out.println(SDI.hasGrammarInfo());
+        if (DEBUG) System.out.println(SDI.hasGrammarInfo());
 
         TablePrinter tablePrinter = getFormattedGrammarInfo(SDI.hasGrammarInfo());
         pw.append(tablePrinter.toString());
@@ -217,7 +217,7 @@ public class ChartGrammaticalForms extends Chart {
                 }
             }
             if (!failures.isEmpty()) {
-                System.out.println("# Failures, " + localeId + "\t" + failures);
+                if (DEBUG) System.out.println("# Failures, " + localeId + "\t" + failures);
             }
         }
         return tablePrinter;
@@ -252,7 +252,7 @@ public class ChartGrammaticalForms extends Chart {
                         .getStatusToCodes(LstrType.unit)
                         .get(Validity.Status.regular)) {
             String shortUnit = uc.getShortId(longUnit);
-            System.out.println(shortUnit);
+            if (DEBUG) System.out.println(shortUnit);
             if (skip.contains(shortUnit)) {
                 continue;
             }
@@ -281,7 +281,7 @@ public class ChartGrammaticalForms extends Chart {
         }
         BASE_TO_FACTOR_TO_UNIT = CldrUtility.protectCollection(_BASE_TO_BEST);
         for (Entry<String, Map<Rational, String>> entry : BASE_TO_FACTOR_TO_UNIT.entrySet()) {
-            System.out.println(entry);
+            if (DEBUG) System.out.println(entry);
         }
     }
 
@@ -390,7 +390,7 @@ public class ChartGrammaticalForms extends Chart {
         //        int comp = u1.compareTo(u2); // should be less
 
         Set<BestUnitForGender> sorted2 = new TreeSet<>(unitToBestUnit.values());
-        System.out.println(sorted2);
+        if (DEBUG) System.out.println(sorted2);
 
         PlaceholderLocation placeholderPosition = PlaceholderLocation.missing;
         Matcher placeholderMatcher = UnitConverter.PLACEHOLDER.matcher("");
@@ -750,7 +750,7 @@ public class ChartGrammaticalForms extends Chart {
                         entry.getValue().stream()
                                 .map(x -> x.shortUnit)
                                 .collect(Collectors.toList());
-                System.out.println(locale + "\t" + entry.getKey() + "\t" + items);
+                if (DEBUG) System.out.println(locale + "\t" + entry.getKey() + "\t" + items);
             }
 
             TablePrinter powerTable =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -81,10 +81,11 @@ import org.xml.sax.SAXException;
  * http://java.sun.com/j2se/1.4.2/docs/api/org/xml/sax/DTDHandler.html
  */
 public class GenerateSidewaysView {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
+
     private static final boolean TOO_BIG_FOR_GITHUB = true;
     private static final String DIR_NAME = "by_type";
     // debug flags
-    static final boolean DEBUG = false;
     static final boolean DEBUG2 = false;
     static final boolean DEBUG_SHOW_ADD = false;
     static final boolean DEBUG_ELEMENT = false;
@@ -211,7 +212,7 @@ public class GenerateSidewaysView {
         String oldMain = "";
         PrintWriter out = null;
 
-        System.out.println("Getting types " + path_value_locales.size());
+        if (DEBUG) System.out.println("Getting types " + path_value_locales.size());
         // Set<String> types = new TreeSet<String>();
         // for (PathHeader path : path_value_locales.keySet()) {
         // String main = getFileName2(path);
@@ -241,8 +242,9 @@ public class GenerateSidewaysView {
         // options[DESTDIR].value, "index.html",
         //            new String[] { "%header%", headerString });
 
-        System.out.println(
-                "Printing files in " + new File(options[DESTDIR].value).getAbsolutePath());
+        if (DEBUG)
+            System.out.println(
+                    "Printing files in " + new File(options[DESTDIR].value).getAbsolutePath());
         // Transliterator toLatin = Transliterator.getInstance("any-latin");
         toHTML = TransliteratorUtilities.toHTML;
         // UnicodeSet BIDI_R = new UnicodeSet("[[:Bidi_Class=R:][:Bidi_Class=AL:]]");
@@ -364,11 +366,12 @@ public class GenerateSidewaysView {
         }
         finish(out, tsvFile);
         finishAll(out, tsvFile);
-        System.out.println(
-                "Done in "
-                        + new RuleBasedNumberFormat(
-                                        new ULocale("en"), RuleBasedNumberFormat.DURATION)
-                                .format((System.currentTimeMillis() - startTime) / 1000.0));
+        if (DEBUG)
+            System.out.println(
+                    "Done in "
+                            + new RuleBasedNumberFormat(
+                                            new ULocale("en"), RuleBasedNumberFormat.DURATION)
+                                    .format((System.currentTimeMillis() - startTime) / 1000.0));
     }
 
     static final String[][] EXEMPLARS = {
@@ -447,7 +450,8 @@ public class GenerateSidewaysView {
                 checkTr(script_UnicodeMap);
             }
         }
-        System.out.println("@@@TOTAL:\t" + variant + "\t" + totalExemplars.toPattern(false));
+        if (DEBUG)
+            System.out.println("@@@TOTAL:\t" + variant + "\t" + totalExemplars.toPattern(false));
         for (String script : script_UnicodeMap.keySet()) {
             UnicodeMap<Set<String>> mapping = script_UnicodeMap.get(script);
             writeCharToLocaleMapping(out, script, mapping);
@@ -465,7 +469,7 @@ public class GenerateSidewaysView {
             return;
         }
         if (foo.contains("tr")) {
-            System.out.println("huh?");
+            if (DEBUG) System.out.println("huh?");
         }
     }
 
@@ -474,7 +478,7 @@ public class GenerateSidewaysView {
         BreakIterator charBreaks =
                 BreakIterator.getCharacterInstance(ULocale.ROOT); // TODO, make default language for
         // script
-        System.out.println("@@Exemplars for\t" + script + "\t" + mapping.keySet());
+        if (DEBUG) System.out.println("@@Exemplars for\t" + script + "\t" + mapping.keySet());
         if (script.equals("Hangul")) { //  || script.equals("Common")
             return; // skip these
         }
@@ -709,8 +713,8 @@ public class GenerateSidewaysView {
         // gather all information
         // TODO tweek for value-laden attributes
         for (String localeID : alllocales) {
-            System.out.println("Loading: " + localeID);
-            System.out.flush();
+            if (DEBUG) System.out.println("Loading: " + localeID);
+            if (DEBUG) System.out.flush();
 
             CLDRFile cldrFile;
             try {
@@ -770,7 +774,7 @@ public class GenerateSidewaysView {
             sorted.put(s.getValue(), s.getKey());
         }
         for (Entry<String, Set<String>> s : sorted.keyValuesSet()) {
-            System.out.println(s);
+            if (DEBUG) System.out.println(s);
         }
     }
 
@@ -824,7 +828,7 @@ public class GenerateSidewaysView {
     private static String getValue(CLDRFile cldrFile, String path, String fullPath) {
         String value = cldrFile.getStringValue(path);
         if (value == null) {
-            System.out.println("Null value for " + path);
+            if (DEBUG) System.out.println("Null value for " + path);
             return value;
         }
         cldrFile.getSourceLocaleID(path, status);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -85,6 +85,8 @@ import org.unicode.cldr.util.XPathParts;
 
 @CLDRTool(alias = "showlanguages", description = "Generate Language info charts")
 public class ShowLanguages {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
+
     private static final boolean SHOW_NATIVE = true;
     private static final boolean SHOW_SKIPPED = false;
     private static int skipped = 0;
@@ -303,9 +305,9 @@ public class ShowLanguages {
             } // fall through
             if (temp.size() == 0) {
                 remainingScripts.remove(script);
-                System.out.println("Removing: " + script);
+                if (DEBUG) System.out.println("Removing: " + script);
             } else {
-                System.out.println("Keeping: " + script);
+                if (DEBUG) System.out.println("Keeping: " + script);
             }
         }
         remainingScripts.remove("Brai");
@@ -476,9 +478,9 @@ public class ShowLanguages {
             } // fall through
             if (temp.size() == 0) {
                 remainingScripts.remove(script);
-                System.out.println("Removing: " + script);
+                if (DEBUG) System.out.println("Removing: " + script);
             } else {
-                System.out.println("Keeping: " + script);
+                if (DEBUG) System.out.println("Keeping: " + script);
             }
         }
         remainingScripts.remove("Brai");
@@ -587,8 +589,9 @@ public class ShowLanguages {
             OfficialStatus status = data.getOfficialStatus();
             if (status.isMajor()) {
                 territoryFix.put(baseLanguage, territory);
-                System.out.println(
-                        "\tAdding\t" + baseLanguage + "\t" + territory + "\t" + language);
+                if (DEBUG)
+                    System.out.println(
+                            "\tAdding\t" + baseLanguage + "\t" + territory + "\t" + language);
             }
         }
     }
@@ -624,15 +627,16 @@ public class ShowLanguages {
                 UnicodeSet exemplars =
                         nativeLanguage.getExemplarSet(ExemplarType.main, WinningChoice.WINNING);
                 if (scriptSet.containsNone(exemplars)) {
-                    System.out.println(
-                            "Skipping CLDR file -- exemplars differ: "
-                                    + language
-                                    + "\t"
-                                    + nativeLanguage.getLocaleID()
-                                    + "\t"
-                                    + scriptSet
-                                    + "\t"
-                                    + exemplars);
+                    if (DEBUG)
+                        System.out.println(
+                                "Skipping CLDR file -- exemplars differ: "
+                                        + language
+                                        + "\t"
+                                        + nativeLanguage.getLocaleID()
+                                        + "\t"
+                                        + scriptSet
+                                        + "\t"
+                                        + exemplars);
                     nativeLanguage = null;
                 }
             }
@@ -997,7 +1001,7 @@ public class ShowLanguages {
                 if (path.indexOf("/generation") >= 0 || path.indexOf("/version") >= 0) continue;
                 skipped++;
                 if (SHOW_SKIPPED) {
-                    System.out.println("Skipped Element: " + path);
+                    if (DEBUG) System.out.println("Skipped Element: " + path);
                 }
             }
 
@@ -1187,7 +1191,7 @@ public class ShowLanguages {
         private static final int MINIMAL_BIG_VENDOR = 8;
 
         static {
-            System.out.println(new UnicodeSet(ESCAPED_URI_QUERY).complement());
+            if (DEBUG) System.out.println(new UnicodeSet(ESCAPED_URI_QUERY).complement());
         }
 
         private String urlEncode(String input) {
@@ -1613,8 +1617,7 @@ public class ShowLanguages {
             PrintWriter territory_language =
                     FileUtilities.openUTF8Writer(
                             CLDRPaths.CHART_DIRECTORY + "tsv/",
-                            "territory-language-information.tsv");
-
+                            "territory_language_information.tsv");
             PrintWriter pw2 = pw21;
             NumberFormat nf = NumberFormat.getInstance(ULocale.ENGLISH);
             nf.setGroupingUsed(true);
@@ -2021,23 +2024,26 @@ public class ShowLanguages {
                     String script = name_script.get(name);
                     if (script != null) {
                         Set<String> langSet = (Set<String>) script_languages.asMap().get(script);
-                        if (langSet != null && langSet.contains(language)) System.out.print("*");
-                        System.out.println(
-                                "\t" + name + " [" + language + "]\t=> " + name + " [" + script
-                                        + "]");
+                        if (langSet != null && langSet.contains(language))
+                            if (DEBUG) System.out.print("*");
+                        if (DEBUG)
+                            System.out.println(
+                                    "\t" + name + " [" + language + "]\t=> " + name + " [" + script
+                                            + "]");
                     } else {
                         String language2 = name_language.get(name);
                         if (language2 != null && !language.equals(language2)) {
                             Set<String> langSet = (Set<String>) language_scripts.get(language);
-                            if (langSet != null) System.out.print("*");
-                            System.out.print(
-                                    "?\tSame script?\t + "
-                                            + getName(NameType.LANGUAGE, language, false)
-                                            + "\t & "
-                                            + getName(NameType.LANGUAGE, language2, false));
+                            if (langSet != null) if (DEBUG) System.out.print("*");
+                            if (DEBUG)
+                                System.out.print(
+                                        "?\tSame script?\t + "
+                                                + getName(NameType.LANGUAGE, language, false)
+                                                + "\t & "
+                                                + getName(NameType.LANGUAGE, language2, false));
                             langSet = (Set<String>) language_scripts.get(language2);
-                            if (langSet != null) System.out.print("*");
-                            System.out.println();
+                            if (langSet != null) if (DEBUG) System.out.print("*");
+                            if (DEBUG) System.out.println();
                         }
                     }
                 }
@@ -2503,7 +2509,7 @@ public class ShowLanguages {
 
             pw.close();
             for (int i = 0; i < counts.length; ++i) {
-                System.out.println("Count\t" + i + "\t" + counts[i]);
+                if (DEBUG) System.out.println("Count\t" + i + "\t" + counts[i]);
             }
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -72,6 +72,7 @@ import org.unicode.cldr.util.XPathParts;
  * https://www.unicode.org/cldr/charts/47/supplemental/locale_coverage.html
  */
 public class ShowLocaleCoverage {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
 
     // relative to the supplemental subdirectory
     private static final String TSV_BASE = "../tsv/";
@@ -121,7 +122,6 @@ public class ShowLocaleCoverage {
     private static final String TSV_MISSING_COUNTS_HEADER =
             "#Locale\tTargetLevel\t№ Found\t№ Unconfirmed\t№ Missing";
 
-    private static final boolean DEBUG = true;
     private static final char DEBUG_FILTER =
             0; // use letter to only load locales starting with that letter
 
@@ -370,9 +370,10 @@ public class ShowLocaleCoverage {
 
             fixCommonLocales();
 
-            System.out.println(Joiner.on("\n").join(languageToRegion.asMap().entrySet()));
+            if (DEBUG)
+                System.out.println(Joiner.on("\n").join(languageToRegion.asMap().entrySet()));
 
-            System.out.println("# Writing coverage: " + availableLanguages);
+            if (DEBUG) System.out.println("# Writing coverage: " + availableLanguages);
 
             NumberFormat percentFormat = NumberFormat.getPercentInstance(Locale.ENGLISH);
             percentFormat.setMaximumFractionDigits(1);
@@ -1060,11 +1061,12 @@ public class ShowLocaleCoverage {
             }
             tablePrinter.toTsv(tsv_summary);
             long end = System.currentTimeMillis();
-            System.out.println(
-                    (end - start)
-                            + " millis = "
-                            + ((end - start) / localeCount)
-                            + " millis/locale");
+            if (DEBUG)
+                System.out.println(
+                        (end - start)
+                                + " millis = "
+                                + ((end - start) / localeCount)
+                                + " millis/locale");
             ShowPlurals.appendBlanksForScrolling(pw);
         }
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 
 public class PluralSnapshot implements Comparable<PluralSnapshot> {
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("DEBUG", "false"));
 
     public enum Plurals {
         zero,
@@ -303,8 +304,8 @@ public class PluralSnapshot implements Comparable<PluralSnapshot> {
                 }
                 SnapshotInfo info = PluralSnapshot.getInstance(pluralType, integral);
 
-                System.out.println("\n" + integral + "\n");
-                System.out.println(info.toOverview());
+                if (DEBUG) System.out.println("\n" + integral + "\n");
+                if (DEBUG) System.out.println(info.toOverview());
 
                 String title =
                         UCharacter.toTitleCase(pluralType.toString(), null)
@@ -324,9 +325,9 @@ public class PluralSnapshot implements Comparable<PluralSnapshot> {
                 for (Entry<PluralSnapshot, Set<String>> ruleEntry : info) {
                     PluralSnapshot ss = ruleEntry.getKey();
                     Set<String> locales = ruleEntry.getValue();
-                    System.out.println();
-                    System.out.println(locales);
-                    System.out.println(ss);
+                    if (DEBUG) System.out.println();
+                    if (DEBUG) System.out.println(locales);
+                    if (DEBUG) System.out.println(ss);
                     // if (ss.count != lastCount) {
                     // out.println(info.toHtmlStringHeader());
                     // lastCount = ss.count;


### PR DESCRIPTION
CLDR-19273

This fixes the two remaining TSV files, and also puts the printfs under an environment flag, to reduce the chaff when generating the charts.

I chose a simple way to reduce the chaff, just prefixing System.out.print... with if (DEBUG) .
We can look at a better way later, but it would be easy to change at that point.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
