### PR TITLE
CLDR-19326 deps: JDK 21

### DIFF
--- a/.github/workflows/build-icu.yml
+++ b/.github/workflows/build-icu.yml
@@ -1,7 +1,8 @@
 # Build ICU
 
 name: Build ICU from CLDR
-
+env:
+  JDK_VERSION: 21
 on:
   workflow_dispatch:
     inputs:
@@ -35,7 +36,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4
@@ -90,7 +91,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Setup Maven Settings
         uses: s4u/maven-settings-action@v2.8.0
@@ -232,7 +233,7 @@ jobs:
         run: cd icu4c/source && ./runConfigureICU Linux && make -j2 && make -C data icu4j-data-install ICU4J_ROOT=$(cd ../../icu4j ; pwd)
       - uses: actions/setup-java@v4
         with:
-          java-version: '16' # For ICU4J
+          java-version: ${{ env.JDK_VERSION }} # For ICU4J
           distribution: 'temurin'
       - name: ICU4J Build
         run: |

--- a/.github/workflows/cldr-modify.yml
+++ b/.github/workflows/cldr-modify.yml
@@ -6,6 +6,7 @@ env:
   CLDR_DIR: ${{ github.workspace }}
   AUTO_BRANCH: auto/cldrmodify/main
   AUTO_REMOTE: origin
+  JDK_VERSION: 21
 
 on:
   push:
@@ -28,7 +29,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,7 @@
 name: "CodeQL"
 
+env:
+  JDK_VERSION: 21
 on:
   push:
     branches: [ main, keyboard*, maint/maint-* ]
@@ -37,7 +39,7 @@ jobs:
       if: matrix.language == 'java'
       uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: ${{ env.JDK_VERSION }}
         distribution: 'temurin'
     - name: Cache local Maven repository
       if: matrix.language == 'java'

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,5 +1,7 @@
 name: cldr-mvn-deploy
 
+env:
+  JDK_VERSION: 21
 on:
   release:
     types: [created]
@@ -25,7 +27,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,7 @@ env:
   ## uncomment only ONE of these
   # CLDR_CHECK_MODE: FINAL_TESTING
   CLDR_CHECK_MODE: BUILD
+  JDK_VERSION: 21
 
 on:
   push:
@@ -82,7 +83,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4
@@ -161,7 +162,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4
@@ -236,7 +237,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,6 +2,9 @@
 
 name: production
 
+env:
+  JDK_VERSION: 21
+
 on:
   workflow_dispatch:
     inputs:
@@ -31,7 +34,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,8 @@
 name: staging
 
 env:
-  JDK_VERSION
+  JDK_VERSION: 21
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,6 +2,8 @@
 
 name: staging
 
+env:
+  JDK_VERSION
 on:
   workflow_dispatch:
     inputs:
@@ -30,7 +32,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/tools/cldr-apps/Dockerfile
+++ b/tools/cldr-apps/Dockerfile
@@ -9,12 +9,12 @@ RUN unzip -j cldr-apps.zip wlp/usr/servers/cldr/apps/cldr-apps.war
 RUN unzip -j cldr-apps.war 'WEB-INF/lib/cldr-code-*'
 RUN mv -v cldr-code-*-SNAPSHOT.jar cldr-code.jar
 
-FROM icr.io/appcafe/open-liberty:26.0.0.4-kernel-slim-java17-openj9-ubi AS server
+FROM icr.io/appcafe/open-liberty:26.0.0.6-kernel-slim-java21-openj9-ubi-minimal AS server
 # copy just the server file so we get config
 COPY --from=setup /opt/ol/wlp/usr/servers/cldr/server.xml /opt/ol/wlp/usr/servers/defaultServer/server.xml
 USER root
 # needed for cldr-archive
-RUN dnf install -y git
+RUN microdnf install -y git
 RUN mkdir /home/default
 RUN chown default /config/server.xml /home/default
 RUN mkdir -p /srv/st/config  /srv/st/src && chown -R default /srv/st

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -75,7 +75,7 @@
         <spotless.version>2.43.0</spotless.version>
 		<google-java-style.version>1.27.0</google-java-style.version>
 		<!-- Note: java-release (applied in the compiler plugin) replaces maven.compiler.source and maven.compiler.target -->
-		<java-release>11</java-release>
+		<java-release>21</java-release>
 	</properties>
 
 	<modules>

--- a/tools/scripts/ansible/openliberty-playbook.yml
+++ b/tools/scripts/ansible/openliberty-playbook.yml
@@ -11,7 +11,7 @@
     - name: "Install Java"
       apt:
         pkg:
-          - openjdk-11-jdk-headless # needed for openliberty
+          - openjdk-21-jdk-headless # needed for openliberty
     # we don't want the defaultServer, we are going to install our own
     - name: "Disable openliberty@defaultServer"
       ansible.builtin.systemd:


### PR DESCRIPTION
- Use Java v21 in `<java-release>`
- update ansible
- use env.JDK_VERSION: 21 in all workflows

I should note we have _already_ been using JDK 21 on production servers for some time. this just makes the compile version official.

CLDR-19326

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
