### PR TITLE
CLDR-19464 remove maven cache

### DIFF
--- a/tools/cldr-apps/docker/featureUtility.properties
+++ b/tools/cldr-apps/docker/featureUtility.properties
@@ -2,6 +2,6 @@
 ## attempt to work around maven issue
 #mavenCentralMirror.url=https://repo1.maven.org/maven2/
 #mavenCentralMirror.url=https://maven-central.storage-download.googleapis.com/maven2/
-mavenCentralMirror.url=https://cldr-staging.unicode.org/repository/maven-central/
+#mavenCentralMirror.url=https://cldr-staging.unicode.org/repository/maven-central/
 #
 


### PR DESCRIPTION
CLDR-19464

See if we have improved docker caching enough that we don't need this special maven cache.

ALLOW_MANY_COMMITS=true