### PR TITLE
CLDR-17854 Multiple numbering systems in Numbers report/charts

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -12,6 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.unicode.cldr.util.Builder;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.FileProcessor;
 import org.unicode.cldr.util.PatternCache;
 
@@ -429,10 +430,10 @@ class LdmlConvertRules {
                     "//ldml/numbers/(symbols|miscPatterns|(decimal|percent|scientific|currency|rational)Formats)\\[@numberSystem=\"([^\"]++)\"\\]/.*");
     public static final List<String> ACTIVE_NUMBERING_SYSTEM_XPATHS =
             Arrays.asList(
-                    CLDRFile.NumberingSystem.defaultSystem.path,
-                    CLDRFile.NumberingSystem.nativeSystem.path,
-                    CLDRFile.NumberingSystem.traditional.path,
-                    CLDRFile.NumberingSystem.finance.path);
+                    CldrNumberingSystem.defaultSystem.path,
+                    CldrNumberingSystem.nativeSystem.path,
+                    CldrNumberingSystem.traditional.path,
+                    CldrNumberingSystem.finance.path);
 
     /** resolved identity should be discarded if inherited, known issue CLDR-17790 */
     public static final Pattern ROOT_IDENTITY_PATTERN = Pattern.compile("//ldml/identity.*");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCMonetary.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCMonetary.java
@@ -13,6 +13,7 @@ import java.io.PrintWriter;
 import java.util.Iterator;
 import java.util.Set;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
 public class POSIX_LCMonetary {
@@ -101,7 +102,7 @@ public class POSIX_LCMonetary {
             }
         } else currency_symbol = POSIXUtilities.POSIXCharName(tmp_currency_symbol);
 
-        numsys = doc.getWinningValue("//ldml/numbers/defaultNumberingSystem");
+        numsys = doc.getWinningValue(CldrNumberingSystem.defaultSystem.path);
         mon_decimal_point =
                 doc.getWinningValue(
                         "//ldml/numbers/currencies/currency[@type='"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCNumeric.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCNumeric.java
@@ -10,6 +10,7 @@ package org.unicode.cldr.posix;
 
 import java.io.PrintWriter;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrNumberingSystem;
 
 public class POSIX_LCNumeric {
     String decimal_point;
@@ -19,7 +20,7 @@ public class POSIX_LCNumeric {
 
     public POSIX_LCNumeric(CLDRFile doc) {
 
-        numsys = doc.getWinningValue("//ldml/numbers/defaultNumberingSystem");
+        numsys = doc.getWinningValue(CldrNumberingSystem.defaultSystem.path);
         decimal_point =
                 POSIXUtilities.POSIXCharName(
                         doc.getWinningValue(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCTime.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCTime.java
@@ -12,6 +12,7 @@ package org.unicode.cldr.posix;
 import com.ibm.icu.text.NumberingSystem;
 import java.io.PrintWriter;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrNumberingSystem;
 
 public class POSIX_LCTime {
     String abday[];
@@ -74,8 +75,8 @@ public class POSIX_LCTime {
 
         // alt_digits
         alt_digits[0] = "";
-        String numsys = doc.getWinningValue("//ldml/numbers/defaultNumberingSystem");
-        if (numsys != null && !numsys.equals("latn")) {
+        String numsys = doc.getWinningValue(CldrNumberingSystem.defaultSystem.path);
+        if (numsys != null && !numsys.equals(CldrNumberingSystem.LATN_SYSTEM)) {
             NumberingSystem ns = NumberingSystem.getInstanceByName(numsys);
             String nativeZeroDigit = ns.getDescription().substring(0, 1);
             // Character ThisDigit;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/BuildIcuCompactDecimalFormat.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/BuildIcuCompactDecimalFormat.java
@@ -1,36 +1,26 @@
 package org.unicode.cldr.test;
 
-import com.ibm.icu.impl.number.DecimalFormatProperties;
 import com.ibm.icu.impl.number.PatternStringParser;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.CompactDecimalFormat;
 import com.ibm.icu.text.CompactDecimalFormat.CompactStyle;
 import com.ibm.icu.text.DecimalFormat;
-import com.ibm.icu.text.DecimalFormat.PropertySetter;
 import com.ibm.icu.text.PluralRules;
-import com.ibm.icu.util.Currency;
 import com.ibm.icu.util.ULocale;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.regex.Pattern;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.ICUServiceBuilder;
-import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XPathParts;
 
 @SuppressWarnings("deprecation")
 public class BuildIcuCompactDecimalFormat {
-    static SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
-    static final int MINIMUM_ARRAY_LENGTH = 15;
-    static final Pattern PATTERN = PatternCache.get("([^0,]*)([0]+)([.]0+)?([^0]*)");
-    static final Pattern TYPE = PatternCache.get("1([0]*)");
     private static final boolean DEBUG = false;
 
     public enum CurrencyStyle {
@@ -41,21 +31,14 @@ public class BuildIcuCompactDecimalFormat {
         UNIT
     }
 
-    /**
-     * JUST FOR DEVELOPMENT
-     *
-     * @param currencyStyle
-     * @param currencyCode
-     */
-    public static final CompactDecimalFormat build(
+    public static CompactDecimalFormat build(
             Factory cldrFactory,
             CLDRFile resolvedCldrFile,
-            Set<String> debugCreationErrors,
-            String[] debugOriginals,
             CompactStyle style,
             ULocale locale,
             CurrencyStyle currencyStyle,
-            String currencyCodeOrUnit) {
+            String currencyCodeOrUnit,
+            String numberingSystem) {
 
         // get the custom data from CLDR for use with the special setCompactCustomData.
         // buildCustomData() needs the currencySymbol to pick the right pattern.
@@ -95,17 +78,14 @@ public class BuildIcuCompactDecimalFormat {
         // create a compact decimal format, and reset its data
 
         CompactDecimalFormat cdf = CompactDecimalFormat.getInstance(locale, style);
-        cdf.setDecimalFormatSymbols(builder.getDecimalFormatSymbols("latn"));
+        cdf.setDecimalFormatSymbols(builder.getDecimalFormatSymbols(numberingSystem));
 
         cdf.setProperties(
-                new PropertySetter() {
-                    @Override
-                    public void set(DecimalFormatProperties props) {
-                        props.setCompactCustomData(customData);
-                        PatternStringParser.parseToExistingProperties(
-                                pattern, props, PatternStringParser.IGNORE_ROUNDING_ALWAYS);
-                        props.setPluralRules(rules);
-                    }
+                props -> {
+                    props.setCompactCustomData(customData);
+                    PatternStringParser.parseToExistingProperties(
+                            pattern, props, PatternStringParser.IGNORE_ROUNDING_ALWAYS);
+                    props.setPluralRules(rules);
                 });
 
         if (DEBUG) {
@@ -130,7 +110,7 @@ public class BuildIcuCompactDecimalFormat {
 
         boolean currSymbolAlphaLeading = false;
         boolean currSymbolAlphaTrailing = false;
-        if (currencySymbol != null && currencySymbol.length() > 0) {
+        if (currencySymbol != null && !currencySymbol.isEmpty()) {
             currSymbolAlphaLeading = UCharacter.isLetter(currencySymbol.codePointAt(0));
             currSymbolAlphaTrailing =
                     (currencySymbol.length() > 1)
@@ -194,32 +174,11 @@ public class BuildIcuCompactDecimalFormat {
 
     private static <A, B, C> void add(
             Map<A, Map<B, C>> customData, A a, B b, C c, boolean replace) {
-        Map<B, C> inner = customData.get(a);
-        if (inner == null) {
-            customData.put(a, inner = new HashMap<>());
-        }
+        Map<B, C> inner = customData.computeIfAbsent(a, k -> new HashMap<>());
         if (replace) {
             inner.put(b, c);
         } else {
             inner.putIfAbsent(b, c);
-        }
-    }
-
-    static class MyCurrencySymbolDisplay {
-        CLDRFile cldrFile;
-
-        public MyCurrencySymbolDisplay(CLDRFile cldrFile) {
-            this.cldrFile = cldrFile;
-        }
-
-        public String getName(Currency currency, int count) {
-            final String currencyCode = currency.getCurrencyCode();
-            if (count > 1) {
-                return currencyCode;
-            }
-            String prefix = "//ldml/numbers/currencies/currency[@type=\"" + currencyCode + "\"]/";
-            String currencySymbol = cldrFile.getWinningValue(prefix + "symbol");
-            return currencySymbol != null ? currencySymbol : currencyCode;
         }
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
@@ -20,6 +20,7 @@ import org.unicode.cldr.test.DisplayAndInputProcessor.NumericType;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.ICUServiceBuilder;
@@ -106,10 +107,10 @@ public class CheckNumbers extends FactoryCheckCLDR {
 
         CLDRFile resolvedFile = getResolvedCldrFileToCheck();
         String defaultNumberingSystem =
-                resolvedFile.getWinningValue(CLDRFile.NumberingSystem.defaultSystem.path);
+                resolvedFile.getWinningValue(CldrNumberingSystem.defaultSystem.path);
         if (defaultNumberingSystem == null
                 || !validNumberingSystems.contains(defaultNumberingSystem)) {
-            defaultNumberingSystem = "latn";
+            defaultNumberingSystem = CldrNumberingSystem.LATN_SYSTEM;
         }
         defaultTimeSeparatorPath =
                 "//ldml/numbers/symbols[@numberSystem=\""
@@ -969,9 +970,6 @@ public class CheckNumbers extends FactoryCheckCLDR {
     /**
      * Produce a canonical pattern, which will vary according to type and whether it is posix or
      * not.
-     *
-     * @param shorter
-     * @param path
      */
     public static String getCanonicalPattern(
             String inpattern, NumericType type, int zeroCount, boolean isPOSIX) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -61,6 +61,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRFileOverride;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CodePointEscaper;
 import org.unicode.cldr.util.DateConstants;
@@ -2551,7 +2552,7 @@ public class ExampleGenerator {
     }
 
     private void handleMinimumGrouping(XPathParts parts, String value, List<String> examples) {
-        String numberSystem = cldrFile.getWinningValue("//ldml/numbers/defaultNumberingSystem");
+        String numberSystem = cldrFile.getWinningValue(CldrNumberingSystem.defaultSystem.path);
         String checkPath =
                 "//ldml/numbers/decimalFormats[@numberSystem=\""
                         + numberSystem
@@ -2921,7 +2922,7 @@ public class ExampleGenerator {
                 SimpleDateFormat sdf =
                         icuServiceBuilder.getDateFormat(calendar, value, numberingSystemOverride);
                 String defaultNumberingSystem =
-                        cldrFile.getWinningValue("//ldml/numbers/defaultNumberingSystem");
+                        cldrFile.getWinningValue(CldrNumberingSystem.defaultSystem.path);
                 String timeSeparator =
                         cldrFile.getWinningValue(
                                 "//ldml/numbers/symbols[@numberSystem='"
@@ -3202,7 +3203,8 @@ public class ExampleGenerator {
     private void handleRationalFormat(
             XPathParts parts, String value, boolean showContexts, List<String> examples) {
         String numberSystem = parts.getAttributeValue(2, "numberSystem"); // null if not present
-        boolean isLatin = numberSystem == null || numberSystem.equals("latn");
+        boolean isLatin =
+                numberSystem == null || numberSystem.equals(CldrNumberingSystem.LATN_SYSTEM);
         DecimalFormat numberFormat =
                 isLatin ? null : icuServiceBuilder.getNumberFormat("0", numberSystem);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -48,12 +48,12 @@ import org.unicode.cldr.util.Annotations;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
-import org.unicode.cldr.util.CLDRFile.NumberingSystem;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CLDRTool;
 import org.unicode.cldr.util.CLDRTreeWriter;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.DateTimeCanonicalizer;
@@ -660,7 +660,7 @@ public class CLDRModify {
                 return Retention.RETAIN;
             }
             // special case for Arabic
-            if (isArabicSublocale && path.startsWith("//ldml/numbers/defaultNumberingSystem")) {
+            if (isArabicSublocale && path.startsWith(CldrNumberingSystem.defaultSystem.path)) {
                 return Retention.RETAIN;
             }
             String localeId = file.getSourceLocaleID(path, null);
@@ -2313,10 +2313,10 @@ public class CLDRModify {
 
                         if (NUMBER_SYSTEM_HACK) {
                             hackAllowOnly.clear();
-                            for (NumberingSystem system : NumberingSystem.values()) {
+                            for (CldrNumberingSystem system : CldrNumberingSystem.values()) {
                                 String numberingSystem =
                                         system.path == null
-                                                ? "latn"
+                                                ? CldrNumberingSystem.LATN_SYSTEM
                                                 : cldrFileToFilter.getStringValue(system.path);
                                 if (numberingSystem != null) {
                                     hackAllowOnly.add(numberingSystem);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -23,9 +23,9 @@ import org.unicode.cldr.tool.FormattedFileWriter.Anchors;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
-import org.unicode.cldr.util.CLDRFile.NumberingSystem;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.ExemplarSets.ExemplarType;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.FileCopier;
@@ -332,7 +332,7 @@ public class ChartCollation extends Chart {
             //            exemplars_all.addAll(exemplars_auxiliary)
             //                .addAll(exemplars_punctuation);
 
-            for (NumberingSystem system : NumberingSystem.values()) {
+            for (CldrNumberingSystem system : CldrNumberingSystem.values()) {
                 UnicodeSet exemplars_numeric = cldrFile.getExemplarsNumeric(system);
                 if (exemplars_numeric != null) {
                     exemplars_all.addAll(exemplars_numeric);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -39,6 +39,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.DtdData;
@@ -1477,7 +1478,7 @@ public class ChartDelta extends Chart {
                                  * Core data
                                  */
                                 "//ldml/characters/exemplarCharacters",
-                                "//ldml/numbers/defaultNumberingSystem",
+                                CldrNumberingSystem.defaultSystem.path,
                                 "//ldml/numbers/otherNumberingSystems/native",
                                 /*
                                  * Territory and Language names

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
@@ -1,6 +1,5 @@
 package org.unicode.cldr.tool;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -14,25 +13,17 @@ import com.ibm.icu.util.JapaneseCalendar;
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 import java.io.IOException;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Month;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
-import org.unicode.cldr.util.CLDRFile.NumberingSystem;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CalculatedCoverageLevels;
@@ -40,7 +31,6 @@ import org.unicode.cldr.util.DateTimeFormats;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.ICUServiceBuilder;
 import org.unicode.cldr.util.Level;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.TempPrintWriter;
 
 public class GenerateDateTimeTestData {
@@ -48,9 +38,6 @@ public class GenerateDateTimeTestData {
     private static final String OUTPUT_SUBDIR = "datetime";
 
     private static final String OUTPUT_FILENAME = "datetime.json";
-
-    private static final SupplementalDataInfo SUPPLEMENTAL_DATA_INFO =
-            SupplementalDataInfo.getInstance();
 
     private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
 
@@ -89,203 +76,7 @@ public class GenerateDateTimeTestData {
         }
     }
 
-    private static final ImmutableSet<String> NUMBERING_SYSTEMS =
-            ImmutableSet.of("latn", "arab", "beng");
-
-    // Use underscores for locale id b/c of CLDR historical reasons, even though dash is preferable
-    // to underscore.
-    private static final ImmutableSet<String> LOCALES =
-            ImmutableSet.of(
-                    "en_US", "en_GB", "zh_Hant_TW", "vi", "ar", "mt_MT", "bn", "zu"
-                    // "root"
-                    );
-
-    private static final ImmutableMap.Builder<Object, Object> newMapStringToObjectBuilder() {
-        return ImmutableMap.builder();
-    }
-
-    private static final ImmutableMap.Builder<Object, ImmutableMap<Object, Object>>
-            newMapStringToMapBuilder() {
-        return ImmutableMap.builder();
-    }
-
-    // Note: CLDR uses the identifier "gregorian", although BCP-47 which came later specifies
-    // "gregory" as the calendar identifier.
-    private static final ImmutableSet<String> CALENDARS =
-            ImmutableSet.of(
-                    "gregorian",
-                    "buddhist",
-                    "hebrew",
-                    "chinese",
-                    "roc",
-                    "japanese",
-                    "islamic",
-                    "islamic-umalqura",
-                    "persian");
-
-    private static final ImmutableSet<String> TIME_ZONES =
-            ImmutableSet.of(
-                    "America/Los_Angeles",
-                    "Africa/Luanda",
-                    "Asia/Tehran",
-                    "Europe/Kiev",
-                    "Australia/Brisbane",
-                    "Pacific/Palau",
-                    "America/Montevideo");
-
-    private static final ImmutableSet<ZonedDateTime> JAVA_TIME_ZONED_DATE_TIMES =
-            ImmutableSet.of(
-                    LocalDate.parse("2024-03-17")
-                            .atStartOfDay(ZoneId.of(ZoneOffset.UTC.getId())), // "Mar 17, 2024"
-                    Instant.parse("2001-07-02T13:14:15.00Z")
-                            .atZone(ZoneOffset.UTC), // "02-Jul-2001, 13:14:15"
-                    Instant.parse("1984-05-29T07:53:00.00Z")
-                            .atZone(ZoneOffset.UTC), // "May 29, 1984, 7:53"
-                    Instant.parse("2050-05-29T16:47:00.00Z")
-                            .atZone(ZoneOffset.UTC), // "2050, May 29, 16:47"
-                    LocalDate.parse("1969-07-16")
-                            .atStartOfDay(ZoneId.of(ZoneOffset.UTC.getId())), // "1969, July 16"
-                    Instant.ofEpochMilli(1_000_000_000L).atZone(ZoneOffset.UTC), // 1e9
-                    Instant.ofEpochMilli(1_000_000_000_000L).atZone(ZoneOffset.UTC) // 1e12
-                    );
-
-    private static final ImmutableSet<ImmutableMap<Object, Object>> TEMPORAL_DATES =
-            ImmutableSet.of(
-                    newMapStringToObjectBuilder()
-                            .put("timeZone", "America/Los_Angeles")
-                            .put("year", 2024)
-                            .put("month", 3)
-                            .put("day", 7)
-                            .put("hour", 0)
-                            .put("minute", 0)
-                            .put("second", 1)
-                            .put("millisecond", 0)
-                            .put("microsecond", 0)
-                            .put("nanosecond", 0)
-                            .put("calendar", "gregory")
-                            .build(),
-                    newMapStringToObjectBuilder()
-                            .put("timeZone", "America/Los_Angeles")
-                            .put("year", 2001)
-                            .put("month", 7)
-                            .put("day", 2)
-                            .put("hour", 13)
-                            .put("minute", 14)
-                            .put("second", 15)
-                            .put("millisecond", 0)
-                            .put("microsecond", 0)
-                            .put("nanosecond", 0)
-                            .build(),
-                    newMapStringToObjectBuilder()
-                            .put("timeZone", "America/Los_Angeles")
-                            .put("year", 1984)
-                            .put("month", 5)
-                            .put("day", 29)
-                            .put("hour", 7)
-                            .put("minute", 53)
-                            .put("second", 0)
-                            .put("millisecond", 0)
-                            .put("microsecond", 0)
-                            .put("nanosecond", 0)
-                            .build(),
-                    newMapStringToObjectBuilder()
-                            .put("timeZone", "America/Los_Angeles")
-                            .put("year", 2030)
-                            .put("month", 5)
-                            .put("day", 29)
-                            .put("hour", 16)
-                            .put("minute", 47)
-                            .put("second", 0)
-                            .put("millisecond", 0)
-                            .put("microsecond", 0)
-                            .put("nanosecond", 0)
-                            .build(),
-                    newMapStringToObjectBuilder()
-                            .put("timeZone", "America/Los_Angeles")
-                            .put("year", 1969)
-                            .put("month", 7)
-                            .put("day", 16)
-                            .put("hour", 0)
-                            .put("minute", 0)
-                            .put("second", 0)
-                            .put("millisecond", 0)
-                            .put("microsecond", 0)
-                            .put("nanosecond", 0)
-                            .build(),
-                    newMapStringToObjectBuilder() // 1e6
-                            .put("timeZone", "America/Los_Angeles")
-                            .put("year", 1970)
-                            .put("month", 1)
-                            .put("day", 12)
-                            .put("hour", 13)
-                            .put("minute", 46)
-                            .put("second", 40)
-                            .put("millisecond", 0)
-                            .put("microsecond", 0)
-                            .put("nanosecond", 0)
-                            .build(),
-                    newMapStringToObjectBuilder() // 1e9
-                            .put("timeZone", "America/Los_Angeles")
-                            .put("year", 2001)
-                            .put("month", 9)
-                            .put("day", 9)
-                            .put("hour", 1)
-                            .put("minute", 46)
-                            .put("second", 40)
-                            .put("millisecond", 0)
-                            .put("microsecond", 0)
-                            .put("nanosecond", 0)
-                            .build());
-
-    private static Set<String> getLocaleNumberingSystems(CLDRFile localeFile) {
-        Set<String> result = new HashSet<>();
-        for (NumberingSystem system : NumberingSystem.values()) {
-            String numberingSystem =
-                    system.path == null ? "latn" : localeFile.getStringValue(system.path);
-            if (numberingSystem != null) {
-                result.add(numberingSystem);
-            }
-        }
-
-        return result;
-    }
-
-    private static ZonedDateTime getZonedDateTimeFromTemporalDateInput(Map<Object, Object> input) {
-        if (!input.containsKey("year")) {
-            return null;
-        }
-        if (!input.containsKey("month")) {
-            return null;
-        }
-        if (!input.containsKey("day")) {
-            return null;
-        }
-
-        // TODO: Use ICU Calendar object to get a date time instant with a calendar
-        if (input.containsKey("calendar") && !((String) input.get("calendar")).equals("gregory")) {
-            return null;
-        }
-
-        int year = (int) input.get("year");
-        int monthInt = (int) input.get("month");
-        int day = (int) input.get("day");
-        Month month = Month.of(monthInt);
-        int hour = (int) input.getOrDefault("hour", 0);
-        int minute = (int) input.getOrDefault("minute", 0);
-        int second = (int) input.getOrDefault("second", 0);
-        int millisecond = (int) input.getOrDefault("millisecond", 0);
-        int microsecond = (int) input.getOrDefault("microsecond", 0);
-        int nanosecondOrig = (int) input.getOrDefault("nanosecond", 0);
-        int nanosecond = ((millisecond * 1000) + microsecond) * 1000 + nanosecondOrig;
-        String timeZoneIdStr = (String) input.getOrDefault("timeZone", "UTC");
-        ZoneId timeZoneId = ZoneId.of(timeZoneIdStr);
-
-        LocalDateTime localDt =
-                LocalDateTime.of(year, month, day, hour, minute, second, nanosecond);
-        return ZonedDateTime.of(localDt, timeZoneId);
-    }
-
-    public static final Optional<CLDRFile> getCLDRFile(String locale) {
+    public static Optional<CLDRFile> getCLDRFile(String locale) {
         CLDRFile cldrFile =
                 CLDR_FACTORY.make(
                         locale, true, DraftStatus.contributed); // don't include provisional data
@@ -299,24 +90,6 @@ public class GenerateDateTimeTestData {
         } else {
             return Optional.of(cldrFile);
         }
-    }
-
-    private static String getDateLength(Map<Object, Object> optionsMap) {
-        String length = null;
-        if (optionsMap.containsKey("dateLength")) {
-            length = (String) optionsMap.get("dateLength");
-        }
-
-        return length;
-    }
-
-    private static String getTimeLength(Map<Object, Object> optionsMap) {
-        String length = null;
-        if (optionsMap.containsKey("timeLength")) {
-            length = (String) optionsMap.get("timeLength");
-        }
-
-        return length;
     }
 
     private static String getExpectedStringForTestCase(
@@ -375,7 +148,8 @@ public class GenerateDateTimeTestData {
     }
 
     /* TODO: Expand the kernel over all locale-preferred calendars:
-
+            private static final SupplementalDataInfo SUPPLEMENTAL_DATA_INFO =
+                SupplementalDataInfo.getInstance();
            List<String> localePreferredCalendars = SUPPLEMENTAL_DATA_INFO.getCalendars(region);
            if (localePreferredCalendars == null) {
                localePreferredCalendars = SUPPLEMENTAL_DATA_INFO.getCalendars("001");
@@ -880,10 +654,7 @@ public class GenerateDateTimeTestData {
     }
 
     public static String computeSkeletonFromSemanticSkeleton(
-            ICUServiceBuilder icuServiceBuilder,
-            CLDRFile localeCldrFile,
-            FieldStyleCombo fieldStyleCombo,
-            String calendarStr) {
+            CLDRFile localeCldrFile, FieldStyleCombo fieldStyleCombo, String calendarStr) {
         SemanticSkeleton skeleton = fieldStyleCombo.semanticSkeleton;
         StringBuilder sb = new StringBuilder();
 
@@ -1103,10 +874,7 @@ public class GenerateDateTimeTestData {
             String calendarStr = testCaseInput.calendar.getType();
             String skeleton =
                     computeSkeletonFromSemanticSkeleton(
-                            icuServiceBuilder,
-                            localeCldrFile,
-                            testCaseInput.fieldStyleCombo,
-                            calendarStr);
+                            localeCldrFile, testCaseInput.fieldStyleCombo, calendarStr);
             // compute the expected
             // TODO: fix CLDR DateTimeFormats constructor to use CLDRFile to get the dateTimeFormat
             //   glue pattern rather than use ICU to get it

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -26,6 +26,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.ICUServiceBuilder;
@@ -161,7 +162,7 @@ public class GeneratePluralRanges {
                 CLDRConfig.getInstance().getCldrFactory().getICUServiceBuilder(loc);
         DecimalFormat nf = icusb.getNumberFormat(1);
         String defaultNumberingSystem =
-                cldrFile.getWinningValue(CLDRFile.NumberingSystem.defaultSystem.path);
+                cldrFile.getWinningValue(CldrNumberingSystem.defaultSystem.path);
         String range =
                 cldrFile.getWinningValue(
                         "//ldml/numbers/miscPatterns[@numberSystem=\""

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -31,6 +31,7 @@ import org.unicode.cldr.util.AnnotationUtil;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.Factory;
@@ -585,8 +586,7 @@ public class GenerateProductionData {
 
     private static final String[] SPECIAL_PATHS =
             new String[] {
-                // Cf. CLDRFile.NumberingSystem.defaultSystem.path
-                "//ldml/numbers/defaultNumberingSystem",
+                CldrNumberingSystem.defaultSystem.path,
                 "//ldml/numbers/defaultNumberingSystem[@alt=\"latn\"]"
             };
     private static final Set<String> SPECIAL_PATH_SET = new TreeSet<>(Arrays.asList(SPECIAL_PATHS));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListUnits.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListUnits.java
@@ -14,6 +14,7 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
@@ -194,7 +195,7 @@ public class ListUnits {
 
     static void getDigits(CLDRFile cldrFile) {
         System.out.println(cldrFile.getLocaleID());
-        String numberSystem = cldrFile.getWinningValue("//ldml/numbers/defaultNumberingSystem");
+        String numberSystem = cldrFile.getWinningValue(CldrNumberingSystem.defaultSystem.path);
         Set<String> seen = new HashSet<>();
         seen.add(numberSystem);
         Pair<UnicodeSet, UnicodeSet> main = getCharacters(cldrFile, numberSystem);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -156,7 +156,7 @@ public class ShowLanguages {
         }
         // since we don't want these listed on the supplemental page, use null
 
-        new ShowPlurals().printPlurals(english, null, pw, cldrFactory);
+        new ShowPlurals().printPlurals(english, null, cldrFactory);
 
         linfo.printLikelySubtags(pw);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -13,8 +13,6 @@ import com.ibm.icu.util.ICUUncheckedIOException;
 import com.ibm.icu.util.ULocale;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.unicode.cldr.test.BuildIcuCompactDecimalFormat;
@@ -24,6 +22,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRURLS;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.ICUServiceBuilder;
@@ -41,17 +40,14 @@ public class ShowPlurals {
             "<i>Not available.<br>Please <a target='_blank' href='"
                     + CLDRURLS.CLDR_NEWTICKET_URL
                     + "'>file a ticket</a> to supply.</i>";
-    final SupplementalDataInfo supplementalDataInfo;
+    private final SupplementalDataInfo supplementalDataInfo;
 
     public static void main(String[] args) {
-        Factory cldrFactory =
-                CLDRConfig.getInstance().getCldrFactory(); // .make(CLDRPaths.MAIN_DIRECTORY, ".*");
+        Factory cldrFactory = CLDRConfig.getInstance().getCldrFactory();
         CLDRFile english = CLDRConfig.getInstance().getEnglish();
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
 
         try {
-            new ShowPlurals().printPlurals(english, null, pw, cldrFactory);
+            new ShowPlurals().printPlurals(english, null, cldrFactory);
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }
@@ -65,8 +61,13 @@ public class ShowPlurals {
         this.supplementalDataInfo = supplementalDataInfo;
     }
 
-    public void printPlurals(
-            CLDRFile english, String localeFilter, PrintWriter index, Factory factory)
+    private String numberingSystem = CldrNumberingSystem.LATN_SYSTEM;
+
+    public void setNumberingSystem(String numberingSystem) {
+        this.numberingSystem = numberingSystem;
+    }
+
+    public void printPlurals(CLDRFile english, String localeFilter, Factory factory)
             throws IOException {
         String section1 = "Rules";
         String section2 = "Comparison";
@@ -80,25 +81,23 @@ public class ShowPlurals {
         pw.append("<div style='margin-right:2em; margin-left:2em'>\n");
         ShowLanguages.showContents(pw, "rules", "Rules", "comparison", "Comparison");
 
-        pw.append(
-                "<h2>"
-                        + CldrUtility.getDoubleLinkedText("rules", "1. " + section1)
-                        + "</h2>"
-                        + System.lineSeparator());
+        pw.append("<h2>")
+                .append(CldrUtility.getDoubleLinkedText("rules", "1. " + section1))
+                .append("</h2>")
+                .append(System.lineSeparator());
         pw.append("<div style='margin-right:2em; margin-left:2em'>\n");
         printPluralTable(english, localeFilter, pw, factory);
         pw.append("</div>\n");
 
+        pw.append("<h2>")
+                .append(CldrUtility.getDoubleLinkedText("comparison", "2. " + section2))
+                .append("</h2>")
+                .append(System.lineSeparator());
         pw.append(
-                "<h2>"
-                        + CldrUtility.getDoubleLinkedText("comparison", "2. " + section2)
-                        + "</h2>"
-                        + System.lineSeparator());
-        pw.append(
-                "<p style='text-align:left'>The plural forms are abbreviated by first letter, with 'x' for 'other'. "
-                        + "If values are made redundant by explicit 0 and 1, they are underlined. "
-                        + "The fractional and integral results are separated for clarity.</p>"
-                        + System.lineSeparator());
+                        "<p style='text-align:left'>The plural forms are abbreviated by first letter, with 'x' for 'other'. "
+                                + "If values are made redundant by explicit 0 and 1, they are underlined. "
+                                + "The fractional and integral results are separated for clarity.</p>")
+                .append(System.lineSeparator());
         pw.append("<div style='margin-right:2em; margin-left:2em'>\n");
         PluralSnapshot.writeTables(english, pw);
         pw.append("</div>\n");
@@ -118,7 +117,9 @@ public class ShowPlurals {
     public void printPluralTable(
             CLDRFile english, String localeFilter, Appendable appendable, Factory factory)
             throws IOException {
-
+        // TODO: clarify why the CLDRFile parameter is named "english", and its purpose.
+        // As actually used by VerifyCompactNumbers, english.getLocaleID() is NOT generally "en".
+        // Reference: https://unicode-org.atlassian.net/browse/CLDR-17854
         final TablePrinter tablePrinter =
                 new TablePrinter()
                         .setTableAttributes("class='dtf-table'")
@@ -153,18 +154,13 @@ public class ShowPlurals {
                         .setHeaderAttributes("class='dtf-th'")
                         .setCellAttributes("class='dtf-s'")
                         .setSpanRows(false);
-        PluralRulesFactory prf = PluralRulesFactory.getInstance(supplementalDataInfo);
-        // Map<ULocale, PluralRulesFactory.SamplePatterns> samples =
-        // PluralRulesFactory.getLocaleToSamplePatterns();
         Set<String> cardinalLocales = supplementalDataInfo.getPluralLocales(PluralType.cardinal);
         Set<String> ordinalLocales = supplementalDataInfo.getPluralLocales(PluralType.ordinal);
-        Set<String> all = new LinkedHashSet<>(cardinalLocales);
-        all.addAll(ordinalLocales);
 
         LanguageTagCanonicalizer canonicalizer = new LanguageTagCanonicalizer();
         SampleMaker sampleMaker = new SampleMaker();
 
-        for (String locale : supplementalDataInfo.getPluralLocales()) {
+        for (String locale : supplementalDataInfo.getPluralLocales(PluralType.cardinal)) {
             if (localeFilter != null && !localeFilter.equals(locale) || locale.equals("root")) {
                 continue;
             }
@@ -203,28 +199,16 @@ public class ShowPlurals {
                 ULocale locale2 = new ULocale(locale);
                 final PluralMinimalPairs samplePatterns =
                         PluralMinimalPairs.getInstance(locale2.toString());
-                //                    pluralType == PluralType.ordinal ? null
-                //                    : CldrUtility.get(samples, locale2);
-
-                String rules = plurals.getRules();
-                rules +=
-                        rules.length() == 0
-                                ? "other:<i>everything</i>"
-                                : ";other:<i>everything else</i>";
-                rules = rules.replace(":", " → ").replace(";", ";<br>");
                 PluralRules pluralRules = plurals.getPluralRules();
-                // final Map<PluralInfo.Count, String> typeToExamples =
-                // plurals.getCountToStringExamplesMap();
-                // final String examples = typeToExamples.get(type).toString().replace(";",
-                // ";<br>");
                 Set<Count> counts = plurals.getCounts();
                 for (PluralInfo.Count count : counts) {
                     String keyword = count.toString();
+                    // Seemingly this code can only produce examples using Latin digits, even if the
+                    // default numbering system for the locale is not "latn". This limitation
+                    // affects the "Examples" column of the "Plural Rules" table in the "Numbers"
+                    // report.
                     DecimalQuantitySamples exampleList =
-                            pluralRules.getDecimalSamples(
-                                    keyword,
-                                    PluralRules.SampleType
-                                            .INTEGER); // plurals.getSamples9999(count);
+                            pluralRules.getDecimalSamples(keyword, PluralRules.SampleType.INTEGER);
                     DecimalQuantitySamples exampleList2 =
                             pluralRules.getDecimalSamples(keyword, PluralRules.SampleType.DECIMAL);
                     if (exampleList == null) {
@@ -271,7 +255,7 @@ public class ShowPlurals {
                             .addCell(locale)
                             .addCell(pluralType.toString())
                             .addCell(count.toString())
-                            .addCell(examples.toString())
+                            .addCell(examples)
                             .addCell(sample)
                             .addCell(rule)
                             .finishRow();
@@ -321,10 +305,16 @@ public class ShowPlurals {
     }
 
     private String getExamples(DecimalQuantitySamples exampleList) {
+        // Seemingly this code only produces examples using Latin digits, even if the
+        // default numbering system for the locale is not "latn". This limitation affects
+        // the "Examples" column of the "Plural Rules" table in the "Numbers" report.
+        // Joiner.join() forces conversion by PluralRules.DecimalQuantitySamplesRange.toString,
+        // which in turn calls com.ibm.icu.impl.number.DecimalQuantity.toExponentString.
+        // Maybe there is a way to make that produce non-Latin digits.
         return Joiner.on(", ").join(exampleList.getSamples()) + (exampleList.bounded ? "" : ", …");
     }
 
-    static final class SampleMaker {
+    final class SampleMaker {
         private ICUServiceBuilder icusb;
         private CLDRFile cldrFile;
 
@@ -338,21 +328,18 @@ public class ShowPlurals {
             String sample;
             String value;
             if (numb.getExponent() > 0) {
-                Set<String> debugCreationErrors = new LinkedHashSet<>();
-                String[] debugOriginals = null;
                 CompactDecimalFormat cdfCurr =
                         BuildIcuCompactDecimalFormat.build(
                                 cldrFactory,
                                 cldrFile,
-                                debugCreationErrors,
-                                debugOriginals,
                                 CompactStyle.SHORT,
                                 ULocale.forLanguageTag(cldrFile.getLocaleID()),
                                 CurrencyStyle.PLAIN,
-                                null);
+                                null,
+                                numberingSystem);
                 value = cdfCurr.format(numb.toDouble());
             } else {
-                NumberFormat nf = icusb.getGenericNumberFormat("latn");
+                NumberFormat nf = icusb.getGenericNumberFormat(numberingSystem);
                 nf.setMaximumFractionDigits((int) numb.getPluralOperand(Operand.v));
                 nf.setMinimumFractionDigits((int) numb.getPluralOperand(Operand.v));
                 value = nf.format(numb.toDouble());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -177,9 +177,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                 /* This may happen for Invalid XPath; InvalidXPathException may be thrown. */
                 return false;
             }
-            if (curValue.equals(baileyValue)) {
-                return true;
-            }
+            return curValue.equals(baileyValue);
         }
         return false;
     }
@@ -1429,6 +1427,9 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                         "Input isn't a file directory:\t" + dir.getPath());
             }
             File[] files = dir.listFiles();
+            if (files == null) {
+                continue;
+            }
             for (File file : files) {
                 String name = file.getName();
                 if (!name.endsWith(".xml") || name.startsWith(".")) continue;
@@ -2414,21 +2415,9 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                 + (type == ExemplarType.main ? "" : "[@type=\"" + type + "\"]");
     }
 
-    public enum NumberingSystem {
-        latin(null),
-        defaultSystem("//ldml/numbers/defaultNumberingSystem"),
-        nativeSystem("//ldml/numbers/otherNumberingSystems/native"),
-        traditional("//ldml/numbers/otherNumberingSystems/traditional"),
-        finance("//ldml/numbers/otherNumberingSystems/finance");
-        public final String path;
-
-        NumberingSystem(String path) {
-            this.path = path;
-        }
-    }
-
-    public UnicodeSet getExemplarsNumeric(NumberingSystem system) {
-        String numberingSystem = system.path == null ? "latn" : getStringValue(system.path);
+    public UnicodeSet getExemplarsNumeric(CldrNumberingSystem system) {
+        String numberingSystem =
+                system.path == null ? CldrNumberingSystem.LATN_SYSTEM : getStringValue(system.path);
         if (numberingSystem == null) {
             return UnicodeSet.EMPTY;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrDateTimePatternGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrDateTimePatternGenerator.java
@@ -139,7 +139,7 @@ public class CldrDateTimePatternGenerator {
     }
 
     private void initDecimal() {
-        String ns = file.getStringValueWithBailey(CLDRFile.NumberingSystem.defaultSystem.path);
+        String ns = file.getStringValueWithBailey(CldrNumberingSystem.defaultSystem.path);
         if (ns == null) {
             ns = "latn";
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrNumberingSystem.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrNumberingSystem.java
@@ -1,0 +1,106 @@
+package org.unicode.cldr.util;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.LinkedHashMap;
+import org.unicode.cldr.icu.LDMLConstants;
+
+public enum CldrNumberingSystem {
+    latin(null),
+    defaultSystem("//ldml/numbers/defaultNumberingSystem"),
+    nativeSystem("//ldml/numbers/otherNumberingSystems/native"),
+    traditional("//ldml/numbers/otherNumberingSystems/traditional"),
+    finance("//ldml/numbers/otherNumberingSystems/finance");
+
+    public final String path;
+
+    CldrNumberingSystem(String path) {
+        this.path = path;
+    }
+
+    public static final String LATN_SYSTEM = "latn";
+    private static final String LATIN_KIND = "Latin";
+
+    /**
+     * Get a map in which the keys are numbering system names like "latn", "arab", etc., and the
+     * values are kinds like "default", "Latin", "native", etc. The first key is always the default
+     * numbering system and is always mapped to "default".
+     *
+     * @param cldrFile the file for a locale
+     * @return the map
+     */
+    public static LinkedHashMap<String, String> getMap(CLDRFile cldrFile) {
+
+        LinkedHashMap<String, String> kindToPath = new LinkedHashMap<>();
+        LinkedHashMap<String, String> systemToKind = new LinkedHashMap<>();
+        kindToPath.put(LDMLConstants.DEFAULT, defaultSystem.path);
+        // LATIN_KIND and LATN_SYSTEM are exceptionally linked without a path
+        kindToPath.put(LATIN_KIND, LATN_SYSTEM);
+        kindToPath.put(LDMLConstants.NATIVE, nativeSystem.path);
+        kindToPath.put(LDMLConstants.TRADITIONAL, traditional.path);
+        kindToPath.put(LDMLConstants.FINANCE, finance.path);
+        for (String kind : kindToPath.keySet()) {
+            String path = kindToPath.get(kind);
+            String system = LATN_SYSTEM.equals(path) ? LATN_SYSTEM : cldrFile.getStringValue(path);
+            if (system != null && !systemToKind.containsKey(system)) {
+                systemToKind.put(system, kind);
+            }
+        }
+        return systemToKind;
+    }
+
+    public static void writeLinks(Writer out, LinkedHashMap<String, String> numberingSystems)
+            throws IOException {
+        out.write(
+                "Information is displayed below once for each of "
+                        + numberingSystems.keySet().size()
+                        + " numbering systems used for this locale: ");
+        boolean needComma = false;
+        for (String numberingSystem : numberingSystems.keySet()) {
+            if (needComma) {
+                out.write(", ");
+            }
+            // Enable clicking on the numbering system to scroll to it. Use onclick and
+            // scrollIntoView instead of simple "href", which would fail in Survey Tool
+            // due to its special handling of anchors.
+            String link = linkId(numberingSystem);
+            String onClick = "document.getElementById('" + link + "').scrollIntoView()";
+            String kind = numberingSystems.get(numberingSystem);
+            // For some reason, in the chart, this link lacks underline unless added here
+            // explicitly. Ideally, style problems should be corrected in CSS rather than in
+            // Java. A better solution is challenging since it needs to work both for
+            // Survey Tool reports and for charts that are rendered outside of Survey Tool.
+            out.write(
+                    "<a style=\"text-decoration: underline;\" onclick=\""
+                            + onClick
+                            + "\">"
+                            + numberingSystem
+                            + " ("
+                            + kind
+                            + ")</a>");
+            needComma = true;
+        }
+        out.write(".");
+    }
+
+    private static String linkId(String numberingSystem) {
+        return "numbering-system-" + numberingSystem;
+    }
+
+    public static void writeHeader(
+            LinkedHashMap<String, String> numberingSystems, String numberingSystem, Writer out)
+            throws IOException {
+        String kind = numberingSystems.get(numberingSystem);
+        // Override the style here, since otherwise there may be no vertical space above the
+        // header. A better solution is challenging since it needs to work both for
+        // Survey Tool reports and for charts that are rendered outside of Survey Tool.
+        out.write(
+                "<h1 style=\"padding-top: 1em\" id=\""
+                        + CldrNumberingSystem.linkId(numberingSystem)
+                        + "\">Numbering System: "
+                        + numberingSystem
+                        + " ("
+                        + kind
+                        + ")</h1>");
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1468,81 +1468,18 @@ public class DateTimeFormats {
             DateTimeFormats formats,
             Writer out)
             throws IOException {
-        // Loop through numbering systems for this locale
-        LinkedHashMap<String, String> numberingSystems = getNumberingSystems(nativeFile);
-        Set<String> systems = numberingSystems.keySet();
+        final LinkedHashMap<String, String> numSysMap = CldrNumberingSystem.getMap(nativeFile);
+        final Set<String> systems = numSysMap.keySet();
         if (systems.size() > 1) {
-            writeNumberingSystemLinks(out, numberingSystems);
+            CldrNumberingSystem.writeLinks(out, numSysMap);
         }
         for (String numberingSystem : systems) {
             if (systems.size() > 1) {
-                String kind = numberingSystems.get(numberingSystem);
-                out.write(
-                        "<h1 style=\"padding-top: 1em\" id=\""
-                                + numberingSystemLinkId(numberingSystem)
-                                + "\">Numbering System: "
-                                + numberingSystem
-                                + " ("
-                                + kind
-                                + ")</h1>");
+                CldrNumberingSystem.writeHeader(numSysMap, numberingSystem, out);
             }
             formats.addTable(english, out, numberingSystem);
             formats.addDateTable(englishFile, out, numberingSystem);
             formats.addDayPeriods(englishFile, out, numberingSystem);
         }
-    }
-
-    private static void writeNumberingSystemLinks(
-            Writer out, LinkedHashMap<String, String> numberingSystems) throws IOException {
-        out.write(
-                "This report is displayed below once for each of "
-                        + numberingSystems.keySet().size()
-                        + " numbering systems used for this locale: ");
-        boolean needComma = false;
-        for (String numberingSystem : numberingSystems.keySet()) {
-            if (needComma) {
-                out.write(", ");
-            }
-            // Enable clicking on the numbering system to scroll to it. Use onclick and
-            // scrollIntoView instead of simple "href", which would fail in Survey Tool
-            // due to its special handling of anchors.
-            String link = numberingSystemLinkId(numberingSystem);
-            String onClick = "document.getElementById('" + link + "').scrollIntoView()";
-            String kind = numberingSystems.get(numberingSystem);
-            // For some reason, in the chart, this link lacks underline unless added here explicitly
-            out.write(
-                    "<a style=\"text-decoration: underline;\" onclick=\""
-                            + onClick
-                            + "\">"
-                            + numberingSystem
-                            + " ("
-                            + kind
-                            + ")</a>");
-            needComma = true;
-        }
-        out.write(".");
-    }
-
-    private static String numberingSystemLinkId(String numberingSystem) {
-        return "numbering-system-" + numberingSystem;
-    }
-
-    private static LinkedHashMap<String, String> getNumberingSystems(CLDRFile cldrFile) {
-        final String LATN = "latn";
-        TreeMap<String, String> m = new TreeMap<>();
-        m.put(LDMLConstants.DEFAULT, CLDRFile.NumberingSystem.defaultSystem.path);
-        m.put("Latin", LATN);
-        m.put(LDMLConstants.NATIVE, CLDRFile.NumberingSystem.nativeSystem.path);
-        m.put(LDMLConstants.TRADITIONAL, CLDRFile.NumberingSystem.traditional.path);
-        m.put(LDMLConstants.FINANCE, CLDRFile.NumberingSystem.finance.path);
-        LinkedHashMap<String, String> systems = new LinkedHashMap<>();
-        for (String kind : m.keySet()) {
-            String path = m.get(kind);
-            String system = LATN.equals(path) ? LATN : cldrFile.getStringValue(path);
-            if (system != null && !systems.containsKey(system)) {
-                systems.put(system, kind);
-            }
-        }
-        return systems;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -50,10 +50,9 @@ public class ICUServiceBuilder {
                 CacheBuilder.newBuilder()
                         .softValues()
                         .build(
-                                new CacheLoader<CLDRLocale, ICUServiceBuilder>() {
+                                new CacheLoader<>() {
                                     @Override
-                                    public ICUServiceBuilder load(final CLDRLocale key)
-                                            throws Exception {
+                                    public ICUServiceBuilder load(final CLDRLocale key) {
                                         return new ICUServiceBuilder(
                                                 cldrFactory.make(key.getBaseName(), true),
                                                 defaultCollationFactory);
@@ -82,7 +81,7 @@ public class ICUServiceBuilder {
     }
 
     @Deprecated
-    public static final ICUServiceBuilder inefficientSingletonServiceBuilder(
+    public static ICUServiceBuilder inefficientSingletonServiceBuilder(
             final CLDRFile resolvedFile) {
         return new ICUServiceBuilder(resolvedFile, defaultCollationFactory);
     }
@@ -566,8 +565,7 @@ public class ICUServiceBuilder {
                             + "\tpath: "
                             + key
                             + CldrUtility.LINE_SEPARATOR
-                            + "value: "
-                            + value);
+                            + "value: null");
         return value;
     }
 
@@ -633,12 +631,10 @@ public class ICUServiceBuilder {
         return result;
     }
 
-    private static final String[] NumberNames = {
-        "integer", "decimal", "percent", "scientific"
-    }; // // "standard", , "INR",
+    private static final String[] NumberNames = {"integer", "decimal", "percent", "scientific"};
 
     // add symbols for clarity.
-    public static final int integer = 0, decimal = 2, percent = 3, scientific = 4;
+    public static final int integer = 0, decimal = 1, percent = 2, scientific = 3;
 
     // ICUServiceBuilder needs a much more substantial overhaul, so adding an enum would be wasted
     // effort
@@ -947,7 +943,7 @@ public class ICUServiceBuilder {
         symbols = new DecimalFormatSymbols();
         if (numberSystem == null) {
             numberSystem =
-                    cldrFile.getWinningValueWithBailey("//ldml/numbers/defaultNumberingSystem");
+                    cldrFile.getWinningValueWithBailey(CldrNumberingSystem.defaultSystem.path);
         }
 
         // currently constants
@@ -1024,25 +1020,26 @@ public class ICUServiceBuilder {
 
     private String getSymbolString(String key, String numsys) {
         // numsys should not be null (previously resolved to defaultNumberingSystem if necessary)
+        if (numsys == null) {
+            throw new IllegalArgumentException("Number system is null");
+        }
         String value = null;
+        String path = "//ldml/numbers/symbols[@numberSystem=\"" + numsys + "\"]/" + key;
         try {
-            value =
-                    cldrFile.getWinningValueWithBailey(
-                            "//ldml/numbers/symbols[@numberSystem=\"" + numsys + "\"]/" + key);
+            value = cldrFile.getWinningValueWithBailey(path);
             if (value == null || value.isEmpty()) {
-                throw new IllegalArgumentException("No value for path");
+                String defNumSys =
+                        cldrFile.getWinningValueWithBailey(CldrNumberingSystem.defaultSystem.path);
+                if (defNumSys == null) {
+                    throw new IllegalArgumentException("Default number system is null");
+                } else if (defNumSys.equals(numsys)) {
+                    throw new IllegalArgumentException("No value for path");
+                }
+                return getSymbolString(key, defNumSys);
             }
             return value;
         } catch (RuntimeException e) {
-            throw new IllegalArgumentException(
-                    "Illegal value <"
-                            + value
-                            + "> at "
-                            + "//ldml/numbers/symbols[@numberSystem='"
-                            + numsys
-                            + "']/"
-                            + key,
-                    e);
+            throw new IllegalArgumentException("Illegal value <" + value + "> at " + path, e);
         }
     }
 
@@ -1060,7 +1057,7 @@ public class ICUServiceBuilder {
         else if (key1.equals("integer")) type = "decimal";
         if (numberSystem == null) {
             numberSystem =
-                    cldrFile.getWinningValueWithBailey("//ldml/numbers/defaultNumberingSystem");
+                    cldrFile.getWinningValueWithBailey(CldrNumberingSystem.defaultSystem.path);
         }
         String path =
                 prefix
@@ -1074,9 +1071,9 @@ public class ICUServiceBuilder {
                         + "Format[@type=\"standard\"]/pattern[@type=\"standard\"]";
 
         String pattern = cldrFile.getWinningValueWithBailey(path);
-        if (pattern == null)
-            throw new IllegalArgumentException(
-                    "locale: " + cldrFile.getLocaleID() + "\tpath: " + path);
+        if (pattern == null) {
+            return getPattern(key1, isCurrency, null /* default numbering system */);
+        }
         return pattern;
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -2758,7 +2758,7 @@ public class SupplementalDataInfo {
     /**
      * Get the default content locale for a specified language
      *
-     * @param language language to search
+     * @param locale language to search
      * @return default content, or null if none
      */
     public String getDefaultContentLocale(String locale) {
@@ -4117,7 +4117,8 @@ public class SupplementalDataInfo {
             tempCountToRule.putAll(countToRule);
             this.countToRule = Collections.unmodifiableMap(tempCountToRule);
 
-            // now build rules
+            // Now build rules.
+            // There should be a comment here explaining why ULocale.ENGLISH is hard-wired.
             NumberFormat nf = NumberFormat.getNumberInstance(ULocale.ENGLISH);
             nf.setMaximumFractionDigits(2);
             StringBuilder pluralRuleBuilder = new StringBuilder();
@@ -4146,13 +4147,9 @@ public class SupplementalDataInfo {
                 _keywords.add(c);
                 if (pluralRules.getDecimalSamples(s, SampleType.DECIMAL) != null) {
                     _decimalKeywords.add(c);
-                } else {
-                    int debug = 1;
                 }
                 if (pluralRules.getDecimalSamples(s, SampleType.INTEGER) != null) {
                     _integerKeywords.add(c);
-                } else {
-                    int debug = 1;
                 }
                 String parsedRules = pluralRules.getRules(s);
                 if (!hasEMatcher.reset(parsedRules).find()) {
@@ -4184,11 +4181,6 @@ public class SupplementalDataInfo {
 
             Output<Map<Count, SampleList[]>> output = new Output();
 
-            // double check
-            // if (!targetKeywords.equals(typeToExamples2.keySet())) {
-            // throw new IllegalArgumentException ("Problem in plurals " + targetKeywords + ", " +
-            // this);
-            // }
             // now fix the longer examples
             String otherFractionalExamples = "";
             List<Double> otherFractions = new ArrayList<>(0);
@@ -4531,7 +4523,7 @@ public class SupplementalDataInfo {
     }
 
     /**
-     * @deprecated use {@link #getPlurals(PluralType)} instead
+     * @deprecated use {@link #getPluralLocales(PluralType)} instead
      */
     @Deprecated
     public Set<String> getPluralLocales() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
@@ -10,8 +10,10 @@ import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -19,6 +21,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import org.unicode.cldr.draft.FileUtilities;
+import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.test.BuildIcuCompactDecimalFormat;
 import org.unicode.cldr.test.BuildIcuCompactDecimalFormat.CurrencyStyle;
 import org.unicode.cldr.tool.ChartDelta;
@@ -37,8 +40,7 @@ public class VerifyCompactNumbers {
     private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
     private static final String DIR = CLDRPaths.VERIFY_DIR + "numbers/";
     // The following is also in ExampleGenerator and DateTimeFormats; it and other shared constant
-    // sets should
-    // probably be moved to a common file of such things.
+    // sets should probably be moved to a common file of such things.
     private static final UnicodeSet BIDI_MARKS = new UnicodeSet("[:Bidi_Control:]").freeze();
     private static final String exampleSep = "<br>";
     private static final String rtlStart = "<div dir='rtl'>";
@@ -68,7 +70,7 @@ public class VerifyCompactNumbers {
      * Produce a set of static tables from the vxml data. Only a stopgap until the above is
      * integrated into ST.
      *
-     * @param args
+     * @param args the command-line arguments
      * @throws IOException
      */
     public static void main(String[] args) throws IOException {
@@ -146,43 +148,63 @@ public class VerifyCompactNumbers {
     }
 
     public static void showNumbers(
-            CLDRFile cldrFile, String currencyCode, Appendable out, Factory factory) {
+            CLDRFile cldrFile, String currencyCode, Writer out, Factory factory) {
         final String localeID = cldrFile.getLocaleID();
         final boolean isRTL = cldrFile.isRTL();
         final Set<String> debugCreationErrors = new LinkedHashSet<>();
         final Set<String> errors = new LinkedHashSet<>();
+        final LinkedHashMap<String, String> numSysMap = CldrNumberingSystem.getMap(cldrFile);
+        final Set<String> systems = numSysMap.keySet();
         try {
-            final TablePrinter tablePrinter = makeTablePrinter();
-            final ICUServiceBuilder builder =
-                    factory.getICUServiceBuilder(CLDRLocale.getInstance(localeID));
-            final NumberFormat nf = builder.getNumberFormat(1);
-            final FormatBuilderArgs fba =
-                    new FormatBuilderArgs(
-                            factory, cldrFile, debugCreationErrors, localeID, currencyCode);
-
-            final CompactDecimalFormat cdf =
-                    createFormat(fba, CompactStyle.SHORT, CurrencyStyle.PLAIN);
-            captureErrors(debugCreationErrors, errors, localeID, "short");
-
-            final CompactDecimalFormat cdfs =
-                    createFormat(fba, CompactStyle.LONG, CurrencyStyle.PLAIN);
-            captureErrors(debugCreationErrors, errors, localeID, "long");
-
-            final CompactDecimalFormat cdfCurr =
-                    createFormat(fba, CompactStyle.SHORT, CurrencyStyle.CURRENCY);
-            captureErrors(debugCreationErrors, errors, localeID, "short-curr");
-
-            final SupplementalDataInfo sdi = CLDR_CONFIG.getSupplementalDataInfo();
-            final Set<Double> allSamples =
-                    collectSamplesAndSetFormats(currencyCode, localeID, sdi, cdf, cdfs, cdfCurr);
-            try {
-                for (double source : allSamples) {
-                    showNumbersForSource(source, nf, isRTL, cdf, cdfs, cdfCurr, tablePrinter);
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
+            if (systems.size() > 1) {
+                CldrNumberingSystem.writeLinks(out, numSysMap);
             }
-            writeTables(tablePrinter, cldrFile, localeID, out, factory);
+            for (String numberingSystem : systems) {
+                if (systems.size() > 1) {
+                    CldrNumberingSystem.writeHeader(numSysMap, numberingSystem, out);
+                }
+                final ICUServiceBuilder builder =
+                        factory.getICUServiceBuilder(CLDRLocale.getInstance(localeID));
+                final String kind = numSysMap.get(numberingSystem);
+                final NumberFormat nf;
+                if (LDMLConstants.DEFAULT.equals(kind)) {
+                    nf = builder.getNumberFormat(ICUServiceBuilder.decimal);
+                } else {
+                    nf = builder.getNumberFormat(ICUServiceBuilder.decimal, numberingSystem);
+                }
+                final FormatBuilderArgs fba =
+                        new FormatBuilderArgs(
+                                factory, cldrFile, debugCreationErrors, localeID, currencyCode);
+
+                final CompactDecimalFormat cdf =
+                        createFormat(fba, CompactStyle.SHORT, CurrencyStyle.PLAIN, numberingSystem);
+                captureErrors(debugCreationErrors, errors, localeID, "short");
+
+                final CompactDecimalFormat cdfs =
+                        createFormat(fba, CompactStyle.LONG, CurrencyStyle.PLAIN, numberingSystem);
+                captureErrors(debugCreationErrors, errors, localeID, "long");
+
+                final CompactDecimalFormat cdfCurr =
+                        createFormat(
+                                fba, CompactStyle.SHORT, CurrencyStyle.CURRENCY, numberingSystem);
+                captureErrors(debugCreationErrors, errors, localeID, "short-curr");
+
+                final SupplementalDataInfo sdi = CLDR_CONFIG.getSupplementalDataInfo();
+                final Set<Double> allSamples =
+                        collectSamplesAndSetFormats(
+                                currencyCode, localeID, sdi, cdf, cdfs, cdfCurr);
+
+                final NumberTable numberTable = new NumberTable(nf, cdf, cdfs, cdfCurr, isRTL);
+                final TablePrinter tablePrinter = makeTablePrinter();
+                try {
+                    for (double source : allSamples) {
+                        numberTable.show(tablePrinter, source);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                writeTables(tablePrinter, cldrFile, localeID, numberingSystem, out, factory);
+            }
             showErrors(errors, out);
             showErrors(debugCreationErrors, out);
         } catch (IOException e) {
@@ -212,40 +234,18 @@ public class VerifyCompactNumbers {
     }
 
     private static CompactDecimalFormat createFormat(
-            FormatBuilderArgs fba, CompactStyle compactStyle, CurrencyStyle currencyStyle) {
+            FormatBuilderArgs fba,
+            CompactStyle compactStyle,
+            CurrencyStyle currencyStyle,
+            String numberingSystem) {
         return BuildIcuCompactDecimalFormat.build(
                 fba.cldrFactory,
                 fba.resolvedCldrFile,
-                fba.debugCreationErrors,
-                null /* debugOriginals */,
                 compactStyle,
                 fba.uLocale,
                 currencyStyle,
-                fba.currencyCodeOrUnit);
-    }
-
-    private static void showNumbersForSource(
-            double source,
-            NumberFormat nf,
-            boolean isRTL,
-            CompactDecimalFormat cdf,
-            CompactDecimalFormat cdfs,
-            CompactDecimalFormat cdfCurr,
-            TablePrinter tablePrinter) {
-        String formattedNumber = nf.format(source);
-        if (isRTL || BIDI_MARKS.containsSome(formattedNumber)) {
-            formattedNumber += exampleSep + rtlStart + formattedNumber + rtlEnd;
-        }
-        String compactFormattedNumber = cdf.format(source);
-        String compactLongFormattedNumber = cdfs.format(source);
-        String compactCurrFormattedNumber = cdfCurr.format(source);
-        tablePrinter
-                .addRow()
-                .addCell(formattedNumber)
-                .addCell(compactFormattedNumber)
-                .addCell(compactLongFormattedNumber);
-        tablePrinter.addCell(compactCurrFormattedNumber);
-        tablePrinter.finishRow();
+                fba.currencyCodeOrUnit,
+                numberingSystem);
     }
 
     private static TablePrinter makeTablePrinter() {
@@ -270,6 +270,7 @@ public class VerifyCompactNumbers {
             TablePrinter tablePrinter,
             CLDRFile cldrFile,
             String localeID,
+            String numberingSystem,
             Appendable out,
             Factory factory)
             throws IOException {
@@ -283,19 +284,18 @@ public class VerifyCompactNumbers {
         out.append(tablePrinter.toString()).append("\n");
         out.append("<h3>Plural Rules</h3>");
         out.append(
-                "<p>Look over the Minimal Pairs to make sure they are ok. "
+                "<p>Look over the Minimal Pairs to make sure they are OK. "
                         + "Then review the examples in the cell to the left. "
                         + "All of those you should be able to substitute for the numbers in the Minimal Pairs, "
-                        + "with an acceptable result. "
-                        + "If any would be incorrect, please "
+                        + "with an acceptable result. If any would be incorrect, please "
                         + "<a target='ticket' href='"
                         + CLDRURLS.CLDR_NEWTICKET_URL
                         + "'>file a ticket</a>.</p>"
                         + "<p>For more details, see "
                         + "<a target='CLDR-ST-DOCS' href='http://cldr.unicode.org/index/cldr-spec/plural-rules'>Plural Rules</a>.</p>");
         ShowPlurals showPlurals = new ShowPlurals(CLDR_CONFIG.getSupplementalDataInfo());
+        showPlurals.setNumberingSystem(numberingSystem);
         showPlurals.printPluralTable(cldrFile, localeID, out, factory);
-        ShowPlurals.appendBlanksForScrolling(out);
     }
 
     public static Set<Double> collectSamplesAndSetFormats(
@@ -383,6 +383,42 @@ public class VerifyCompactNumbers {
                 errors.add(locale + "\t" + length + "\t" + s);
             }
             debugCreationErrors.clear();
+        }
+    }
+
+    private static class NumberTable {
+        private final NumberFormat nf;
+        private final CompactDecimalFormat cdf, cdfs, cdfCurr;
+        private final boolean isRTL;
+
+        public NumberTable(
+                NumberFormat nf,
+                CompactDecimalFormat cdf,
+                CompactDecimalFormat cdfs,
+                CompactDecimalFormat cdfCurr,
+                boolean isRTL) {
+            this.nf = nf;
+            this.cdf = cdf;
+            this.cdfs = cdfs;
+            this.cdfCurr = cdfCurr;
+            this.isRTL = isRTL;
+        }
+
+        public void show(TablePrinter tablePrinter, double source) {
+            String formattedNumber = nf.format(source);
+            if (isRTL || BIDI_MARKS.containsSome(formattedNumber)) {
+                formattedNumber += exampleSep + rtlStart + formattedNumber + rtlEnd;
+            }
+            String compactFormattedNumber = cdf.format(source);
+            String compactLongFormattedNumber = cdfs.format(source);
+            String compactCurrFormattedNumber = cdfCurr.format(source);
+            tablePrinter
+                    .addRow()
+                    .addCell(formattedNumber)
+                    .addCell(compactFormattedNumber)
+                    .addCell(compactLongFormattedNumber)
+                    .addCell(compactCurrFormattedNumber)
+                    .finishRow();
         }
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/tool/GenerateDateTimeTestDataTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/tool/GenerateDateTimeTestDataTest.java
@@ -48,7 +48,7 @@ public class GenerateDateTimeTestDataTest {
 
             String actual =
                     GenerateDateTimeTestData.computeSkeletonFromSemanticSkeleton(
-                            icuServiceBuilder, localeCldrFile, fieldStyleCombo, calendarStr);
+                            localeCldrFile, fieldStyleCombo, calendarStr);
 
             assertEquals(
                     expected,
@@ -141,7 +141,7 @@ public class GenerateDateTimeTestDataTest {
 
             String actual =
                     GenerateDateTimeTestData.computeSkeletonFromSemanticSkeleton(
-                            icuServiceBuilder, localeCldrFile, fieldStyleCombo, calendarStr);
+                            localeCldrFile, fieldStyleCombo, calendarStr);
 
             assertEquals(
                     expected,

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckNumbers.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckNumbers.java
@@ -12,6 +12,7 @@ import org.unicode.cldr.test.CheckNumbers;
 import org.unicode.cldr.unittest.TestXMLSource.DummyXMLSource;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XMLSource;
@@ -63,7 +64,7 @@ public class TestCheckNumbers extends TestFmwkPlus {
                     || (locale.startsWith("ar_") && !defaultContentLocales.contains(locale))) {
                 CLDRFile cldrFile = cldrFactory.make(locale, false);
                 String defaultNumberSys =
-                        cldrFile.getStringValue("//ldml/numbers/defaultNumberingSystem");
+                        cldrFile.getStringValue(CldrNumberingSystem.defaultSystem.path);
                 if (defaultNumberSys == null) {
                     errln(
                             "Missing explicit defaultNumberingSystem entry in "

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompactNumbers.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCompactNumbers.java
@@ -10,6 +10,9 @@ import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.util.Currency;
 import com.ibm.icu.util.ULocale;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -19,9 +22,9 @@ import org.unicode.cldr.test.BuildIcuCompactDecimalFormat.CurrencyStyle;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.ICUServiceBuilder;
-import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
@@ -29,10 +32,8 @@ import org.unicode.cldr.util.VerifyCompactNumbers;
 
 public class TestCompactNumbers extends TestFmwkPlus {
     static final boolean DEBUG = false;
-    private static final StandardCodes sc = StandardCodes.make();
     private static final CLDRConfig CLDRCONFIG = CLDRConfig.getInstance();
     private static final SupplementalDataInfo SDI = CLDRCONFIG.getSupplementalDataInfo();
-    private static final CLDRFile ENGLISH = CLDRCONFIG.getEnglish();
     private static final Factory factory2 = CLDRCONFIG.getCldrFactory();
 
     public static void main(String[] args) {
@@ -42,7 +43,7 @@ public class TestCompactNumbers extends TestFmwkPlus {
     public void TestVerify() {
         // Just verify no crashes
         CLDRFile cldrFile = factory2.make("it", true);
-        Appendable out = new StringBuilder();
+        Writer out = new PrintWriter(new StringWriter());
         VerifyCompactNumbers.showNumbers(cldrFile, "EUR", out, factory2);
         if (DEBUG) {
             System.out.println(out);
@@ -66,12 +67,11 @@ public class TestCompactNumbers extends TestFmwkPlus {
                 BuildIcuCompactDecimalFormat.build(
                         factory2,
                         cldrFile,
-                        debugCreationErrors,
-                        debugOriginals,
                         CompactStyle.SHORT,
                         locale2,
                         CurrencyStyle.PLAIN,
-                        currencyCode);
+                        currencyCode,
+                        CldrNumberingSystem.LATN_SYSTEM);
 
         Map<String, Map<String, String>> data =
                 BuildIcuCompactDecimalFormat.buildCustomData(
@@ -86,22 +86,20 @@ public class TestCompactNumbers extends TestFmwkPlus {
                 BuildIcuCompactDecimalFormat.build(
                         factory2,
                         cldrFile,
-                        debugCreationErrors,
-                        debugOriginals,
                         CompactStyle.LONG,
                         locale2,
                         CurrencyStyle.PLAIN,
-                        currencyCode);
+                        currencyCode,
+                        CldrNumberingSystem.LATN_SYSTEM);
         CompactDecimalFormat cdfCurr =
                 BuildIcuCompactDecimalFormat.build(
                         factory2,
                         cldrFile,
-                        debugCreationErrors,
-                        debugOriginals,
                         CompactStyle.SHORT,
                         locale2,
                         CurrencyStyle.CURRENCY,
-                        currencyCode);
+                        currencyCode,
+                        CldrNumberingSystem.LATN_SYSTEM);
 
         Set<Double> allSamples =
                 VerifyCompactNumbers.collectSamplesAndSetFormats(
@@ -177,12 +175,11 @@ public class TestCompactNumbers extends TestFmwkPlus {
                             BuildIcuCompactDecimalFormat.build(
                                     factory2,
                                     cldrFile,
-                                    debugCreationErrors,
-                                    debugOriginals,
                                     compactStyle,
                                     ULocale.forLanguageTag(locale),
                                     currencyStyle,
-                                    null);
+                                    null,
+                                    CldrNumberingSystem.LATN_SYSTEM);
 
                     // note: custom data looks good:
                     // 1000000={other=0 milionů, one=0 milion, few=0 miliony, many=0 milionu}
@@ -195,12 +192,11 @@ public class TestCompactNumbers extends TestFmwkPlus {
                             BuildIcuCompactDecimalFormat.build(
                                     factory2,
                                     cldrFile,
-                                    debugCreationErrors,
-                                    debugOriginals,
                                     compactStyle,
                                     ULocale.forLanguageTag(locale),
                                     currencyStyle,
-                                    currencyCode);
+                                    currencyCode,
+                                    CldrNumberingSystem.LATN_SYSTEM);
 
                     cdfCurr.setCurrency(Currency.getInstance(currencyCode));
                     int sigDigits = 3;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -41,6 +41,7 @@ import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.ChainedMap;
 import org.unicode.cldr.util.ChainedMap.M4;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrPathUtilities;
 import org.unicode.cldr.util.CldrPathUtilities.IntervalSeparatorType;
 import org.unicode.cldr.util.Counter2;
@@ -1354,11 +1355,11 @@ public class TestCoverageLevel extends TestFmwkPlus {
         for (String localeId : factory.getAvailable()) {
             CLDRFile cldrFile = factory.make(localeId, true);
             String defaultNumberSystem =
-                    cldrFile.getStringValue(CLDRFile.NumberingSystem.defaultSystem.path);
+                    cldrFile.getStringValue(CldrNumberingSystem.defaultSystem.path);
             String nativeNumberSystem =
-                    cldrFile.getStringValue(CLDRFile.NumberingSystem.nativeSystem.path);
+                    cldrFile.getStringValue(CldrNumberingSystem.nativeSystem.path);
             String financeNumberSystem =
-                    cldrFile.getStringValue(CLDRFile.NumberingSystem.finance.path); // could be null
+                    cldrFile.getStringValue(CldrNumberingSystem.finance.path); // could be null
             for (NumPathCoverageItem item : testItems) {
                 String pathForDefault = item.numPath.replace("xxxx", defaultNumberSystem);
                 Level defaultLevel = SDI.getCoverageLevel(pathForDefault, localeId);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -41,6 +41,7 @@ import org.unicode.cldr.util.CLDRFileOverride;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CldrIntervalFormat;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CodePointEscaper;
 import org.unicode.cldr.util.Counter;
@@ -268,7 +269,7 @@ public class TestExampleGenerator extends TestFmwk {
      */
     static final Set<String> DELIBERATE_OK_TO_MISS_BACKGROUND =
             ImmutableSet.of(
-                    "//ldml/numbers/defaultNumberingSystem",
+                    CldrNumberingSystem.defaultSystem.path,
                     "//ldml/numbers/otherNumberingSystems/native",
                     // TODO fix formatting
                     "//ldml/characters/exemplarCharacters",
@@ -299,7 +300,7 @@ public class TestExampleGenerator extends TestFmwk {
      */
     static final Set<String> TEMPORARY_OK_TO_MISS_BACKGROUND =
             ImmutableSet.of(
-                    "//ldml/numbers/defaultNumberingSystem",
+                    CldrNumberingSystem.defaultSystem.path,
                     "//ldml/dates/calendars/calendar[@type=\"([^\"]*+)\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"([^\"]*+)\"][@count=\"([^\"]*+)\"]",
                     "//ldml/dates/timeZoneNames/zone[@type=\"([^\"]*+)\"]/long/standard",
                     "//ldml/dates/timeZoneNames/metazone[@type=\"([^\"]*+)\"]/short/generic",

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -36,6 +36,7 @@ import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CLDRURLS;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Containment;
 import org.unicode.cldr.util.Counter;
@@ -792,7 +793,7 @@ public class TestPathHeader extends TestFmwkPlus {
         Set<String> alreadySeen = new HashSet<>();
 
         checkPathDescriptionCompleteness(
-                pathDescription, normal, "//ldml/numbers/defaultNumberingSystem", alreadySeen);
+                pathDescription, normal, CldrNumberingSystem.defaultSystem.path, alreadySeen);
         for (PathHeader pathHeader : getPathHeaders(english)) {
             if (pathHeader.shouldHide()) {
                 continue;
@@ -821,7 +822,7 @@ public class TestPathHeader extends TestFmwkPlus {
                             + value
                             + "\t"
                             + path);
-        } else if (description == PathDescription.MISSING_DESCRIPTION) {
+        } else if (PathDescription.MISSING_DESCRIPTION.equals(description)) {
             errorDescription = ("Fallback Description:\t" + value + "\t" + path);
         } else {
             return;

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/WikiSubdivisionLanguages.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/WikiSubdivisionLanguages.java
@@ -37,11 +37,11 @@ import org.unicode.cldr.rdf.TsvWriter;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
-import org.unicode.cldr.util.CLDRFile.NumberingSystem;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.ChainedMap;
 import org.unicode.cldr.util.ChainedMap.M4;
+import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.ExemplarSets.ExemplarType;
@@ -233,7 +233,7 @@ public final class WikiSubdivisionLanguages {
                     file.getExemplarSet(ExemplarType.auxiliary, WinningChoice.WINNING);
             UnicodeSet punctuation =
                     file.getExemplarSet(ExemplarType.punctuation, WinningChoice.WINNING);
-            UnicodeSet numbers = file.getExemplarsNumeric(NumberingSystem.defaultSystem);
+            UnicodeSet numbers = file.getExemplarsNumeric(CldrNumberingSystem.defaultSystem);
             exemplars =
                     new UnicodeSet()
                             .addAll(main)


### PR DESCRIPTION
-In VerifyCompactNumbers.java, loop through numbering systems; refactor with new subclass NumberTable

-Move enlarged CLDRFile.NumberingSystem class to new top-level class CldrNumberingSystem

-Replace string literals with values defined in CldrNumberingSystem, for encapsulation

-Do not call ShowPlurals.appendBlanksForScrolling for the Plural Rules table, since it would put 100 blank lines between the output for different numbering systems

-Fix compiler warnings; remove dead code

-Comments

CLDR-17854

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
