### PR TITLE
CLDR-19575 improve robustness of .testsForMissingItem logic

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -349,7 +349,7 @@ function addSelectedItem(theRow) {
     selectedItemWrapper.setTestHtml(testHtml);
   } else {
     // missing item, but there may be errors.
-    const tests = theRow.testsForMissingItem;
+    const tests = theRow?.testsForMissingItem;
     const testHtml = tests ? cldrSurvey.testsToHtml(tests) : "<i>no tests</i>";
     selectedItemWrapper.setTestHtml(testHtml);
   }
@@ -621,7 +621,7 @@ function addXpath(theRow) {
 
 function getItemDescription(candidateStatus, theRow) {
   if (!candidateStatus) {
-    if (theRow.testsForMissingItem?.length) {
+    if (theRow?.testsForMissingItem?.length) {
       return cldrText.get("item_description_missing_tests");
     } else {
       // won't be shown

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -839,9 +839,9 @@ function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
       theRow.winningVhash,
       cldrSurvey.cloneAnon(protoButton)
     );
-  } else if (theRow.testsForMissingItem?.length) {
+  } else if (theRow?.testsForMissingItem?.length) {
     const errorMajorTypes = new Set(
-      theRow.testsForMissingItem.map(({ type }) => type)
+      theRow?.testsForMissingItem.map(({ type }) => type)
     );
     let worstType = "Unknown";
     if (errorMajorTypes.has("Error")) {


### PR DESCRIPTION
some of these must be called in a startup situation, where some more defensive logic is needed.