### PR TITLE
CLDR-19572 Coverage level in export

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrCoverage.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrCoverage.mjs
@@ -291,9 +291,21 @@ const localeToXpathCoverageMap = {};
  * @internal
  */
 function updateCoverageMap(locale, coverageToXpaths) {
-  localeToCoverageMap[locale] = coverageToXpaths;
   // install the inverted map :  xpath -> coverage
   localeToXpathCoverageMap[locale] = invertMap(coverageToXpaths);
+  return coverageToXpaths;
+}
+
+async function fetchCoverageMapForLocale(locale) {
+  try {
+    const client = await cldrClient.getClient();
+    const { body } = await client.apis.xpath.getCoverageForLocale({ locale });
+    const { coverageToXpaths } = body;
+    return updateCoverageMap(locale, coverageToXpaths);
+  } catch (e) {
+    cldrNotify.exception(e, `Could not load coverage for ${locale}`);
+    return updateCoverageMap(locale, {}); // mark as empty
+  }
 }
 
 /**
@@ -303,18 +315,10 @@ function updateCoverageMap(locale, coverageToXpaths) {
 async function getCoverageMapForLocale(locale) {
   // The caller should validate the locale first.
   if (localeToCoverageMap[locale] === undefined) {
-    // we check for 'undefined' because 'null' might mean we errored before.
-    try {
-      const client = await cldrClient.getClient();
-      const { body } = await client.apis.xpath.getCoverageForLocale({ locale });
-      const { coverageToXpaths } = body;
-      updateCoverageMap(locale, coverageToXpaths);
-    } catch (e) {
-      cldrNotify.exception(e, `Could not load coverage for ${locale}`);
-      updateCoverageMap(locale, {}); // mark as empty
-    }
+    // put a promise here waiting for the map
+    localeToCoverageMap[locale] = fetchCoverageMapForLocale(locale);
   }
-  return localeToCoverageMap[locale];
+  return await localeToCoverageMap[locale];
 }
 
 /**
@@ -323,7 +327,7 @@ async function getCoverageMapForLocale(locale) {
  * @returns a string such as MODERN or falsy on error
  */
 async function getCoverageForPath(locale, xpathid) {
-  if (!getCoverageMapForLocale(locale)) return null;
+  if (!(await getCoverageMapForLocale(locale))) return null;
   return localeToXpathCoverageMap?.[locale]?.[xpathid];
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrCoverage.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrCoverage.mjs
@@ -4,8 +4,10 @@
 
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrClient from "./cldrClient.mjs";
+import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrXlsx from "./cldrXlsx.mjs";
 import * as XLSX from "xlsx";
+import { invertMap } from "./setUtils.mjs";
 
 let surveyLevels = null;
 
@@ -268,11 +270,70 @@ async function getCoverageStatusXlsx() {
   XLSX.writeFile(wb, `${ws_name}.xlsx`);
 }
 
+// --- xpath to coverage
+
+/**
+ * Map from locale -> coverage -> xpath id
+ * Added by getCoverageMapForLocale()
+ */
+const localeToCoverageMap = {};
+
+/**
+ * Map from locale -> xpath id -> coverage
+ * Updated by updateCoverage()
+ */
+const localeToXpathCoverageMap = {};
+
+/**
+ * Update coverage map for a locale.
+ * @param {*} locale
+ * @param {*} coverageToXpaths
+ * @internal
+ */
+function updateCoverageMap(locale, coverageToXpaths) {
+  localeToCoverageMap[locale] = coverageToXpaths;
+  // install the inverted map :  xpath -> coverage
+  localeToXpathCoverageMap[locale] = invertMap(coverageToXpaths);
+}
+
+/**
+ * return the raw coverage->xpath map for a locale
+ * @param {String} locale
+ */
+async function getCoverageMapForLocale(locale) {
+  // The caller should validate the locale first.
+  if (localeToCoverageMap[locale] === undefined) {
+    // we check for 'undefined' because 'null' might mean we errored before.
+    try {
+      const client = await cldrClient.getClient();
+      const { body } = await client.apis.xpath.getCoverageForLocale({ locale });
+      const { coverageToXpaths } = body;
+      updateCoverageMap(locale, coverageToXpaths);
+    } catch (e) {
+      cldrNotify.exception(e, `Could not load coverage for ${locale}`);
+      updateCoverageMap(locale, {}); // mark as empty
+    }
+  }
+  return localeToCoverageMap[locale];
+}
+
+/**
+ * @param {String} locale locale id
+ * @param {String} xpathid hex xpath id
+ * @returns a string such as MODERN or falsy on error
+ */
+async function getCoverageForPath(locale, xpathid) {
+  if (!getCoverageMapForLocale(locale)) return null;
+  return localeToXpathCoverageMap?.[locale]?.[xpathid];
+}
+
 export {
   covName,
   covValue,
   effectiveCoverage,
   effectiveName,
+  getCoverageForPath,
+  getCoverageMapForLocale,
   getCoverageStatus,
   getCoverageStatusXlsx,
   getSurveyOrgCov,

--- a/tools/cldr-apps/js/src/esm/cldrDashData.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDashData.mjs
@@ -454,7 +454,7 @@ async function downloadXlsx(data, locale, cb) {
       }
     }
     const xpath = await getXpath();
-    const url = `https://st.unicode.org/cldr-apps/v#/${locale}/${e.page}/${e.xpstrid}`;
+    const url = getSurveyUrl(locale, e.xpstrid, e.page);
     const cats = Array.from(e.cats).join(", ");
     ws_data.push([
       cats,

--- a/tools/cldr-apps/js/src/esm/cldrUserListExport.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrUserListExport.mjs
@@ -33,6 +33,8 @@ async function downloadUserActivity(userId /*, session*/) {
       "XpathCode", // 2
       "Value", // 3
       "When", // 4
+      "URL", // 5
+      // "Coverage", // 6
     ],
   ];
   for (const r of data) {
@@ -42,6 +44,12 @@ async function downloadUserActivity(userId /*, session*/) {
       r[header.XPATH_CODE],
       r[header.VALUE],
       new Date(r[header.LAST_MOD]), // TODO: convert to 'date'
+      cldrXlsx.getSurveyUrl(
+        r[header.LOCALE_NAME],
+        r[header.XPATH_STRHASH],
+        null
+      ),
+      // r[header.COVERAGE],
     ]);
   }
   var ws = XLSX.utils.aoa_to_sheet(ws_data);

--- a/tools/cldr-apps/js/src/esm/cldrUserListExport.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrUserListExport.mjs
@@ -1,18 +1,14 @@
 import * as XLSX from "xlsx";
 import * as cldrAjax from "./cldrAjax.mjs";
-import * as cldrXlsx from "./cldrXlsx.mjs";
 import * as cldrCoverage from "./cldrCoverage.mjs";
+import * as cldrProgress from "./cldrProgress.mjs";
+import * as cldrXlsx from "./cldrXlsx.mjs";
 
 // shim global fetch
 const fetch = cldrAjax.doFetch;
+const limit = 16_777_216; // big limit
 
-/**
- * Download the user activity database
- */
-async function downloadUserActivity(userId /*, session*/) {
-  //    http://127.0.0.1:9080/cldr-apps/SurveyAjax?what=recent_items&user=1289&limit=16777216
-  const limit = 16_777_216; // big limit
-  // const limit = 3; // testing
+async function fetchUserActivity(userId) {
   const url = `SurveyAjax?what=recent_items&user=${userId}&limit=${limit}`;
   const result = await fetch(url, {
     headers: {
@@ -22,6 +18,38 @@ async function downloadUserActivity(userId /*, session*/) {
   const json = await result.json();
   const { data, header } = json.recent;
 
+  return { data, header };
+}
+
+async function extractDataRow(r, header) {
+  const localeName = r[header.LOCALE_NAME];
+  const xpathId = r[header.XPATH_STRHASH];
+  const locale = r[header.LOCALE];
+  // fetch coverage if not present
+  const coverage =
+    (await cldrCoverage.getCoverageForPath(locale, xpathId)) || "unknown";
+  const xpathCode = r[header.XPATH_CODE];
+  const value = r[header.VALUE];
+  const lastMod = new Date(r[header.LAST_MOD]); // TODO: convert to 'date'
+  const surveyUrl = cldrXlsx.getSurveyUrl(locale, xpathId, null);
+
+  return {
+    localeName,
+    xpathId,
+    locale,
+    coverage,
+    xpathCode,
+    value,
+    lastMod,
+    surveyUrl,
+  };
+}
+
+/**
+ * Download the user activity database
+ */
+async function downloadUserActivity(userId /*, session*/) {
+  const { data, header } = await fetchUserActivity(userId);
   const wb = XLSX.utils.book_new();
 
   var ws_name = `SurveyTool#${userId}`;
@@ -39,19 +67,22 @@ async function downloadUserActivity(userId /*, session*/) {
     ],
   ];
   for (const r of data) {
-    const localeName = r[header.LOCALE_NAME];
-    const xpathId = r[header.XPATH_STRHASH];
-    const locale = r[header.LOCALE];
-    // fetch coverage if not present
-    const coverage =
-      (await cldrCoverage.getCoverageForPath(locale, xpathId)) || "unknown";
+    const {
+      localeName,
+      xpathId,
+      xpathCode,
+      value,
+      lastMod,
+      surveyUrl,
+      coverage,
+    } = await extractDataRow(r, header);
     ws_data.push([
       localeName,
       xpathId,
-      r[header.XPATH_CODE],
-      r[header.VALUE],
-      new Date(r[header.LAST_MOD]), // TODO: convert to 'date'
-      cldrXlsx.getSurveyUrl(locale, xpathId, null),
+      xpathCode,
+      value,
+      lastMod,
+      surveyUrl,
       coverage,
     ]);
   }
@@ -67,4 +98,75 @@ async function downloadUserActivity(userId /*, session*/) {
   XLSX.writeFile(wb, `survey_recent_activity${userId}.xlsx`);
 }
 
-export { downloadUserActivity };
+/**
+ *
+ * @param {Object} users - array with id, email, etc
+ * @param {Function} callback called with (msg,percent)
+ */
+async function downloadAllUserActivity(users, callback) {
+  const allToFetch = users.length;
+  const wb = XLSX.utils.book_new();
+
+  var ws_name = `SurveyToolAllUsers`;
+
+  /* make worksheet */
+  var ws_data = [
+    [
+      "UserId",
+      "Email",
+      "Org",
+      "UserLevel",
+      "LocaleId",
+      "Locale",
+      "XpathId",
+      "XpathCode",
+      "Value",
+      "When",
+      "URL",
+      "Coverage",
+    ],
+  ];
+  let fetched = 0;
+  for (const { id: userId, email, org, userLevelName } of users) {
+    const fetchPercent = cldrProgress.friendlyPercent(fetched, allToFetch);
+    fetched++;
+    callback(
+      `Fetching #${userId}: ${fetched}/${allToFetch}, ${ws_data.length} rows`,
+      fetchPercent
+    );
+    const { data, header } = await fetchUserActivity(userId);
+    for (const r of data) {
+      const {
+        locale,
+        localeName,
+        xpathId,
+        xpathCode,
+        value,
+        lastMod,
+        surveyUrl,
+        coverage,
+      } = await extractDataRow(r, header);
+      ws_data.push([
+        userId,
+        email,
+        org,
+        userLevelName,
+        locale,
+        localeName,
+        xpathId,
+        xpathCode,
+        value,
+        lastMod,
+        surveyUrl,
+        coverage,
+      ]);
+    }
+  }
+  var ws = XLSX.utils.aoa_to_sheet(ws_data);
+
+  XLSX.utils.book_append_sheet(wb, ws, ws_name);
+  XLSX.writeFile(wb, `${ws_name}.xlsx`, { compression: true });
+  callback(`Wrote ${ws_name} with ${users.length} users`, 100);
+}
+
+export { downloadUserActivity, downloadAllUserActivity };

--- a/tools/cldr-apps/js/src/esm/cldrUserListExport.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrUserListExport.mjs
@@ -1,6 +1,7 @@
 import * as XLSX from "xlsx";
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrXlsx from "./cldrXlsx.mjs";
+import * as cldrCoverage from "./cldrCoverage.mjs";
 
 // shim global fetch
 const fetch = cldrAjax.doFetch;
@@ -34,22 +35,24 @@ async function downloadUserActivity(userId /*, session*/) {
       "Value", // 3
       "When", // 4
       "URL", // 5
-      // "Coverage", // 6
+      "Coverage", // 6
     ],
   ];
   for (const r of data) {
+    const localeName = r[header.LOCALE_NAME];
+    const xpathId = r[header.XPATH_STRHASH];
+    const locale = r[header.LOCALE];
+    // fetch coverage if not present
+    const coverage =
+      (await cldrCoverage.getCoverageForPath(locale, xpathId)) || "unknown";
     ws_data.push([
-      r[header.LOCALE_NAME],
-      r[header.XPATH_STRHASH],
+      localeName,
+      xpathId,
       r[header.XPATH_CODE],
       r[header.VALUE],
       new Date(r[header.LAST_MOD]), // TODO: convert to 'date'
-      cldrXlsx.getSurveyUrl(
-        r[header.LOCALE_NAME],
-        r[header.XPATH_STRHASH],
-        null
-      ),
-      // r[header.COVERAGE],
+      cldrXlsx.getSurveyUrl(locale, xpathId, null),
+      coverage,
     ]);
   }
   var ws = XLSX.utils.aoa_to_sheet(ws_data);

--- a/tools/cldr-apps/js/src/esm/cldrVettingParticipation.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVettingParticipation.mjs
@@ -264,7 +264,7 @@ function storeInitialResponseData(json) {
 }
 
 async function fetchMoreData() {
-  preloadVotingResults();
+  await preloadVotingResults();
   if (!wasCancelled()) {
     // Note: some code in preloadVotingResults may still be executing
     // while createTable is executing, due to promises for data which
@@ -273,15 +273,23 @@ async function fetchMoreData() {
   }
 }
 
-function preloadVotingResults() {
+const FETCH_LIMIT = 5;
+
+async function preloadVotingResults() {
   let allToFetch = 0; // total count needed to fetch
   let fetched = 0; // number confirmed fetched
+  let currentlyWaiting = [];
+
+  const tasks = [];
+
+  // break the user up into tasks
   for (const [id, user] of Object.entries(vpData.uidToUser)) {
+    user.data = {};
     if (VP_DEBUG) {
       console.log("preloadVotingResults, outer loop, user id = " + id);
     }
     if (wasCancelled()) {
-      return;
+      return null;
     }
     if (!user.locales || !user.locales.length) {
       if (VP_DEBUG) {
@@ -289,8 +297,6 @@ function preloadVotingResults() {
       }
       continue;
     }
-    // "user" here is an object; id = user.id
-    user.data = {};
     for (const locale of user.locales.sort()) {
       if (VP_DEBUG) {
         console.log(
@@ -300,47 +306,77 @@ function preloadVotingResults() {
             locale
         );
       }
+
+      tasks.push({ id, user, locale });
+    }
+  }
+
+  allToFetch = tasks.length;
+
+  // we now have a linearized task list
+  for (const task of tasks) {
+    if (wasCancelled()) {
+      return null;
+    }
+    VP_DEBUG && console.dir(task);
+
+    currentlyWaiting.push(processTask(task));
+    // stop and wait if more than n are waiting
+    if (currentlyWaiting.length > FETCH_LIMIT) {
+      VP_DEBUG && console.log("Waiting for " + currentlyWaiting.length);
+      await Promise.all(currentlyWaiting);
+      currentlyWaiting = []; // reset it so we can wait for more
+    }
+    if (wasCancelled()) {
+      return;
+    }
+  }
+  // wait for the rest at the end
+  VP_DEBUG && console.log("Waiting for the last " + currentlyWaiting.length);
+  await Promise.all(currentlyWaiting);
+
+  /** per-task function. returns a promise for that task. */
+  function processTask({ id, user, locale }) {
+    // "user" here is an object; id = user.id
+    if (wasCancelled()) {
+      return null;
+    }
+    // Specifying "org" for the coverage level means that the server will determine
+    // the coverage level based on the vetter's organization and the locale (where the
+    // vetter is the user whose id is specified here, not the user requesting the data)
+    user.data[locale] = cldrAjax.doFetch(
+      `./api/summary/participation/for/${id}/${locale}/org`
+    );
+    user.data[locale].then(() => {
       if (wasCancelled()) {
         return;
       }
-      // Specifying "org" for the coverage level means that the server will determine
-      // the coverage level based on the vetter's organization and the locale (where the
-      // vetter is the user whose id is specified here, not the user requesting the data)
-      user.data[locale] = cldrAjax.doFetch(
-        `./api/summary/participation/for/${id}/${locale}/org`
-      );
-      allToFetch++;
-
-      user.data[locale].then(() => {
-        if (wasCancelled()) {
-          return;
-        }
-        fetched++;
-        const fetchPercent = cldrProgress.friendlyPercent(fetched, allToFetch);
-        if (VP_DEBUG) {
-          console.log(
-            "preloadVotingResults, delayed effect, fetchPercent = " +
-              fetchPercent +
-              ", user id = " +
-              id +
-              ", locale = " +
-              locale
-          );
-        }
-        const viewData = {
-          message:
-            fetched +
-            "/" +
-            allToFetch +
-            ` Loaded data for Vetter id #${user.id} - ${cldrLoad.getLocaleName(
-              locale
-            )}`,
-          percent: fetchPercent,
-          status: Status.PROCESSING,
-        };
-        callbackToSetData(viewData);
-      });
-    }
+      fetched++;
+      const fetchPercent = cldrProgress.friendlyPercent(fetched, allToFetch);
+      if (VP_DEBUG) {
+        console.log(
+          "preloadVotingResults, delayed effect, fetchPercent = " +
+            fetchPercent +
+            ", user id = " +
+            id +
+            ", locale = " +
+            locale
+        );
+      }
+      const viewData = {
+        message:
+          fetched +
+          "/" +
+          allToFetch +
+          ` Loaded data for Vetter id #${user.id} - ${cldrLoad.getLocaleName(
+            locale
+          )}`,
+        percent: fetchPercent,
+        status: Status.PROCESSING,
+      };
+      callbackToSetData(viewData);
+    });
+    return user.data[locale];
   }
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrVettingParticipation.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVettingParticipation.mjs
@@ -656,4 +656,32 @@ function addColumnComments(worksheet) {
   }
 }
 
-export { Status, cancel, hasPermission, saveAsSheet, start, viewMounted };
+/**
+ * Helper function to fetch the main vetting_participation list
+ * @returns vetting participation spreadsheet
+ */
+async function getVettingParticipationList() {
+  try {
+    // TODO CLDR-19572
+    // note: this is parallel code to.makeRequest(RequestType.START)
+    // but that call site is not structured to use the same structure.
+    const resp = await cldrAjax.doFetch(
+      `SurveyAjax?what=vetting_participation&s=${cldrStatus.getSessionId()}`
+    );
+    const body = await resp.json();
+    return body;
+  } catch (e) {
+    cldrNotify.exception(e, `Loading vetting_participation`);
+    return null;
+  }
+}
+
+export {
+  Status,
+  cancel,
+  hasPermission,
+  saveAsSheet,
+  start,
+  viewMounted,
+  getVettingParticipationList,
+};

--- a/tools/cldr-apps/js/src/esm/cldrXlsx.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrXlsx.mjs
@@ -14,4 +14,14 @@ function pushComment(ws, where, t) {
   ws[where].c.push({ a: "SurveyTool", t });
 }
 
-export { pushComment };
+/**
+ *
+ * @param {String} locale locale for the links
+ * @param {String} strid xpath hash
+ * @param {String?} page optional page
+ */
+function getSurveyUrl(locale, strid, page) {
+  return `https://st.unicode.org/cldr-apps/v#/${locale}/${page || ""}/${strid}`;
+}
+
+export { getSurveyUrl, pushComment };

--- a/tools/cldr-apps/js/src/esm/setUtils.mjs
+++ b/tools/cldr-apps/js/src/esm/setUtils.mjs
@@ -45,4 +45,20 @@ function asList(a) {
   return l;
 }
 
-export { minus, union, asList };
+/**
+ * Return an inverted map, xpath -> coverage
+ * In other words, this maps `{ A: [x,y], B: [z]}` to `{x: A, y: A, z: B}`
+ * @param {Object} map
+ * @internal
+ */
+function invertMap(map) {
+  const r = {};
+  for (const [k, vs] of Object.entries(map)) {
+    vs.forEach((v) => {
+      r[v] = k;
+    });
+  }
+  return r;
+}
+
+export { minus, union, asList, invertMap };

--- a/tools/cldr-apps/js/src/views/DownloadAllUserActivity.vue
+++ b/tools/cldr-apps/js/src/views/DownloadAllUserActivity.vue
@@ -1,20 +1,40 @@
 <script setup>
 import * as cldrUserListExport from "../esm/cldrUserListExport.mjs";
+import * as cldrVettingParticipation from "../esm/cldrVettingParticipation.mjs";
+import * as cldrNotify from "../esm/cldrNotify.mjs";
 
 import { ref } from "vue";
 
 const message = ref("");
 const percent = ref(0);
+const inProgress = ref(false);
 
 function canCancel() {
   return false;
 }
 
 function progressBarStatus() {
-  return "normal";
+  return inProgress.value ? "active" : "normal";
 }
 
-function start() {}
+async function start() {
+  inProgress.value = true;
+  message.value = `Loading…`;
+  const list = await cldrVettingParticipation.getVettingParticipationList();
+  message.value = `Loaded ${list.users.length} users`;
+
+  try {
+    await cldrUserListExport.downloadAllUserActivity(list.users, (m, p) => {
+      message.value = m;
+      percent.value = p;
+    });
+  } catch (e) {
+    message.value = `Error: ${e}`;
+    cldrNotify.exception(e, `downloadAllUserActivity`);
+  }
+
+  inProgress.value = false;
+}
 </script>
 
 <template>

--- a/tools/cldr-apps/js/src/views/DownloadAllUserActivity.vue
+++ b/tools/cldr-apps/js/src/views/DownloadAllUserActivity.vue
@@ -1,0 +1,33 @@
+<script setup>
+import * as cldrUserListExport from "../esm/cldrUserListExport.mjs";
+
+import { ref } from "vue";
+
+const message = ref("");
+const percent = ref(0);
+
+function canCancel() {
+  return false;
+}
+
+function progressBarStatus() {
+  return "normal";
+}
+
+function start() {}
+</script>
+
+<template>
+  <p>
+    This section will download a large .xlsx file with all of your user’s
+    activity for this release.
+  </p>
+
+  <button v-if="canCancel()" @click="cancel()">Cancel</button>
+  <button v-else @click="start()">Generate .xlsx</button>
+  <br />
+  <p class="progressBar">
+    <a-progress :percent="percent" :status="progressBarStatus()" />
+  </p>
+  <p v-if="message">{{ message }}</p>
+</template>

--- a/tools/cldr-apps/js/src/views/VettingParticipation.vue
+++ b/tools/cldr-apps/js/src/views/VettingParticipation.vue
@@ -3,9 +3,11 @@ import { onMounted, ref, reactive } from "vue";
 
 import * as cldrVettingParticipation from "../esm/cldrVettingParticipation.mjs";
 import * as cldrStatus from "../esm/cldrStatus.mjs";
+import DownloadAllUserActivity from "./DownloadAllUserActivity.vue";
 
 const STATUS = cldrVettingParticipation.Status;
 
+const shownPanel = ref(["participation"]);
 let hasPermission = ref(false);
 let isTcOrg = ref(false);
 let message = ref("");
@@ -92,50 +94,57 @@ defineExpose({
       (Your organization is not enabled for Vetting Participation.)
     </span>
   </div>
-  <div v-else>
-    <p v-if="status != STATUS.INIT">Generation Status: {{ status }}</p>
-    <p class="buttons">
-      <button v-if="canCancel()" @click="cancel()">Cancel</button>
-      <button v-else @click="start()">Generate Table Now</button>
-    </p>
-    <p class="progressBar">
-      <a-progress :percent="percent" :status="progressBarStatus()" />
-    </p>
-    <p v-if="message">{{ message }}</p>
-    <hr />
-    <div v-if="tableHeader && tableComments && tableBody">
+  <a-collapse v-model:activeKey="shownPanel" accordion v-else>
+    <a-collapse-panel key="participation" header="Vetting Participation Table">
+      <p v-if="status != STATUS.INIT">Generation Status: {{ status }}</p>
       <p class="buttons">
-        <button @click="saveAsSheet">Save as Spreadsheet .xlsx</button>
+        <button v-if="canCancel()" @click="cancel()">Cancel</button>
+        <button v-else @click="start()">Generate Table Now</button>
       </p>
-      <table>
-        <thead>
-          <tr>
-            <th v-for="(cell, index) of tableHeader" :key="cell">
-              <a-tooltip :title="tableComments[index]">
-                {{ cell }}
-              </a-tooltip>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="row of tableBody" :key="row">
-            <td v-for="(cell, index) of row" :key="cell">
-              <div v-if="accountColumnIndex == index">
-                <a-tooltip title="Show recent activity ↗">
-                  <a :href="accountRecentActivityLink(cell)" target="_blank">{{
-                    cell
-                  }}</a>
+      <p class="progressBar">
+        <a-progress :percent="percent" :status="progressBarStatus()" />
+      </p>
+      <p v-if="message">{{ message }}</p>
+      <hr />
+      <div v-if="tableHeader && tableComments && tableBody">
+        <p class="buttons">
+          <button @click="saveAsSheet">Save as Spreadsheet .xlsx</button>
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th v-for="(cell, index) of tableHeader" :key="cell">
+                <a-tooltip :title="tableComments[index]">
+                  {{ cell }}
                 </a-tooltip>
-              </div>
-              <div v-else>
-                {{ cell }}
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row of tableBody" :key="row">
+              <td v-for="(cell, index) of row" :key="cell">
+                <div v-if="accountColumnIndex == index">
+                  <a-tooltip title="Show recent activity ↗">
+                    <a
+                      :href="accountRecentActivityLink(cell)"
+                      target="_blank"
+                      >{{ cell }}</a
+                    >
+                  </a-tooltip>
+                </div>
+                <div v-else>
+                  {{ cell }}
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </a-collapse-panel>
+    <a-collapse-panel key="download" header="Download all user activity">
+      <DownloadAllUserActivity />
+    </a-collapse-panel>
+  </a-collapse>
 </template>
 
 <style scoped>

--- a/tools/cldr-apps/js/test/nonbrowser/test-cldrSetUtils.mjs
+++ b/tools/cldr-apps/js/test/nonbrowser/test-cldrSetUtils.mjs
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import mocha from "mocha";
+
+import { invertMap } from "../../src/esm/setUtils.mjs";
+
+describe("setUtils test", function () {
+  describe("invertMap", function () {
+    it("Should be able to invert an object", () => {
+      const input = {
+        MODERN: ["m3", "m1", "m2", "m0"],
+        CORE: ["c0"],
+      };
+      const expected = {
+        m0: "MODERN",
+        m1: "MODERN",
+        m2: "MODERN",
+        m3: "MODERN",
+        c0: "CORE",
+      };
+      const actual = invertMap(input);
+      expect(actual).to.deep.equal(expected);
+    });
+  });
+});

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -3379,6 +3379,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
     }
 
     public boolean isValidLocale(CLDRLocale locale) {
+        if (locale == null) return false;
         return getLocalesSet().contains(locale);
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -110,9 +110,9 @@ public class VoteAPIHelper {
 
     static Response handleGetLocaleErrors(String loc) {
         final SurveyMain sm = CookieSession.sm;
-        final CLDRLocale locale = CLDRLocale.getInstance(loc);
+        final CLDRLocale locale = CLDRLocale.getExistingInstance(loc);
         final STFactory factory = sm.getSTFactory();
-        if (!factory.getAvailableCLDRLocales().contains(locale)) {
+        if (locale == null || !factory.getAvailableCLDRLocales().contains(locale)) {
             // locale not found
             return Response.status(404).build();
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
@@ -197,18 +197,27 @@ public class XPathAPI {
 
     public final class LocaleCoverageInfo {
         @Schema(description = "map from coverage level to array of xpath string ids")
+        /**
+         * Example: "CORE": [ "6cf943e652b01478", ], "MODERATE": [ "4a74ce35a9fa3778", ], "MODERN":
+         * [ "11d5a244a70d1edd", "3a6f1bf0dd41ae4c", "3ebe0f49892a8a85", ],
+         */
         public Map<String, Collection<String>> coverageToXpaths = new TreeMap<>();
 
+        /** Compute all coverage levels for a locale. This is cached client-side. */
         public LocaleCoverageInfo(String locale) {
             SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
             CLDRFile f = CookieSession.sm.getDiskFactory().make(locale, true);
             CoverageLevel2 cov = sdi.getCoverageLevelInfo(locale);
+            // get all XPaths
             for (final String x : f.fullIterable()) {
+                // get the coverage level
                 final Level l = cov.getLevel(x);
-                final Collection<String> subSet =
+                // get the set of XPaths at this coverage level
+                final Collection<String> pathsAtThisCoverageLevel =
                         coverageToXpaths.computeIfAbsent(
                                 l.name(), (String key) -> new ArrayList<>());
-                subSet.add(XPathTable.getStringIDString(x));
+                // add the XPath StringId to the list
+                pathsAtThisCoverageLevel.add(XPathTable.getStringIDString(x));
             }
         }
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
@@ -1,7 +1,12 @@
 package org.unicode.cldr.web.api;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -16,6 +21,12 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.unicode.cldr.test.CoverageLevel2;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.web.CookieSession;
 import org.unicode.cldr.web.XPathTable;
 
@@ -182,6 +193,69 @@ public class XPathAPI {
                                 .setHexId(xpt.getStringIDString(decId))
                                 .setXpath(xpath))
                 .build();
+    }
+
+    public final class LocaleCoverageInfo {
+        @Schema(description = "map from coverage level to array of xpath string ids")
+        public Map<String, Collection<String>> coverageToXpaths = new TreeMap<>();
+
+        public LocaleCoverageInfo(String locale) {
+            SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
+            CLDRFile f = CookieSession.sm.getDiskFactory().make(locale, true);
+            CoverageLevel2 cov = sdi.getCoverageLevelInfo(locale);
+            for (final String x : f.fullIterable()) {
+                final Level l = cov.getLevel(x);
+                final Collection<String> subSet =
+                        coverageToXpaths.computeIfAbsent(
+                                l.name(), (String key) -> new ArrayList<>());
+                subSet.add(XPathTable.getStringIDString(x));
+            }
+        }
+    }
+
+    @GET
+    @Path("/coverage/{locale}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Get all coverage buckets for a locale")
+    @APIResponses(
+            value = {
+                @APIResponse(
+                        responseCode = "404",
+                        description = "Locale not found",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = STError.class))),
+                @APIResponse(
+                        responseCode = "200",
+                        description = "Details about a given Locale",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(implementation = LocaleCoverageInfo.class)))
+            })
+    public Response getCoverageForLocale(
+            @Parameter(required = true, example = "mt", schema = @Schema(type = SchemaType.STRING))
+                    @PathParam("locale")
+                    String locale,
+            @HeaderParam(Auth.SESSION_HEADER) String session) {
+        // somewhat expensive operation, so we'll verify session
+        // Verify session
+        final CookieSession mySession = Auth.getSession(session);
+        if (mySession == null) {
+            return Auth.noSessionResponse();
+        }
+        // somewhat expensive, so we'll require a user, for now
+        if (mySession.user == null) {
+            return Response.status(Response.Status.FORBIDDEN.getStatusCode()).build();
+        }
+        if (!CookieSession.sm.isValidLocale(CLDRLocale.getExistingInstance(locale))) {
+            // locale not found
+            return Response.status(404).build();
+        }
+
+        return Response.ok(new LocaleCoverageInfo(locale)).build();
     }
 
     private final XPathTable getXPathTable() {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAPI.java
@@ -1,9 +1,9 @@
 package org.unicode.cldr.web.api;
 
-import java.util.ArrayList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
 import java.util.Collection;
 import java.util.Map;
-import java.util.TreeMap;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -201,24 +201,23 @@ public class XPathAPI {
          * Example: "CORE": [ "6cf943e652b01478", ], "MODERATE": [ "4a74ce35a9fa3778", ], "MODERN":
          * [ "11d5a244a70d1edd", "3a6f1bf0dd41ae4c", "3ebe0f49892a8a85", ],
          */
-        public Map<String, Collection<String>> coverageToXpaths = new TreeMap<>();
+        public final Map<String, Collection<String>> coverageToXpaths;
 
         /** Compute all coverage levels for a locale. This is cached client-side. */
         public LocaleCoverageInfo(String locale) {
             SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
             CLDRFile f = CookieSession.sm.getDiskFactory().make(locale, true);
             CoverageLevel2 cov = sdi.getCoverageLevelInfo(locale);
+            Multimap<String, String> coverageToXPathID = TreeMultimap.create();
+
             // get all XPaths
             for (final String x : f.fullIterable()) {
                 // get the coverage level
                 final Level l = cov.getLevel(x);
                 // get the set of XPaths at this coverage level
-                final Collection<String> pathsAtThisCoverageLevel =
-                        coverageToXpaths.computeIfAbsent(
-                                l.name(), (String key) -> new ArrayList<>());
-                // add the XPath StringId to the list
-                pathsAtThisCoverageLevel.add(XPathTable.getStringIDString(x));
+                coverageToXPathID.put(l.name(), XPathTable.getStringIDString(x));
             }
+            coverageToXpaths = coverageToXPathID.asMap();
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -2869,7 +2869,7 @@ public class SupplementalDataInfo {
     }
 
     /**
-     * Get the raw coverage level info
+     * Get the raw coverage level info object.
      *
      * @param loc
      * @return

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -2861,16 +2861,24 @@ public class SupplementalDataInfo {
         Level result = null;
         result = coverageCache.get(xpath, loc);
         if (result == null) {
-            CoverageLevel2 cov = localeToCoverageLevelInfo.get(loc);
-            if (cov == null) {
-                cov = CoverageLevel2.getInstance(this, loc);
-                localeToCoverageLevelInfo.put(loc, cov);
-            }
-
+            CoverageLevel2 cov = getCoverageLevelInfo(loc);
             result = cov.getLevel(xpath);
             coverageCache.put(xpath, loc, result);
         }
         return result;
+    }
+
+    /**
+     * Get the raw coverage level info
+     *
+     * @param loc
+     * @return
+     */
+    public final CoverageLevel2 getCoverageLevelInfo(String loc) {
+        CoverageLevel2 cov =
+                localeToCoverageLevelInfo.computeIfAbsent(
+                        loc, (String key) -> CoverageLevel2.getInstance(this, key));
+        return cov;
     }
 
     /**


### PR DESCRIPTION
- add new REST API for getting coverage-by-locale - cached on the client
- add URL to the user activity sheet


the 'user activity' sheet now has a URL and Coverage column:

<img width="397" height="241" alt="image" src="https://github.com/user-attachments/assets/77b20e0e-53ff-4686-b513-bdbc15444c57" />

- Also fixes a problem where VettingParticipation would send too many requests at once
- Also, add a VettingParticipation feature to download  ALL ACTIVITY FROM ALL OF YOUR USERS

<img width="686" height="396" alt="image" src="https://github.com/user-attachments/assets/b81b5037-7052-4f2e-a9da-fe1330ae5421" />

Partial copy of the spreasheet: 

<img width="792" height="524" alt="image" src="https://github.com/user-attachments/assets/6f124709-f787-40b0-ba4e-0d950ac308bd" />



CLDR-19572

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
