### PR TITLE
CLDR-16983 use punctuation, number exemplars in CheckForExemplars

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -86,6 +87,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                     + "The CLDR Technical Committee will reply to your forum post if they need any more information in "
                     + "order to resolve the error or next steps on how to resolve if they still believe it is an error.";
 
+    /** List of XPath substrings that are omitted from all exemplar checks */
     static String[] EXEMPLAR_SKIPS = {
         "/currencySpacing",
         "/exemplarCharacters",
@@ -221,6 +223,14 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         return cldrLocale;
     }
 
+    private static final EnumSet<ExemplarType> EXEMPLARS_TO_ADD_TO_DEFAULT =
+            EnumSet.of(
+                    ExemplarType.auxiliary,
+                    ExemplarType.punctuation,
+                    ExemplarType.punctuation_auxiliary,
+                    ExemplarType.numbers,
+                    ExemplarType.numbers_auxiliary);
+
     @Override
     public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFile, Options options, List<CheckStatus> possibleErrors) {
@@ -262,21 +272,19 @@ public class CheckForExemplars extends FactoryCheckCLDR {
 
         boolean isRTL = RTL.containsSome(exemplars);
         if (isRTL) {
+            // TODO: CLDR-19115 document when RTL_CONTROLS are permitted.
             exemplars.addAll(RTL_CONTROLS);
         }
-        // UnicodeSet temp = resolvedFile.getExemplarSet("standard");
-        // if (temp != null) exemplars.addAll(temp);
-        UnicodeSet auxiliary =
-                safeGetExemplars(
-                        ExemplarType.auxiliary,
-                        possibleErrors,
-                        resolvedFile,
-                        ok); // resolvedFile.getExemplarSet("auxiliary",
-        // CLDRFile.WinningChoice.WINNING);
-        if (auxiliary != null) {
-            exemplars.addAll(auxiliary);
-        }
 
+        // Now, add a bunch of additional
+        for (final ExemplarType addType : EXEMPLARS_TO_ADD_TO_DEFAULT) {
+            UnicodeSet additionalSet = safeGetExemplars(addType, possibleErrors, resolvedFile, ok);
+
+            if (additionalSet != null) {
+                exemplars.addAll(additionalSet);
+            }
+        }
+        // TODO: CLDR-19115 remove (or document) the next line, replace it with just "U+0020"?
         exemplars.addAll(ExemplarSets.AlwaysOK).addAll(LB_JOIN_CONTROLS).freeze();
         exemplarsPlusAscii = new UnicodeSet(exemplars).addAll(ASCII).freeze();
 
@@ -306,6 +314,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         return result;
     }
 
+    /** UnicodeSet of characters that are illegal (prohibited in values). */
     static final UnicodeSet ESCAPE = new UnicodeSet("[❰❱]").freeze();
 
     @Override
@@ -323,18 +332,10 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         String sourceLocale = getResolvedCldrFileToCheck().getSourceLocaleID(path, otherPathStatus);
         checkEncoding(value, result);
 
-        // if we are an alias to another path, then skip
-        // if (!path.equals(otherPathStatus.pathWhereFound)) {
-        // return this;
-        // }
-
         // now check locale source
+        // no errors in code fallback.
         if (XMLSource.CODE_FALLBACK_ID.equals(sourceLocale)) {
             return this;
-            // } else if ("root".equals(sourceLocale)) {
-            // // skip eras for non-gregorian
-            // if (true) return this;
-            // if (path.indexOf("/calendar") >= 0 && path.indexOf("gregorian") <= 0) return this;
         }
 
         // Check all paths for illegal characters, even EXEMPLAR_SKIPS
@@ -943,14 +944,17 @@ public class CheckForExemplars extends FactoryCheckCLDR {
     /**
      * Return null if ok, otherwise UnicodeSet of bad characters
      *
-     * @param exemplarSet
+     * @param exemplarSet the locale's exemplar set
+     * @param exemplarSetPlusASCII the exemplar set, plus all of ASCII
      * @param value
      * @return
      */
-    private UnicodeSet containsAllCountingParens(
+    public static UnicodeSet containsAllCountingParens(
             UnicodeSet exemplarSet, UnicodeSet exemplarSetPlusASCII, String value) {
         UnicodeSet result = null;
+
         if (exemplarSet.containsAll(value)) {
+            // no error, value was entirely in exemplar set
             return result;
         }
 
@@ -980,7 +984,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         return result;
     }
 
-    private UnicodeSet addDisallowedItems(
+    private static UnicodeSet addDisallowedItems(
             UnicodeSet exemplarSet, String outside, UnicodeSet result) {
         if (!exemplarSet.containsAll(outside)) {
             if (result == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -59,6 +59,9 @@ import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
 
 public class CheckForExemplars extends FactoryCheckCLDR {
+    private static final String QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS =
+            "are not in the exemplar characters";
+
     public static final UnicodeSet RTL_CONTROLS =
             new UnicodeSet("[\\u061C\\u200E\\u200F]").freeze();
 
@@ -413,7 +416,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                             errorOption,
                             Subtype.charactersNotInMainOrAuxiliaryExemplars,
                             Subtype.asciiCharactersNotInMainOrAuxiliaryExemplars,
-                            "are not in the exemplar characters",
+                            QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS,
                             result);
                 }
             }
@@ -428,7 +431,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                             errorOption,
                             Subtype.charactersNotInMainOrAuxiliaryExemplars,
                             Subtype.asciiCharactersNotInMainOrAuxiliaryExemplars,
-                            "are not in the exemplar characters",
+                            QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS,
                             result);
                 }
             }
@@ -449,7 +452,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                             errorOption,
                             Subtype.charactersNotInMainOrAuxiliaryExemplars,
                             Subtype.asciiCharactersNotInMainOrAuxiliaryExemplars,
-                            "are not in the exemplar characters",
+                            QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS,
                             result);
                 }
             }
@@ -470,7 +473,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                             errorOption,
                             Subtype.charactersNotInMainOrAuxiliaryExemplars,
                             Subtype.asciiCharactersNotInMainOrAuxiliaryExemplars,
-                            "are not in the exemplar characters",
+                            QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS,
                             result);
                 }
             }
@@ -537,7 +540,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                             errorOption,
                             Subtype.charactersNotInMainOrAuxiliaryExemplars,
                             Subtype.asciiCharactersNotInMainOrAuxiliaryExemplars,
-                            "are not in the exemplar characters",
+                            QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS,
                             result);
                 }
             }
@@ -550,7 +553,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                         CheckStatus.warningType,
                         Subtype.charactersNotInMainOrAuxiliaryExemplars,
                         Subtype.asciiCharactersNotInMainOrAuxiliaryExemplars,
-                        "are not in the exemplar characters",
+                        QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS,
                         result);
             }
         } else {
@@ -562,7 +565,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
                         errorOption,
                         Subtype.charactersNotInMainOrAuxiliaryExemplars,
                         Subtype.asciiCharactersNotInMainOrAuxiliaryExemplars,
-                        "are not in the exemplar characters",
+                        QUALIFIER_NOT_IN_EXEMPLAR_CHARACTERS,
                         result);
             }
         }
@@ -654,6 +657,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
 
     private String checkAndReplacePlaceholders(
             String path, String value, List<CheckStatus> result) {
+        // TODO CLDR-11609: move these tests to CheckPlaceholders
         CheckStatus.Type statusType =
                 getPhase() == Phase.BUILD
                         ? CheckStatus.warningType
@@ -693,7 +697,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
             minimum = 1;
         }
 
-        // TODO: move these tests to CheckPlaceholder
+        // TODO CLDR-11609: move these tests to CheckPlaceholders
 
         // Now see what is there, and see if they match
         Matcher matcher = patternMatcher.reset(value);
@@ -888,9 +892,19 @@ public class CheckForExemplars extends FactoryCheckCLDR {
 
     static final String TEST = "؉";
 
+    /**
+     * Helper for adding the 'missing characters' message
+     *
+     * @param missing UnicodeSet of what's missing
+     * @param type main type - either warning, or error.
+     * @param subtype subtype if any non-ascii present
+     * @param subtypeAscii subtype if missing is all SCII
+     * @param qualifier helper message
+     * @param result list to add to (out param)
+     */
     private void addMissingMessage(
             UnicodeSet missing,
-            CheckStatus.Type warningVsError,
+            CheckStatus.Type type,
             Subtype subtype,
             Subtype subtypeAscii,
             String qualifier,
@@ -919,7 +933,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         result.add(
                 new CheckStatus()
                         .setCause(this)
-                        .setMainType(warningVsError)
+                        .setMainType(type)
                         .setSubtype(ASCII.containsAll(missing) ? subtypeAscii : subtype)
                         .setMessage(message, new Object[] {fixedMissing, scriptString, qualifier}));
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckUnits.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckUnits.java
@@ -100,6 +100,7 @@ public class CheckUnits extends CheckCLDR {
                 try {
                     SimpleFormatter sf = SimpleFormatter.compileMinMaxArguments(value, min, max);
                 } catch (Exception e) {
+                    // TODO CLDR-11609: move to CheckPlaceHolders?
                     result.add(
                             new CheckStatus()
                                     .setCause(this)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCheckForExemplars.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCheckForExemplars.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,16 +59,37 @@ public class TestCheckForExemplars {
                 "\u1041\u1040\u1037",
             })
     void TestZawgyiWarning(final String value) {
-        cfe.setCldrFileToCheck(factory.make("my", true), options, possibleErrors);
-        assertTrue(possibleErrors.isEmpty(), () -> possibleErrors.toString());
-        Optional<CheckStatus> assertHadCheck = assertHadCheck(value, ZAWGYI_SUBTYPE, BASIC_PATH);
-        CheckStatus cs = assertHadCheck.get();
+        setLocaleId("my");
+        CheckStatus cs = assertHadSingleCheck(value, ZAWGYI_SUBTYPE, BASIC_PATH);
         if (cs != null) {
             // check the message
             assertTrue(
                     cs.getMessage().contains("Zawgyi") && cs.getMessage().contains("confidence"),
                     () -> "Unexpected message:" + cs.getMessage());
         }
+    }
+
+    private CheckStatus assertHadSingleCheck(
+            final String value, final Subtype expectedSubtype, final String path) {
+        Optional<CheckStatus> csOptional = assertHadCheck(value, expectedSubtype, path);
+        CheckStatus cs = csOptional.get();
+        return cs;
+    }
+
+    private void setLocaleId(final String localeId) {
+        cfe.setCldrFileToCheck(factory.make(localeId, true), options, possibleErrors);
+        assertTrue(possibleErrors.isEmpty(), () -> possibleErrors.toString());
+    }
+
+    @Test
+    void TestHindiExemplars() {
+        final String UM_XPath = "//ldml/localeDisplayNames/territories/territory[@type=\"UM\"]";
+        final String UM_hi = "यू॰एस॰ आउटलाइंग द्वीपसमूह";
+        setLocaleId("hi");
+        List<CheckStatus> checks = runChecks(UM_hi, UM_XPath);
+
+        // should not fail
+        assertTrue(checks.isEmpty(), () -> checks.toString());
     }
 
     /**
@@ -77,10 +99,7 @@ public class TestCheckForExemplars {
      */
     private Optional<CheckStatus> assertHadCheck(
             final String value, final Subtype expectedSubtype, final String path) {
-        cfe.check(path, path, value, options, possibleErrors);
-        // stream of errors in the expected subtype
-        final Stream<CheckStatus> haveExpected =
-                possibleErrors.stream().filter(e -> e.getSubtype() == expectedSubtype);
+        final Stream<CheckStatus> haveExpected = runChecks(value, expectedSubtype, path);
         // the first such error
         final Optional<CheckStatus> first = haveExpected.findFirst();
         assertNotNull(
@@ -90,5 +109,20 @@ public class TestCheckForExemplars {
                                 "Did not get check %s: %s, but had %s",
                                 expectedSubtype, value, possibleErrors.toString()));
         return first;
+    }
+
+    private Stream<CheckStatus> runChecks(
+            final String value, final Subtype expectedSubtype, final String path) {
+        // stream of errors in the expected subtype
+        Stream<CheckStatus> errorStream = runChecks(value, path).stream();
+        if (expectedSubtype == null) return errorStream;
+        final Stream<CheckStatus> haveExpected =
+                errorStream.filter(e -> e.getSubtype() == expectedSubtype);
+        return haveExpected;
+    }
+
+    private List<CheckStatus> runChecks(final String value, final String path) {
+        cfe.check(path, path, value, options, possibleErrors);
+        return possibleErrors;
     }
 }


### PR DESCRIPTION
CLDR-16983

- also cleanup javadocs and add more TODO references to CLDR-19115
- factor the `are not in the exemplar characters` message into a single constant

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
