### PR TITLE
CLDR-19552 Error message with up arrows

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -44,6 +44,7 @@ import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CldrIntervalFormat;
 import org.unicode.cldr.util.CldrIntervalFormat.IntervalDiff;
+import org.unicode.cldr.util.CldrIntervalFormat.IntervalPatternConstructor;
 import org.unicode.cldr.util.CldrPathUtilities;
 import org.unicode.cldr.util.CldrPathUtilities.IntervalSeparatorType;
 import org.unicode.cldr.util.CldrUtility;
@@ -1755,11 +1756,10 @@ public class CheckDates extends FactoryCheckCLDR {
                 }
             }
 
-            // Check against constructed interval
-            CldrIntervalFormat.IntervalPatternConstructor ipu =
-                    new CldrIntervalFormat.IntervalPatternConstructor(
-                            getCldrFileToCheck(), calendar);
             try {
+                // Check against constructed interval
+                IntervalPatternConstructor ipu =
+                        new IntervalPatternConstructor(getCldrFileToCheck(), calendar);
                 Output<String> availablePath = new Output<>();
                 Output<String> availableFormat = new Output<>();
                 String constructedPattern = ipu.construct(id, id2, availablePath, availableFormat);
@@ -1815,7 +1815,7 @@ public class CheckDates extends FactoryCheckCLDR {
                 result.add(
                         new CheckStatus()
                                 .setCause(this)
-                                .setMainType(CheckStatus.errorType)
+                                .setMainType(CheckStatus.warningType)
                                 .setSubtype(Subtype.datetimePatternLikelyIncorrect)
                                 .setMessage("DateIntervalInfo.PatternInfo exception {0}", e));
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -653,7 +653,7 @@ public class CheckDates extends FactoryCheckCLDR {
         IntervalSeparatorType separatorType = DatetimeUtilities.getSeparatorType(parts);
         String intervalPath =
                 CldrPathUtilities.intervalFormat(calendar, separatorType.id, separatorType.subId);
-        String intervalPattern = cldrFile.getStringValue(intervalPath);
+        String intervalPattern = cldrFile.getStringValueWithBailey(intervalPath);
         String plainValue = SimpleFormatter.compile(value).format("", "");
         if (!intervalPattern.contains(plainValue)) {
             CldrIntervalFormat intPattern;
@@ -887,7 +887,7 @@ public class CheckDates extends FactoryCheckCLDR {
         DatetimeUtilities.FieldKind fieldKind = DatetimeUtilities.getFieldKind(value);
         String separatorPath =
                 DatetimeUtilities.getSeparatorPath(calendar, fieldKind == FieldKind.TIME);
-        String separator = getResolvedCldrFileToCheck().getStringValue(separatorPath);
+        String separator = getResolvedCldrFileToCheck().getStringValueWithBailey(separatorPath);
         Set<String> found = extractNumericSeparator(parts.toString(), value);
 
         if (found.isEmpty()) {
@@ -1001,7 +1001,7 @@ public class CheckDates extends FactoryCheckCLDR {
                         .cloneAsThawed()
                         .setAttribute(calendarIndex, "type", calendar)
                         .setAttribute(dateFormatLengthIndex, "type", length);
-        String dateValue = resolvedCldrFile.getStringValue(currentDateParts.toString());
+        String dateValue = resolvedCldrFile.getStringValueWithBailey(currentDateParts.toString());
         if (dateValue == null) {
             throw new IllegalArgumentException(
                     "Missing value: " + currentDateParts); // should never occur
@@ -1336,7 +1336,7 @@ public class CheckDates extends FactoryCheckCLDR {
     private String getValues(CLDRFile resolvedCldrFileToCheck, Collection<String> values) {
         Set<String> results = new TreeSet<>();
         for (String path : values) {
-            final String stringValue = resolvedCldrFileToCheck.getStringValue(path);
+            final String stringValue = resolvedCldrFileToCheck.getStringValueWithBailey(path);
             if (stringValue != null) {
                 results.add(stringValue);
             }
@@ -1625,7 +1625,7 @@ public class CheckDates extends FactoryCheckCLDR {
                             coreParts.putAttributeValue(-1, "id", coreSkeleton);
                             String coreValue =
                                     getResolvedCldrFileToCheck()
-                                            .getStringValue(coreParts.toString());
+                                            .getStringValueWithBailey(coreParts.toString());
                             if (coreValue != null
                                     && !RelatedDatePathValues.contains(value, coreValue)) {
                                 if (DEBUG && getLocaleID().equals("zu") && id.equals("hmsv")) {
@@ -1952,7 +1952,7 @@ public class CheckDates extends FactoryCheckCLDR {
                 String base = !hasStar ? key : key.substring(0, star);
                 bases.add(base);
                 String xpath = AVAILABLE_PREFIX + base + AVAILABLE_SUFFIX;
-                String value1 = getCldrFileToCheck().getStringValue(xpath);
+                String value1 = getCldrFileToCheck().getStringValueWithBailey(xpath);
                 // String localeFound = getCldrFileToCheck().getSourceLocaleID(xpath, null);  &&
                 // !localeFound.equals("root") && !localeFound.equals("code-fallback")
                 if (value1 != null) {
@@ -1961,7 +1961,7 @@ public class CheckDates extends FactoryCheckCLDR {
                     if (hasStar) {
                         String zone = key.substring(star + 1);
                         timezonePattern =
-                                getResolvedCldrFileToCheck().getStringValue(APPEND_TIMEZONE);
+                                getResolvedCldrFileToCheck().getStringValueWithBailey(APPEND_TIMEZONE);
                         value1 = MessageFormat.format(timezonePattern, value1, zone);
                     }
                     if (equalsExceptWidth(value, value1)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -1961,7 +1961,8 @@ public class CheckDates extends FactoryCheckCLDR {
                     if (hasStar) {
                         String zone = key.substring(star + 1);
                         timezonePattern =
-                                getResolvedCldrFileToCheck().getStringValueWithBailey(APPEND_TIMEZONE);
+                                getResolvedCldrFileToCheck()
+                                        .getStringValueWithBailey(APPEND_TIMEZONE);
                         value1 = MessageFormat.format(timezonePattern, value1, zone);
                     }
                     if (equalsExceptWidth(value, value1)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrIntervalFormat.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrIntervalFormat.java
@@ -45,6 +45,17 @@ public class CldrIntervalFormat {
         this.secondPattern = PatternElement.listToPattern(secondFields);
     }
 
+    /**
+     * Format an interval using the first format, separator, and final format derived from the
+     * pattern used with getInstance.
+     *
+     * @param earlier
+     * @param later
+     * @param icuServiceBuilder
+     * @param timezone
+     * @param numberingSystem
+     * @return
+     */
     public String format(
             Date earlier,
             Date later,
@@ -76,6 +87,14 @@ public class CldrIntervalFormat {
         return formatted1 + separator + formatted2;
     }
 
+    /**
+     * May throw an exception if the pattern is not well-formed (eg a date field like "n"). So
+     * callers should catch any errors.
+     *
+     * @param calendar
+     * @param pattern
+     * @return
+     */
     public static CldrIntervalFormat getInstance(String calendar, String pattern) {
         List<PatternElement> patternElements = DatetimeUtilities.getPatternElements(pattern);
         Set<FieldType> variableFields = EnumSet.noneOf(FieldType.class);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrIntervalFormat.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrIntervalFormat.java
@@ -330,19 +330,19 @@ public class CldrIntervalFormat {
             this.calendar = calendar;
             this.numericSeparator =
                     SimpleFormatter.compile(
-                            cldrFile.getStringValue(
+                            cldrFile.getStringValueWithBailey(
                                     CldrPathUtilities.intervalSeparator(calendar, "numeric")));
             this.nonNumericSeparator =
                     SimpleFormatter.compile(
-                            cldrFile.getStringValue(
+                            cldrFile.getStringValueWithBailey(
                                     CldrPathUtilities.intervalSeparator(calendar, "non-numeric")));
             this.mixedSeparator =
                     SimpleFormatter.compile(
-                            cldrFile.getStringValue(
+                            cldrFile.getStringValueWithBailey(
                                     CldrPathUtilities.intervalSeparator(calendar, "mixed")));
             this.fallbackSeparator =
                     SimpleFormatter.compile(
-                            cldrFile.getStringValue(
+                            cldrFile.getStringValueWithBailey(
                                     CldrPathUtilities.intervalFormatFallback(calendar)));
         }
 
@@ -366,7 +366,7 @@ public class CldrIntervalFormat {
             // get the full format from the fields
 
             String path = CldrPathUtilities.availableFormat(calendar, fields);
-            String fullFormat = cldrFile.getStringValue(path);
+            String fullFormat = cldrFile.getStringValueWithBailey(path);
             String fields2 = fields;
 
             if (fullFormat == null) {
@@ -383,7 +383,7 @@ public class CldrIntervalFormat {
                 }
                 if (!fields2.equals(fields)) {
                     path = CldrPathUtilities.availableFormat(calendar, fields2);
-                    fullFormat = cldrFile.getStringValue(path);
+                    fullFormat = cldrFile.getStringValueWithBailey(path);
                 }
                 if (fullFormat == null && SKIP_IF_MISSING.contains(fields2)) {
                     return null; // no good replacement

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DatetimeUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DatetimeUtilities.java
@@ -1167,10 +1167,10 @@ public class DatetimeUtilities extends TestFmwk {
     public static Pair<String, String> getIntervalSeparatorAndBase(
             CLDRFile cldrFile, String calendar, IntervalSeparatorType separatorType) {
         String sepValue =
-                cldrFile.getStringValue(
+                cldrFile.getStringValueWithBailey(
                         CldrPathUtilities.intervalSeparator(calendar, separatorType));
         String intervalPattern =
-                cldrFile.getStringValue(
+                cldrFile.getStringValueWithBailey(
                         CldrPathUtilities.intervalFormat(
                                 calendar, separatorType.id, separatorType.subId));
         CldrIntervalFormat intPattern = CldrIntervalFormat.getInstance(calendar, intervalPattern);


### PR DESCRIPTION
CLDR-19552

This ticket

- Changes use of getStringValue to getStringValueWithBailey to handle the problem with ^^^
    - The value being tested is already clean, but these are using for **other** values that used in the check, eg for conflicts.
    - This is both in CheckDates.java and in the methods it uses in CldrIntervalFormat.java and DatetimeUtilities.java
- In CheckDates.java
    - Moves CldrIntervalFormat.IntervalPatternConstructor ipu =... inside the subsequent try/catch block
    - Changes the catch clause resulting to be a warning, not an error
    - We might change the wording also, since it is not a problem with the item being tests, but rather in **other** values.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
