### PR TITLE
fix(cy): set abbreviated am/pm to yb/yh instead of inheriting from root

### DIFF
--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -1702,9 +1702,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="abbreviated">
 							<dayPeriod type="midnight">canol nos</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="am">yb</dayPeriod>
 							<dayPeriod type="noon">canol dydd</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">yh</dayPeriod>
 							<dayPeriod type="morning1">y bore</dayPeriod>
 							<dayPeriod type="afternoon1">y prynhawn</dayPeriod>
 							<dayPeriod type="evening1">yr hwyr</dayPeriod>
@@ -1731,9 +1731,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
 							<dayPeriod type="midnight">↑↑↑</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="am">yb</dayPeriod>
 							<dayPeriod type="noon">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">yh</dayPeriod>
 							<dayPeriod type="morning1">bore</dayPeriod>
 							<dayPeriod type="afternoon1">prynhawn</dayPeriod>
 							<dayPeriod type="evening1">↑↑↑</dayPeriod>

--- a/common/testData/datetime/datetime.json
+++ b/common/testData/datetime/datetime.json
@@ -2886,5 +2886,85 @@
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
     "expected": "12:00:00"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hm",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T09:30:00Z[Etc/GMT]",
+    "expected": "9:30 yb"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hm",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T14:30:00Z[Etc/GMT]",
+    "expected": "2:30 yh"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T09:30:00Z[Etc/GMT]",
+    "expected": "9:30:00 yb"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T14:30:00Z[Etc/GMT]",
+    "expected": "2:30:00 yh"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hm",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T09:30:00Z[Etc/GMT]",
+    "expected": "9:30 yb"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hm",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T14:30:00Z[Etc/GMT]",
+    "expected": "2:30 yh"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T09:30:00Z[Etc/GMT]",
+    "expected": "9:30:00 yb"
+  },
+  {
+    "semanticSkeleton": "T",
+    "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
+    "hourCycle": "H12",
+    "calendar": "gregorian",
+    "locale": "cy",
+    "input": "2024-07-01T14:30:00Z[Etc/GMT]",
+    "expected": "2:30:00 yh"
   }
 ]


### PR DESCRIPTION
## Summary

Welsh users formatting 12-hour times (e.g. `h:mm a`) receive the English strings `AM`/`PM` instead of the Welsh abbreviated day-period forms `yb` (y bore) and `yh` (yr hwyr). This regressed between CLDR 47 and CLDR 48.

## Root cause

In `common/main/cy.xml` the `format/abbreviated` am and pm entries were `↑↑↑` in both releases — the data itself did not change. Under ICU 77 (CLDR 47) this was masked by a lateral fallback that resolved `↑↑↑` at the abbreviated width to the locale's own wide entries (`yb`/`yh`). ICU 78 (CLDR 48) now resolves `↑↑↑` correctly against the parent locale (root), which has `AM`/`PM`, surfacing the gap.

The identifying commit is **`f81989f8b`** (`CLDR-18850 v48 vxml merge to main`), which is the Survey Tool merge that left `format/abbreviated` am/pm as `↑↑↑`.

## Changes

- **`common/main/cy.xml`** — replace `↑↑↑` with `yb`/`yh` in both `format/abbreviated` and `stand-alone/abbreviated` contexts, consistent with the existing `wide` entries.
- **`common/testData/datetime/datetime.json`** — add four test cases (`hm`/`hms` × AM/PM for locale `cy`) to prevent silent regression.

## Reproduction (Node.js / Intl, which delegates to ICU)

```js
// Pass: Node 24.13.0 / ICU 77.1 / CLDR 47
// Fail: Node 24.16.0 / ICU 78.3 / CLDR 48

const fmt = new Intl.DateTimeFormat('cy', {
  hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'UTC',
});

const parts = fmt.formatToParts(new Date('2024-07-01T09:30:00Z'));
const period = parts.find(p => p.type === 'dayPeriod')?.value;
// CLDR 47: "yb"  ✓
// CLDR 48: "AM"  ✗
console.log(period);
```

## Diff

```diff
 <dayPeriodContext type="format">
   <dayPeriodWidth type="abbreviated">
     <dayPeriod type="midnight">canol nos</dayPeriod>
-    <dayPeriod type="am">↑↑↑</dayPeriod>
+    <dayPeriod type="am">yb</dayPeriod>
     <dayPeriod type="noon">canol dydd</dayPeriod>
-    <dayPeriod type="pm">↑↑↑</dayPeriod>
+    <dayPeriod type="pm">yh</dayPeriod>
     ...
   </dayPeriodWidth>
```