### PR TITLE
CLDR-19559 memory/loading improvements

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -6,6 +6,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
 import com.ibm.icu.text.NumberFormat;
 import java.io.File;
 import java.io.IOException;
@@ -101,7 +102,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
         private final CLDRLocale locale;
 
         /** For readonly locales, there's no DB */
-        private final boolean readonly;
+        final boolean readonly;
 
         /** Stamp that tracks if this locale has been modified (by a vote) */
         private final MutableStamp stamp;
@@ -1323,6 +1324,13 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
     private final int CLDR_LOCALE_CACHE_MAX =
             CLDRConfig.getInstance().getProperty("CLDR_LOCALE_CACHE_MAX", 100);
 
+    /** We don't want to expire some items (such as root, en). Store a reference to them here. */
+    final ConcurrentHashMap<CLDRLocale, PerLocaleData> keepTheseItems = new ConcurrentHashMap<>();
+
+    /** List of locale IDs to not expire */
+    final Set<CLDRLocale> DO_NOT_EXPIRE_LOCALES =
+            ImmutableSet.of(CLDRLocale.getInstance("root"), CLDRLocale.getInstance("en"));
+
     /** Per locale map */
     private final LoadingCache<CLDRLocale, PerLocaleData> locales =
             CacheBuilder.newBuilder()
@@ -1330,13 +1338,19 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                     .expireAfterAccess(Duration.ofHours(CLDR_LOCALE_CACHE_HOURS))
                     .maximumSize(CLDR_LOCALE_CACHE_MAX)
                     .removalListener(
-                            notification ->
-                                    logger.info(
-                                            () ->
-                                                    "Locale expired: "
-                                                            + notification.getKey()
-                                                            + " due to "
-                                                            + notification.getCause()))
+                            notification -> {
+                                final CLDRLocale key = (CLDRLocale) notification.getKey();
+                                logger.info(
+                                        () ->
+                                                "Locale expired: "
+                                                        + key
+                                                        + " due to "
+                                                        + notification.getCause());
+                                getICUServiceFactory().removeFromCache(key);
+                                // keepTheseItems should not be expired via soft reference,
+                                // but could be timed out.
+                                keepTheseItems.remove(key);
+                            })
                     .build(
                             new CacheLoader<CLDRLocale, PerLocaleData>() {
 
@@ -1384,7 +1398,12 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
 
         // now load the actual locale
         try {
-            return locales.get(locale);
+            final PerLocaleData pld = locales.get(locale);
+            // Prevent some locales from expiring.
+            if (pld.readonly && DO_NOT_EXPIRE_LOCALES.contains(locale)) {
+                keepTheseItems.put(locale, pld);
+            }
+            return pld;
         } catch (ExecutionException e) {
             SurveyLog.logException(logger, e, "get(" + locale + ")");
             e.printStackTrace();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -1,5 +1,8 @@
 package org.unicode.cldr.util;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.DateFormatSymbols;
 import com.ibm.icu.text.DecimalFormat;
@@ -23,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
 import org.unicode.cldr.util.SupplementalDataInfo.CurrencyNumberInfo;
@@ -43,17 +46,34 @@ public class ICUServiceBuilder {
 
     public static class ICUServiceFactory {
         private final Factory cldrFactory;
-        private final Map<CLDRLocale, ICUServiceBuilder> ISBMap = new ConcurrentHashMap<>();
+        private final LoadingCache<CLDRLocale, ICUServiceBuilder> ISBMap =
+                CacheBuilder.newBuilder()
+                        .softValues()
+                        .build(
+                                new CacheLoader<CLDRLocale, ICUServiceBuilder>() {
+                                    @Override
+                                    public ICUServiceBuilder load(final CLDRLocale key)
+                                            throws Exception {
+                                        return new ICUServiceBuilder(
+                                                cldrFactory.make(key.getBaseName(), true),
+                                                defaultCollationFactory);
+                                    }
+                                });
 
         // TODO CLDR-19409: separate interface for collation?
 
+        public void removeFromCache(final CLDRLocale loc) {
+            if (loc == null) return;
+            ISBMap.invalidate(loc);
+        }
+
         public ICUServiceBuilder forLocale(final CLDRLocale loc) {
-            return ISBMap.computeIfAbsent(
-                    loc,
-                    newLoc ->
-                            new ICUServiceBuilder(
-                                    cldrFactory.make(newLoc.getBaseName(), true),
-                                    defaultCollationFactory));
+            if (loc == null) return null;
+            try {
+                return ISBMap.get(loc);
+            } catch (ExecutionException e) {
+                throw new RuntimeException("Could not build ICU Service for " + loc, e);
+            }
         }
 
         public ICUServiceFactory(Factory f) {


### PR DESCRIPTION
- Change ICUServiceBuilder to use soft references in its cache
- Expire ICUServiceBuilder items when the SurveyTool (STFactory) detects an expired locale
- Retain en, root in the STFactory cache as they are immutable

CLDR-19559

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
