### PR TITLE
CLDR-19575 add testsForMissingItem to row response

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -328,9 +328,6 @@ function addInfoMessage(html) {
 }
 
 function addSelectedItem(theRow) {
-  if (!selectedItemWrapper) {
-    return;
-  }
   const item = findSelectedItem(theRow);
 
   const { displayValue, valueClass } = getValueAndClass(theRow, item);
@@ -345,10 +342,17 @@ function addSelectedItem(theRow) {
   const { linkUrl, linkText } = getLinkUrlAndText(theRow, item);
   selectedItemWrapper.setLink(linkUrl, linkText);
 
-  const testHtml = item?.tests
-    ? cldrSurvey.testsToHtml(item.tests)
-    : "<i>no tests</i>";
-  selectedItemWrapper.setTestHtml(testHtml);
+  if (item) {
+    const testHtml = item?.tests
+      ? cldrSurvey.testsToHtml(item.tests)
+      : "<i>no tests</i>";
+    selectedItemWrapper.setTestHtml(testHtml);
+  } else {
+    // missing item, but there may be errors.
+    const tests = theRow.testsForMissingItem;
+    const testHtml = tests ? cldrSurvey.testsToHtml(tests) : "<i>no tests</i>";
+    selectedItemWrapper.setTestHtml(testHtml);
+  }
 
   selectedItemWrapper.setExampleHtml(item?.example);
 }
@@ -617,7 +621,12 @@ function addXpath(theRow) {
 
 function getItemDescription(candidateStatus, theRow) {
   if (!candidateStatus) {
-    return "";
+    if (theRow.testsForMissingItem?.length) {
+      return cldrText.get("item_description_missing_tests");
+    } else {
+      // won't be shown
+      return "";
+    }
   }
   /*
    * candidateStatus may be "winner, "alias", "constructed", "fallback", "fallback_code", "fallback_root", or "loser".

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -836,6 +836,26 @@ function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
       theRow.winningVhash,
       cldrSurvey.cloneAnon(protoButton)
     );
+  } else if (theRow.testsForMissingItem?.length) {
+    const errorMajorTypes = new Set(
+      theRow.testsForMissingItem.map(({ type }) => type)
+    );
+    let worstType = "Unknown";
+    if (errorMajorTypes.has("Error")) {
+      worstType = "Error";
+    } else if (errorMajorTypes.has("Warning")) {
+      worstType = "Warning";
+    }
+    const icon = cldrSurvey.addIcon(
+      cell,
+      worstType === "Error" ? "i-stop" : "i-warn"
+    );
+    icon.setAttribute("dir", "ltr");
+    icon.title = cldrText.get("item_description_missing_tests");
+    cldrDom.addClass(
+      cell,
+      worstType === "Error" ? "d-item-err-noicon" : "d-item-warn"
+    );
   }
 
   if (theRow.votingResults.votesForMissing) {

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -815,6 +815,9 @@ function updateRowEnglishComparisonCell(tr, theRow, cell) {
  */
 function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
   cldrDom.removeAllChildNodes(cell); // win
+  // reset these classes in case they were set below.
+  cldrDom.removeClass(cell, "d-item-err-noicon");
+  cldrDom.removeClass(cell, "d-item-warn");
   if (theRow.rowFlagged) {
     const flagIcon = cldrSurvey.addIcon(cell, "s-flag");
     flagIcon.title = cldrText.get("flag_desc");

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -185,6 +185,8 @@ const strings = {
     "This item is inherited from the root locale.",
   item_description_loser: "This item is currently losing.",
   item_description_fallback: "This item is inherited from the ${0} locale.",
+  item_description_missing_tests:
+    "This item is missing, but there are errors/warnings.",
   followAlias: "Jump to Original ⇒",
   noFollowAlias: "This item is constructed from other values.",
 
@@ -671,6 +673,7 @@ function sub(k, map) {
  * @return the string with substitutions made, or an empty string for failure
  */
 function subTemplate(template, map) {
+  if (!map) return template; // if no map was provided
   if (template) {
     if (map instanceof Array) {
       return template.replace(/\${(\d)}/g, (blank, i) => map[i]);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
@@ -81,6 +81,9 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
             // change, just as if the user had never voted.
             if (value == CldrUtility.INHERITANCE_MARKER && status == Status.missing) {
                 value = null;
+            } else if (value.equals(VoteResolver.NO_WINNING_VALUE)) {
+                // this is a non-value, there was an abstension. remove the path.
+                value = null;
             }
             fullPath = getFullPathWithResolver(path, resolver);
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -1148,6 +1148,14 @@ public class DataPage {
         public boolean fixedCandidates() {
             return haveFixedCandidates;
         }
+
+        @Override
+        public List<CheckStatus> getMissingCheckStatusList() {
+            if (inheritedItem != null && inheritedItem.rawValue == null) {
+                return inheritedItem.getCheckStatusList();
+            }
+            return null;
+        }
     }
 
     /*

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -693,6 +693,14 @@ public class DataPage {
             return pathHeader;
         }
 
+        public List<CheckStatus> getTestsForMissingItem() {
+            if (inheritedItem != null && inheritedItem.rawValue == null) {
+                return inheritedItem.getTests();
+            } else {
+                return null;
+            }
+        }
+
         /**
          * Get the CandidateItem for this DataRow that has the given value.
          *
@@ -746,6 +754,7 @@ public class DataPage {
             if (inheritedItem == null) {
                 CandidateItem shimItem = new CandidateItem(null);
                 List<CheckStatus> iTests = new ArrayList<>();
+                // TODO CLDR-19575: should be TestCache from checkCldr
                 checkCldr.check(base_xpath_string, iTests, null);
                 STFactory.removeExcludedChecks(iTests);
                 if (!iTests.isEmpty()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -254,6 +254,11 @@ public class VoteAPI {
 
             @Schema(description = "True if candidates are fixed (disable plus).", example = "false")
             public boolean fixedCandidates;
+
+            @Schema(
+                    description =
+                            "If set, these are tests which are on the 'missing' item, since there is no candidate item.")
+            public CheckStatusSummary testsForMissingItem[];
         }
 
         public static final class Page {
@@ -473,6 +478,18 @@ public class VoteAPI {
                 this.subtypeUrl = SubtypeToURLMap.forSubtype(this.subtype); // could be null.
             }
             this.entireLocale = checkStatus.getEntireLocale();
+        }
+
+        /** convert one CheckStatus into a CheckStatusSummary for streaming */
+        public static CheckStatusSummary of(CheckStatus cs) {
+            if (cs == null) return null;
+            return new CheckStatusSummary(cs);
+        }
+
+        /** Convert a whole list of CheckStatus */
+        public static CheckStatusSummary[] of(List<CheckStatus> checkList) {
+            if (checkList == null || checkList.isEmpty()) return null;
+            return checkList.stream().map(cs -> of(cs)).toArray(s -> new CheckStatusSummary[s]);
         }
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.web.DataPage.DataRow;
 import org.unicode.cldr.web.DataPage.DataRow.CandidateItem;
 import org.unicode.cldr.web.SurveyException.ErrorCode;
 import org.unicode.cldr.web.UserRegistry.User;
+import org.unicode.cldr.web.api.VoteAPI.CheckStatusSummary;
 import org.unicode.cldr.web.api.VoteAPI.EntireLocaleStatusResponse;
 import org.unicode.cldr.web.api.VoteAPI.RowResponse;
 import org.unicode.cldr.web.api.VoteAPI.RowResponse.Row.Candidate;
@@ -340,6 +341,7 @@ public class VoteAPIHelper {
         row.xpstrid = XPathTable.getStringIDString(xpath);
         row.fixedCandidates = r.fixedCandidates();
         row.noEscaping = DisplayAndInputProcessor.hasUnicodeSetValue(xpath);
+        row.testsForMissingItem = CheckStatusSummary.of(r.getTestsForMissingItem());
         return row;
     }
 

--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -2691,6 +2691,12 @@ transition: background-color 0.2s;
 	height: 17px;
 	background: url(stop.png) no-repeat center center;
 }
+.i-warn {
+	padding: 2px;
+	width: 17px;
+	height: 17px;
+	background: url(warn.png) no-repeat center center;
+}
 .i-flag {
 	padding: 2px;
 	width: 17px;
@@ -2724,6 +2730,10 @@ td.d-change,td.d-change-err,td.d-change-warn {
 
 td.d-change-err, td.d-win-err, .d-item-err {
 	background: #fa9092 url(stop.png) no-repeat right top !important;
+}
+
+.d-item-err-noicon {
+	background: #fa9092;
 }
 
 td.d-change-confirmonly {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -252,8 +252,13 @@ public abstract class CheckCLDR implements CheckAccessor {
 
             ValueStatus valueStatus = ValueStatus.NONE;
             if (pathValueInfo != null) {
+                // compute any errs/warning on missing
+                valueStatus =
+                        ValueStatus.forList(
+                                pathValueInfo.getMissingCheckStatusList(), null, valueStatus);
+                // compute error status for winner
                 CandidateInfo winner = pathValueInfo.getCurrentItem();
-                valueStatus = getValueStatus(winner, ValueStatus.NONE, null);
+                valueStatus = getValueStatus(winner, valueStatus, null);
 
                 // if limited submission, and winner doesn't have an error, limit the values
 
@@ -330,10 +335,10 @@ public abstract class CheckCLDR implements CheckAccessor {
                 return StatusAction.ALLOW;
             }
 
-            // Disallow errors.
-            ValueStatus valueStatus =
+            // Disallow errors in the newly entered item.
+            ValueStatus valueStatusOnNewItem =
                     getValueStatus(enteredValue, ValueStatus.NONE, CheckStatus.crossCheckSubtypes);
-            if (valueStatus == ValueStatus.ERROR) {
+            if (valueStatusOnNewItem == ValueStatus.ERROR) {
                 return StatusAction.FORBID_ERRORS;
             }
 
@@ -342,52 +347,78 @@ public abstract class CheckCLDR implements CheckAccessor {
                 return StatusAction.ALLOW;
             }
 
-            // Voting for an existing value is ok
-            valueStatus = ValueStatus.NONE;
-            for (CandidateInfo value : pathValueInfo.getValues()) {
-                if (value == enteredValue) {
-                    return StatusAction.ALLOW;
+            // this is a separate ValueStatus, on the existing items.
+            /** Note: Parallel to {@link #getShowRowAction} */
+            ValueStatus valueStatusOnExistingItems = ValueStatus.NONE;
+            if (pathValueInfo != null) {
+                // Check if there are checks on the 'missing' item.
+                valueStatusOnExistingItems =
+                        ValueStatus.forList(
+                                pathValueInfo.getMissingCheckStatusList(),
+                                CheckStatus.crossCheckSubtypes,
+                                valueStatusOnExistingItems);
+                // Check for checks on any candidate.
+                for (CandidateInfo value : pathValueInfo.getValues()) {
+                    if (value == enteredValue) {
+                        // voting for an existing value - always allowed in this phase.
+                        return StatusAction.ALLOW;
+                    }
+                    // pick up any valueStatus from existing items
+                    valueStatusOnExistingItems =
+                            getValueStatus(
+                                    value,
+                                    valueStatusOnExistingItems,
+                                    CheckStatus.crossCheckSubtypes);
                 }
-                valueStatus = getValueStatus(value, valueStatus, CheckStatus.crossCheckSubtypes);
             }
 
             // If there were any errors/warnings on other values, allow
-            if (valueStatus != ValueStatus.NONE) {
+            if (valueStatusOnExistingItems != ValueStatus.NONE) {
                 return StatusAction.ALLOW;
             }
 
             // Otherwise (we are vetting, but with no errors or warnings)
             // DISALLOW NEW STUFF
-
             return StatusAction.FORBID_UNLESS_DATA_SUBMISSION;
         }
 
+        /** Analog to CheckCLDR.ErrorType, simplified for status resolution */
         public enum ValueStatus {
             ERROR,
             WARNING,
-            NONE
+            NONE;
+
+            /** Compute the ValueStatus for a CheckStatus list */
+            public static ValueStatus forList(
+                    List<CheckStatus> list,
+                    Set<Subtype> changeErrorToWarning,
+                    ValueStatus previous) {
+                if (list == null) return previous;
+                for (CheckStatus item : list) {
+                    CheckStatus.Type type = item.getType();
+                    if (type.equals(CheckStatus.Type.Error)) {
+                        if (changeErrorToWarning != null
+                                && changeErrorToWarning.contains(item.getSubtype())) {
+                            return ValueStatus.WARNING;
+                        } else {
+                            return ValueStatus.ERROR;
+                        }
+                    } else if (type.equals(CheckStatus.Type.Warning)) {
+                        previous = ValueStatus.WARNING;
+                    }
+                }
+                return previous;
+            }
         }
 
         public ValueStatus getValueStatus(
                 CandidateInfo value, ValueStatus previous, Set<Subtype> changeErrorToWarning) {
             if (previous == ValueStatus.ERROR || value == null) {
+                // short cut, we're not going to upgrade from ERROR
                 return previous;
             }
 
-            for (CheckStatus item : value.getCheckStatusList()) {
-                CheckStatus.Type type = item.getType();
-                if (type.equals(CheckStatus.Type.Error)) {
-                    if (changeErrorToWarning != null
-                            && changeErrorToWarning.contains(item.getSubtype())) {
-                        return ValueStatus.WARNING;
-                    } else {
-                        return ValueStatus.ERROR;
-                    }
-                } else if (type.equals(CheckStatus.Type.Warning)) {
-                    previous = ValueStatus.WARNING;
-                }
-            }
-            return previous;
+            return ValueStatus.forList(value.getCheckStatusList(), changeErrorToWarning, previous);
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
@@ -51,10 +51,11 @@ public class CheckLogicalGroupings extends FactoryCheckCLDR {
         return this;
     }
 
-    // remember to add this class to the list in CheckCLDR.getCheckAll
-    // to run just this test, on just locales starting with 'nl', use CheckCLDR with -fnl.*
-    // -t.*LogicalGroupings.*
-
+    /**
+     * remember to add this class to the list in {@link CheckCLDR#getCheckAll} <br>
+     * to run just this test, on just locales starting with 'nl', use CheckCLDR with <code>
+     * -fnl.* -t.*LogicalGroupings.*</code>
+     */
     @Override
     public CheckCLDR handleCheck(
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRInfo.java
@@ -31,6 +31,9 @@ public class CLDRInfo {
         CLDRLocale getLocale();
 
         String getXpath();
+
+        /** get the CheckStatus for any missing items, such as logical group errors, or null */
+        List<CheckStatus> getMissingCheckStatusList();
     }
 
     public interface CandidateInfo { // DataPage.DataRow.CandidateItem will implement

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -1381,6 +1381,11 @@ public class TestCheckCLDR extends TestFmwk {
         public void setBaselineValue(String baselineValue) {
             this.baselineValue = baselineValue;
         }
+
+        @Override
+        public List<CheckStatus> getMissingCheckStatusList() {
+            return null;
+        }
     }
 
     final Set<String> cldrLocales =


### PR DESCRIPTION
- DataRow.setShimTests() has handled the error-but-missing case for literally a dozen years, however, the 'new' api did not serialize the case
- Previously, the entire DataPage was serialized as-is, and so had a case where inheritedItem was a synthetic item (value=null) but that contained the tests on the missing item.
- Anyway, the 'new' voting API did not pick up on this situation.
- This commit adds a Row.testsForMissingItem[] array with any errors that are on a missing item.
- the FE should check for this value and show the errors appropriately.

The payload looks like this (this is on a partial Row)

```json
{
        "testsForMissingItem": [
          {
            "cause": "CheckLogicalGroupings",
            "entireLocale": false,
            "message": "Incomplete logical group - missing values for: [<a class=\"pathReference\" href=\"/cldr-apps/v#/ga/Europe/7ef2abe841a36d8f\">generic-long</a>]; level=moderate",
            "phase": "VETTING",
            "subtype": "incompleteLogicalGroup",
            "subtypeUrl": "https://cldr.unicode.org/translation/getting-started/resolving-errors",
            "type": "Error"
          }
        ]
}
```

CLDR-19575

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
