### PR TITLE
Jira pending: Add Nogai (nog) Keyboards: Add Cyrillic, Latin, Arabic, and Runic layouts

### DIFF
--- a/keyboards/nog-Arab.xml
+++ b/keyboards/nog-Arab.xml
@@ -30,8 +30,8 @@
         <key id="پ" output="پ"/>
 
         <key id="چ" output="چ"/>
-        <key id="ە" output="ە"/>
-        <key id="ئ" output="ئ"/>
+        <key id="ە" output="ە" longpress="ئە"/>
+        <key id="ئ" output="ئ" longpress="ٴ"/>
         <key id="ر" output="ر"/>
         <key id="ى" output="ى"/>
         <key id="ۈ" output="ۈ" longpress="ۉ"/>

--- a/keyboards/nog-Arab.xml
+++ b/keyboards/nog-Arab.xml
@@ -34,7 +34,7 @@
         <key id="ئ" output="ئ"/>
         <key id="ر" output="ر"/>
         <key id="ى" output="ى"/>
-        <key id="ۉ" output="ۉ" longpress="ۈ"/>
+        <key id="ۈ" output="ۈ" longpress="ۉ"/>
         <key id="و" output="و" longpress="ؤ ۉ"/>
         <key id="ز" output="ز" longpress="ظ ذ ژ"/>
         <key id="گ" output="گ"/>
@@ -46,7 +46,7 @@
             <default>
                 <row r="1" keys="ڭ ۆ ۇ ق ف غ ع ه خ ح ج"/>
                 <row r="2" keys="ش س ي ب ل ا ت ن م ك پ"/>
-                <row r="3" keys="چ ە ئ ر ى ۉ و ز گ د"/>
+                <row r="3" keys="چ ە ئ ر ى ۈ و ز گ د"/>
             </default>
         </formFactor>
     </formFactors>

--- a/keyboards/nog-Arab.xml
+++ b/keyboards/nog-Arab.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Nogai Arabic Keyboard Specification -->
+<!DOCTYPE keyboard3 SYSTEM "https://www.unicode.org/cldr/dtd/production/keyboard3.dtd">
+<keyboard3 locale="nog-Arab">
+    <info name="Nogai (Arabic)" layout="Arabic" indicator="نوغ"/>
+
+    <keys>
+        <key id="ڭ" output="ڭ"/>
+        <key id="ۆ" output="ۆ"/>
+        <key id="ۇ" output="ۇ"/>
+        <key id="ق" output="ق"/>
+        <key id="ف" output="ف"/>
+        <key id="غ" output="غ"/>
+        <key id="ع" output="ع"/>
+        <key id="ه" output="ه" longpress="ھ"/>
+        <key id="خ" output="خ"/>
+        <key id="ح" output="ح"/>
+        <key id="ج" output="ج"/>
+
+        <key id="ش" output="ش"/>
+        <key id="س" output="س" longpress="ص ث"/>
+        <key id="ي" output="ي"/>
+        <key id="ب" output="ب"/>
+        <key id="ل" output="ل" longpress="لا لإ لأ لآ"/>
+        <key id="ا" output="ا" longpress="أ آ ء إ ٱ"/>
+        <key id="ت" output="ت" longpress="ط ة"/>
+        <key id="ن" output="ن"/>
+        <key id="م" output="م"/>
+        <key id="ك" output="ك"/>
+        <key id="پ" output="پ"/>
+
+        <key id="چ" output="چ"/>
+        <key id="ە" output="ە"/>
+        <key id="ئ" output="ئ"/>
+        <key id="ر" output="ر"/>
+        <key id="ى" output="ى"/>
+        <key id="ۉ" output="ۉ" longpress="ۈ"/>
+        <key id="و" output="و" longpress="ؤ ۉ"/>
+        <key id="ز" output="ز" longpress="ظ ذ ژ"/>
+        <key id="گ" output="گ"/>
+        <key id="د" output="د"/>
+    </keys>
+
+    <formFactors>
+        <formFactor type="phone">
+            <default>
+                <row r="1" keys="ڭ ۆ ۇ ق ف غ ع ه خ ح ج"/>
+                <row r="2" keys="ش س ي ب ل ا ت ن م ك پ"/>
+                <row r="3" keys="چ ە ئ ر ى ۉ و ز گ د"/>
+            </default>
+        </formFactor>
+    </formFactors>
+</keyboard3>

--- a/keyboards/nog-Cyrl.xml
+++ b/keyboards/nog-Cyrl.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE keyboard3 SYSTEM "https://www.unicode.org/cldr/dtd/production/keyboard3.dtd">
+<keyboard3 locale="nog-Cyrl">
+    <info name="Nogai (Cyrillic)" layout="ЙЦУКЕН" indicator="Ног"/>
+
+    <keys>
+        <key id="й" output="й" longpress="y ي 𐰖 𐰘"/>
+        <key id="ц" output="ц" longpress="ts c تس 𐱃𐰽"/>
+        <key id="у" output="у" longpress="уь ү u ۉ ۈ ۇ و ا 𐰆 𐰇"/>
+        <key id="к" output="к" longpress="қ k q ق ك 𐰴 𐰚"/>
+        <key id="е" output="е" longpress="ё yo e يو ە يە ا 𐰀 𐰃"/>
+        <key id="н" output="н" longpress="нъ ң n ڭ ن 𐰣 𐰤 𐰭"/>
+        <key id="г" output="г" longpress="ғ g ğ گ غ 𐰍 𐰏"/>
+        <key id="ш" output="ш" longpress="ş ش 𐱁"/>
+        <key id="щ" output="щ" longpress="şç شچ 𐱁𐰲"/>
+        <key id="з" output="з" longpress="z ز 𐰔"/>
+        <key id="х" output="х" longpress="һ h x خ ح 𐰴 𐰚"/>
+        <key id="ъ" output="ъ" longpress="ء"/>
+
+        <key id="ф" output="ф" longpress="f ف 𐰯"/>
+        <key id="ы" output="ы" longpress="ı i ى ئ ا 𐰃"/>
+        <key id="в" output="в" longpress="v و 𐰉"/>
+        <key id="а" output="а" longpress="аь ә a ا ە 𐰂 𐰀"/>
+        <key id="п" output="п" longpress="p پ 𐰯"/>
+        <key id="р" output="р" longpress="r ر 𐰺 𐰼"/>
+        <key id="о" output="о" longpress="оь ө o ۆ و ا 𐰆 𐰇"/>
+        <key id="л" output="л" longpress="l ل 𐰞 𐰠"/>
+        <key id="д" output="д" longpress="d د 𐰑 𐰓"/>
+        <key id="ж" output="ж" longpress="j ج 𐰖"/>
+        <key id="э" output="э" longpress="e ە ئه ا 𐰀"/>
+
+        <key id="я" output="я" longpress="ya يا 𐰖𐰀"/>
+        <key id="ч" output="ч" longpress="ç چ 𐰲"/>
+        <key id="с" output="с" longpress="s س 𐰽 𐰾"/>
+        <key id="м" output="м" longpress="m م 𐰢"/>
+        <key id="и" output="и" longpress="і i ى ي ئ ا 𐰃"/>
+        <key id="т" output="т" longpress="t ت 𐱃 𐱅"/>
+        <key id="ь" output="ь" longpress="&apos; ء"/>
+        <key id="б" output="б" longpress="b ب 𐰉 𐰋"/>
+        <key id="ю" output="ю" longpress="yu يو يۋ 𐰖𐰆"/>
+    </keys>
+
+    <formFactors>
+        <formFactor type="phone">
+            <default>
+                <row r="1" keys="й ц у к е н г ш щ з х ъ"/>
+                <row r="2" keys="ф ы в а п р о л д ж э"/>
+                <row r="3" keys="я ч с м и т ь б ю"/>
+            </default>
+        </formFactor>
+    </formFactors>
+</keyboard3>

--- a/keyboards/nog-Cyrl.xml
+++ b/keyboards/nog-Cyrl.xml
@@ -20,14 +20,14 @@
         <key id="ф" output="ф" longpress="f ف 𐰯"/>
         <key id="ы" output="ы" longpress="ı i ى ئ ا 𐰃"/>
         <key id="в" output="в" longpress="v و 𐰉"/>
-        <key id="а" output="а" longpress="аь ә a ا ە 𐰂 𐰀"/>
+        <key id="а" output="а" longpress="аь ә a ا ء ە 𐰂 𐰀"/>
         <key id="п" output="п" longpress="p پ 𐰯"/>
         <key id="р" output="р" longpress="r ر 𐰺 𐰼"/>
         <key id="о" output="о" longpress="оь ө o ۆ ۉ و ا 𐰆 𐰇"/>
         <key id="л" output="л" longpress="l ل 𐰞 𐰠"/>
         <key id="д" output="д" longpress="d د 𐰑 𐰓"/>
         <key id="ж" output="ж" longpress="j ج 𐰖"/>
-        <key id="э" output="э" longpress="e ە ئه ا 𐰀"/>
+        <key id="э" output="э" longpress="e ە ئە ا 𐰀"/>
 
         <key id="я" output="я" longpress="ya يا 𐰖𐰀"/>
         <key id="ч" output="ч" longpress="ç چ 𐰲"/>

--- a/keyboards/nog-Cyrl.xml
+++ b/keyboards/nog-Cyrl.xml
@@ -6,7 +6,7 @@
     <keys>
         <key id="й" output="й" longpress="y ي 𐰖 𐰘"/>
         <key id="ц" output="ц" longpress="ts c تس 𐱃𐰽"/>
-        <key id="у" output="у" longpress="уь ү u ۉ ۈ ۇ و ا 𐰆 𐰇"/>
+        <key id="у" output="у" longpress="уь ү u ۈ ۇ و ا 𐰆 𐰇"/>
         <key id="к" output="к" longpress="қ k q ق ك 𐰴 𐰚"/>
         <key id="е" output="е" longpress="ё yo e يو ە يە ا 𐰀 𐰃"/>
         <key id="н" output="н" longpress="нъ ң n ڭ ن 𐰣 𐰤 𐰭"/>
@@ -23,7 +23,7 @@
         <key id="а" output="а" longpress="аь ә a ا ە 𐰂 𐰀"/>
         <key id="п" output="п" longpress="p پ 𐰯"/>
         <key id="р" output="р" longpress="r ر 𐰺 𐰼"/>
-        <key id="о" output="о" longpress="оь ө o ۆ و ا 𐰆 𐰇"/>
+        <key id="о" output="о" longpress="оь ө o ۆ ۉ و ا 𐰆 𐰇"/>
         <key id="л" output="л" longpress="l ل 𐰞 𐰠"/>
         <key id="д" output="д" longpress="d د 𐰑 𐰓"/>
         <key id="ж" output="ж" longpress="j ج 𐰖"/>

--- a/keyboards/nog-Latn.xml
+++ b/keyboards/nog-Latn.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Nogai Latin Keyboard Specification -->
+<!DOCTYPE keyboard3 SYSTEM "https://www.unicode.org/cldr/dtd/production/keyboard3.dtd">
+<keyboard3 locale="nog-Latn">
+    <info name="Nogai (Latin)" layout="QWERTY" indicator="Nog"/>
+
+    <keys>
+        <key id="q" output="q"/>
+        <key id="w" output="w"/>
+        <key id="e" output="e"/>
+        <key id="r" output="r"/>
+        <key id="t" output="t"/>
+        <key id="y" output="y"/>
+        <key id="u" output="u" longpress="ü û"/>
+        <key id="ı" output="ı" longpress="i İ î"/>
+        <key id="o" output="o" longpress="ö"/>
+        <key id="p" output="p"/>
+        <key id="ğ" output="ğ"/>
+        <key id="ü" output="ü"/>
+
+        <key id="a" output="a" longpress="ä â"/>
+        <key id="s" output="s" longpress="ş"/>
+        <key id="d" output="d"/>
+        <key id="f" output="f"/>
+        <key id="g" output="g" longpress="ğ"/>
+        <key id="h" output="h"/>
+        <key id="j" output="j"/>
+        <key id="k" output="k"/>
+        <key id="l" output="l"/>
+        <key id="ş" output="ş"/>
+        <key id="i" output="i" longpress="ı I î"/>
+        <key id="ä" output="ä"/>
+
+        <key id="z" output="z"/>
+        <key id="x" output="x"/>
+        <key id="c" output="c" longpress="ç"/>
+        <key id="v" output="v"/>
+        <key id="b" output="b"/>
+        <key id="n" output="n" longpress="ñ ŋ"/>
+        <key id="m" output="m"/>
+        <key id="ö" output="ö"/>
+        <key id="ç" output="ç"/>
+        <key id="ñ" output="ñ"/>
+    </keys>
+
+    <formFactors>
+        <formFactor type="phone">
+            <default>
+                <row r="1" keys="q w e r t y u ı o p ğ ü"/>
+                <row r="2" keys="a s d f g h j k l ş i ä"/>
+                <row r="3" keys="z x c v b n m ö ç ñ"/>
+            </default>
+        </formFactor>
+    </formFactors>
+</keyboard3>

--- a/keyboards/nog-Runr.xml
+++ b/keyboards/nog-Runr.xml
@@ -8,7 +8,7 @@
         <key id="𐰀" output="𐰀"/>
         <key id="𐰂" output="𐰂"/>
         <key id="𐰃" output="𐰃" longpress="𐰶"/>
-        <key id="𐰆" output="𐰆" longpress="𐰹"/>
+        <key id="𐰆" output="𐰆" longpress="𐰹 𐰗"/>
         <key id="𐰇" output="𐰇" longpress="𐰈 𐰜"/>
         <key id="𐰖" output="𐰖"/>
         <key id="𐰘" output="𐰘"/>
@@ -24,7 +24,7 @@
         <key id="𐰞" output="𐰞" longpress="𐰫"/>
         <key id="𐰠" output="𐰠"/>
         <key id="𐰣" output="𐰣" longpress="𐰮"/>
-        <key id="𐰤" output="𐰤" longpress="𐰨 𐰪"/>
+        <key id="𐰤" output="𐰤" longpress="𐰨 𐰪 𐰩"/>
         <key id="𐰑" output="𐰑"/>
         <key id="𐰓" output="𐰓"/>
         <key id="𐰭" output="𐰭"/>

--- a/keyboards/nog-Runr.xml
+++ b/keyboards/nog-Runr.xml
@@ -19,12 +19,12 @@
 
         <key id="𐰍" output="𐰍"/>
         <key id="𐰏" output="𐰏"/>
-        <key id="𐰴" output="𐰴"/>
+        <key id="𐰴" output="𐰴" longpress="𐰸"/>
         <key id="𐰚" output="𐰚"/>
         <key id="𐰞" output="𐰞" longpress="𐰫"/>
         <key id="𐰠" output="𐰠"/>
         <key id="𐰣" output="𐰣" longpress="𐰮"/>
-        <key id="𐰤" output="𐰤" longpress="𐰨 𐰪 𐰩"/>
+        <key id="𐰤" output="𐰤" longpress="𐰨 𐰪 𐰩 𐰦"/>
         <key id="𐰑" output="𐰑"/>
         <key id="𐰓" output="𐰓"/>
         <key id="𐰭" output="𐰭"/>
@@ -36,8 +36,8 @@
         <key id="𐰢" output="𐰢"/>
         <key id="𐰯" output="𐰯"/>
         <key id="𐰲" output="𐰲"/>
-        <key id="𐱁" output="𐱁" longpress="𐱁𐰲"/>
-        <key id="𐰔" output="𐰔"/>
+        <key id="𐱁" output="𐱁" longpress="𐱁𐰲 𐱀"/>
+        <key id="𐰔" output="𐰔" longpress="𐰕"/>
     </keys>
 
     <formFactors>

--- a/keyboards/nog-Runr.xml
+++ b/keyboards/nog-Runr.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Nogai Runic Keyboard Specification -->
+<!DOCTYPE keyboard3 SYSTEM "https://www.unicode.org/cldr/dtd/production/keyboard3.dtd">
+<keyboard3 locale="nog-Runr">
+    <info name="Nogai (Runic)" layout="Old Turkic" indicator="𐰣𐰆𐰍"/>
+
+    <keys>
+        <key id="𐰀" output="𐰀"/>
+        <key id="𐰂" output="𐰂"/>
+        <key id="𐰃" output="𐰃" longpress="𐰶"/>
+        <key id="𐰆" output="𐰆" longpress="𐰹"/>
+        <key id="𐰇" output="𐰇" longpress="𐰈 𐰜"/>
+        <key id="𐰖" output="𐰖"/>
+        <key id="𐰘" output="𐰘"/>
+        <key id="𐰺" output="𐰺"/>
+        <key id="𐰼" output="𐰼"/>
+        <key id="𐱃" output="𐱃" longpress="𐱃𐰽"/>
+        <key id="𐱅" output="𐱅"/>
+
+        <key id="𐰍" output="𐰍"/>
+        <key id="𐰏" output="𐰏"/>
+        <key id="𐰴" output="𐰴"/>
+        <key id="𐰚" output="𐰚"/>
+        <key id="𐰞" output="𐰞" longpress="𐰫"/>
+        <key id="𐰠" output="𐰠"/>
+        <key id="𐰣" output="𐰣" longpress="𐰮"/>
+        <key id="𐰤" output="𐰤" longpress="𐰨 𐰪"/>
+        <key id="𐰑" output="𐰑"/>
+        <key id="𐰓" output="𐰓"/>
+        <key id="𐰭" output="𐰭"/>
+
+        <key id="𐰽" output="𐰽"/>
+        <key id="𐰾" output="𐰾"/>
+        <key id="𐰉" output="𐰉"/>
+        <key id="𐰋" output="𐰋"/>
+        <key id="𐰢" output="𐰢"/>
+        <key id="𐰯" output="𐰯"/>
+        <key id="𐰲" output="𐰲"/>
+        <key id="𐱁" output="𐱁" longpress="𐱁𐰲"/>
+        <key id="𐰔" output="𐰔"/>
+    </keys>
+
+    <formFactors>
+        <formFactor type="phone">
+            <default>
+                <row r="1" keys="𐰀 𐰂 𐰃 𐰆 𐰇 𐰖 𐰘 𐰺 𐰼 𐱃 𐱅"/>
+                <row r="2" keys="𐰍 𐰏 𐰴 𐰚 𐰞 𐰠 𐰣 𐰤 𐰑 𐰓 𐰭"/>
+                <row r="3" keys="𐰽 𐰾 𐰉 𐰋 𐰢 𐰯 𐰲 𐱁 𐰔"/>
+            </default>
+        </formFactor>
+    </formFactors>
+</keyboard3>


### PR DESCRIPTION
Jira ticket creation is temporarily pending due to new account permission restrictions (Account: Enikeev).

- [ ] This PR completes the ticket.

## Sociolinguistic and Technical Justification for Nogai Layouts (nog-Cyrl, nog-Latn, nog-Arab, nog-Runr)

### 1. UNESCO Status and Current Linguistic Peril
The Nogai language (`nog`) is officially classified by the UNESCO Atlas of the World's Languages in Danger as "Definitely Endangered." The language faces severe existential pressure due to a historical lack of institutional support, a critical shortage of native-language schools, and systematic displacement from official and educational spheres. Providing native digital input mechanisms is a critical, non-negotiable step toward preventing total language extinction.

### 2. Historical Context: Forced Script Transitions as Structural Assimilation
The orthographic history of the Nogai language is a documentation of forced linguistic engineering and voluntary-compulsory Russification of minoritized indigenous peoples:
* **Pre-1928:** The Nogai people utilized a highly functional Arabic-based script, maintaining deep cultural and historical ties with their heritage.
* **1928–1938:** The Arabic script was officially replaced by a Latin-based alphabet.
* **1938–Present:** As part of a centralized policy of forced cultural assimilation, the Latin script was abruptly abolished and replaced with a modified Cyrillic alphabet.

These rapid, politically driven script disruptions fractured intergenerational literacy, isolated the population from their historical literature, and acted as structural elements of linguistic ethnocide.

### 3. Digital Marginalization as Ongoing Assimilation
Currently, major operating systems and input engines (including Google Gboard, iOS, and Windows) completely lack native support for Nogai layouts. This absence forces Nogai speakers into absolute digital dependency on surrogate layouts:
* **Forced Substitution:** Speakers are systematically forced to use either standard Russian or Kazakh keyboards. 
* **Technical Fragmentation:** Using the Russian layout forces users to manually split native digraphs (Аь, Оь, Уь, Нъ) into separate characters. This breaks digital text processing, renders spell-check and predictive text impossible, and corrupts corpus linguistics data.
* **Digital Colonialism:** Forcing an endangered language community to adopt the dominant state language's layout (Russian) functions as an ongoing mechanism of digital assimilation, stripping the language of its visual autonomy.

### 4. Technical Philosophy of the Multi-Script Layout (`nog-Cyrl.xml`)
The proposed `nog-Cyrl.xml` layout is designed not merely as a typing utility, but as a decolonial tool for cultural reclamation and linguistic self-determination. 

While the base layer conforms to the currently enforced Cyrillic orthography to meet immediate practical needs, the `longpress` (extended hold) functionality strategically bridges the fractured historical layers of the language:
* **Arabic Graphics (Arab):** Integrated via longpress to accommodate the historical literary heritage and to support the active Nogai diaspora (e.g., in Turkey and the Middle East) who still cultivate or study Arabic-based materials.
* **Old Turkic Runes (Runr):** Integrated to support a powerful grassroots cultural revival and historical reclamation movement among younger generations, activists, and researchers seeking to reconnect with pre-colonial roots.
* **Latin Graphics (Latn):** Included to provide a functional bridge for future orthographic modernization and integration with the wider Turkic digital space.

### Conclusion
By unifying these graphic systems into a cohesive, longpress-accessible architecture, this specification empowers a marginalized speech community to bypass structural barriers, reclaim their graphic history, and democratically determine the future trajectory of their language.

ALLOW_MANY_COMMITS=true
