### PR TITLE
CLDR-14953 fixes to vxml generation

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.unicode.cldr.util.*;
@@ -59,7 +60,7 @@ public class OutputFileManager {
     private static final FileFilter xmlFileFilter =
             file -> {
                 String s = file.getName().toLowerCase();
-                return s.endsWith(XML_SUFFIX) && !"en.xml".equals(s) && !"root.xml".equals(s);
+                return s.endsWith(XML_SUFFIX);
             };
 
     /**
@@ -214,16 +215,18 @@ public class OutputFileManager {
 
     public static Set<CLDRLocale> createVxmlLocaleSet() {
         Set<CLDRLocale> set = new TreeSet<>(SurveyMain.getLocalesSet());
-        // skip "en" and "root", since they should never be changed by the Survey Tool
-        set.remove(CLDRLocale.getInstance("en"));
-        set.remove(CLDRLocale.getInstance(LocaleNames.ROOT));
-        // Remove "mul", "mul_ZZ", etc.; all "special" locales except algorithmic.
-        set.removeIf(
-                loc -> {
-                    SpecialLocales.Type t = SpecialLocales.getType(loc);
-                    return t != null && t != SpecialLocales.Type.algorithmic;
-                });
+        // Only remove "scratch" locales (mul).
+        // All others need processing.
+        set.removeIf(loc -> isSkippedLocale(loc));
         return set;
+    }
+
+    /**
+     * @returns true if this locale should be skipped, that is not even considered.
+     */
+    public static boolean isSkippedLocale(CLDRLocale loc) {
+        SpecialLocales.Type t = SpecialLocales.getType(loc);
+        return t != null && t == SpecialLocales.Type.scratch;
     }
 
     /**
@@ -307,6 +310,7 @@ public class OutputFileManager {
         for (File f : Objects.requireNonNull(dirFile.listFiles())) {
             List<Pair<String, String>> data = new ArrayList<>();
             String canonicalPath = f.getCanonicalPath();
+            // never remove root or non-xml
             if (canonicalPath.endsWith("root.xml") || !canonicalPath.endsWith(XML_SUFFIX)) {
                 continue;
             }
@@ -457,9 +461,7 @@ public class OutputFileManager {
                     CLDRLocale parLoc = childLoc.getParent();
                     if (parLoc != null) {
                         String parentName = parLoc + XML_SUFFIX;
-                        if (!childName.equals(parentName)
-                                && !"en.xml".equals(parentName)
-                                && !"root.xml".equals(parentName)) {
+                        if (!childName.equals(parentName)) {
                             String parentPathName = dirName + "/" + parentName;
                             File fParent = new File(parentPathName);
                             if (!fParent.exists() && !otherParentExists(parentPathName, c)) {
@@ -536,43 +538,28 @@ public class OutputFileManager {
                 }
             }
         }
-        Set<String> diff = symmetricDifference(vxmlFiles, bxmlFiles);
-        if (!diff.isEmpty()) {
-            boolean someOnlyInVxml = false, someOnlyInBxml = false;
-            for (String name : diff) {
-                if (vxmlFiles.contains(name)) {
-                    someOnlyInVxml = true;
-                } else {
-                    someOnlyInBxml = true;
-                }
-                if (someOnlyInVxml && someOnlyInBxml) {
-                    break;
-                }
-            }
-            if (someOnlyInVxml) {
-                /*
-                 * Notification only, not a failure
-                 */
-                StringBuilder message =
-                        new StringBuilder("File(s) present in VXML but not in baseline:");
-                for (String name : diff) {
-                    if (vxmlFiles.contains(name)) {
-                        message.append(" ").append(name);
-                    }
-                }
-                results.addVerificationWarning(message.toString());
-            }
-            if (someOnlyInBxml) {
-                StringBuilder message =
-                        new StringBuilder("File(s) present in baseline but not in VXML:");
-                for (String name : diff) {
-                    if (bxmlFiles.contains(name)) {
-                        message.append(" ").append(name);
-                    }
-                }
-                results.addVerificationFailure(message.toString());
-            }
-        }
+        // all new items
+        Set<String> newInVxml =
+                vxmlFiles.stream().filter(f -> !bxmlFiles.contains(f)).collect(Collectors.toSet());
+
+        // error, missing items
+        Set<String> missingInVxml =
+                bxmlFiles.stream().filter(f -> !vxmlFiles.contains(f)).collect(Collectors.toSet());
+
+        // we celebrate new annotations, not an error
+        Set<String> newAnnotations =
+                newInVxml.stream()
+                        .filter(f -> f.startsWith("common/annotations/"))
+                        .collect(Collectors.toSet());
+        // error, some other item
+        Set<String> newOtherFiles =
+                newInVxml.stream()
+                        .filter(f -> !newAnnotations.contains(f))
+                        .collect(Collectors.toSet());
+
+        results.addVerificationFailure("Missing in VXML, present in baseline", missingInVxml);
+        results.addVerificationWarning("New annotations in VXML", newAnnotations);
+        results.addVerificationFailure("Unexpected new in VXML, not in baseline", newOtherFiles);
     }
 
     /**
@@ -594,9 +581,9 @@ public class OutputFileManager {
 
     private static final Predicate<String> isAnnotations = x -> x.startsWith("//ldml/annotations");
 
-    private final Map<String, Object> OPTS_SKIP_ANNOTATIONS =
+    private static final Map<String, Object> OPTS_SKIP_ANNOTATIONS =
             ImmutableMap.of("SKIP_PATH", isAnnotations);
-    private final Map<String, Object> OPTS_KEEP_ANNOTATIONS =
+    private static final Map<String, Object> OPTS_KEEP_ANNOTATIONS =
             ImmutableMap.of("SKIP_PATH", isAnnotations.negate());
 
     /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
@@ -20,6 +20,8 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.*;
 import java.util.Map.Entry;
@@ -29,6 +31,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.io.FileUtils;
 import org.unicode.cldr.util.*;
 
 public class OutputFileManager {
@@ -101,21 +104,38 @@ public class OutputFileManager {
                     results.generationMessage = "Directory creation for vetting data failed.";
                     return;
                 }
-                if (!ofm.outputAllFiles(vxmlGenerator, results)) {
-                    results.generationMessage = "File output failed.";
-                    return;
-                }
                 if (!ofm.copyDtd(results.directory)) {
                     results.generationMessage = "Copying DTD failed.";
                     return;
                 }
+                if (!ofm.outputAllFiles(vxmlGenerator, results)) {
+                    results.generationMessage = "File output failed.";
+                    return;
+                }
                 File vxmlDir = new File(results.directory + "/" + Kind.vxml.name());
+                vxmlDir.mkdirs();
+                ofm.copyReadmes(vxmlDir);
                 ofm.removeEmptyFiles(vxmlDir);
                 ofm.verifyAllFiles(results, vxmlDir);
             }
             logger.log(Level.WARNING, "generateVxml finished");
         } catch (Exception e) {
             logger.log(Level.SEVERE, "generateVxml: " + e.getMessage(), e);
+        }
+    }
+
+    private void copyReadmes(File vxmlDir) {
+        Path commonPath = vxmlDir.toPath().resolve("common");
+        final Path newMain = commonPath.resolve("main");
+        final Path newAnnotations = commonPath.resolve("annotations");
+        final Path oldMain = new File(CLDRPaths.MAIN_DIRECTORY).toPath();
+        final Path oldAnnotations = new File(CLDRPaths.ANNOTATIONS_DIRECTORY).toPath();
+
+        try {
+            copyReadmeMaybe(oldMain, newMain);
+            copyReadmeMaybe(oldAnnotations, newAnnotations);
+        } catch (IOException e) {
+            logger.log(Level.WARNING, e, () -> "Could not copy README.md files");
         }
     }
 
@@ -139,13 +159,28 @@ public class OutputFileManager {
                 vetdataDir.getParent() + "/" + vetdataDir.getName() + "-" + timestamp;
         File manualVetdataDir = new File(manualVetdataDirName);
         if (!manualVetdataDir.mkdirs()) {
+            logger.warning("vetdata dir already existed " + manualVetdataDir);
             return null;
         }
         return manualVetdataDir;
     }
 
+    static final String READMEmd = "README.md";
+
+    private static void copyReadmeMaybe(Path oldMain, Path newMain) throws IOException {
+        Path oldReadme = oldMain.resolve(READMEmd);
+        if (oldReadme.toFile().canRead()) {
+            newMain.toFile().mkdirs();
+            Path newReadme = newMain.resolve(READMEmd);
+            Files.copy(oldReadme, newReadme, StandardCopyOption.REPLACE_EXISTING);
+            logger.info("Copying " + oldReadme + " to " + newReadme);
+        } else {
+            logger.info("README did not exist: " + oldReadme);
+        }
+    }
+
     /**
-     * Copy the DTD file from trunk into subfolders of the given vetdata folder ("auto" or "manual")
+     * Copy all DTD files from main into subfolders of the given vetdata folder ("auto" or "manual")
      *
      * @param vetdataDir the File for the vetdata directory
      * @return true for success, or false for failure
@@ -160,10 +195,8 @@ public class OutputFileManager {
      */
     private boolean copyDtd(File vetdataDir) {
         String dtdDirName = "dtd";
-        String dtdFileName = "ldml.dtd";
         File baseDir = CLDRConfig.getInstance().getCldrBaseDirectory();
-        String dtdSourceName =
-                baseDir + "/" + DirNames.justCommon + "/" + dtdDirName + "/" + dtdFileName;
+        String dtdSourceName = baseDir + "/" + DirNames.justCommon + "/" + dtdDirName + "/";
         File dtdSource = new File(dtdSourceName);
         if (!dtdSource.exists()) {
             return false;
@@ -172,15 +205,12 @@ public class OutputFileManager {
         for (String s : vp) {
             File destDir =
                     new File(vetdataDir + "/" + s + "/" + DirNames.justCommon + "/" + dtdDirName);
-            if (!destDir.exists() && !destDir.mkdirs()) {
-                return false;
-            }
             try {
-                File dtdFile = new File(destDir + "/" + dtdFileName);
-                if (!dtdFile.exists()) {
-                    Files.copy(dtdSource.toPath(), dtdFile.toPath());
-                }
+                destDir.mkdirs(); // to make parent dirs
+                FileUtils.copyDirectory(dtdSource, destDir, true);
+                logger.info("Copied DTDs to " + destDir);
             } catch (Exception e) {
+                SurveyLog.logException(logger, e, "Copying DTDs to " + destDir.toString());
                 return false;
             }
         }
@@ -200,7 +230,9 @@ public class OutputFileManager {
                 for (OutputFileManager.Kind kind : OutputFileManager.Kind.values()) {
                     if (kind == OutputFileManager.Kind.vxml
                             || kind == OutputFileManager.Kind.pxml) {
-                        logger.log(Level.WARNING, "Writing " + loc.getDisplayName() + ":" + kind);
+                        logger.log(
+                                Level.WARNING,
+                                "Writing " + kind + "/" + loc + "\t" + loc.getDisplayName());
                         writeManualOutputFile(results.directory, loc, kind);
                     }
                 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VxmlQueue.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VxmlQueue.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.unicode.cldr.util.*;
 
 public class VxmlQueue {
@@ -245,6 +246,22 @@ public class VxmlQueue {
 
         public void addVerificationWarning(String s) {
             verificationWarnings.add(s);
+        }
+
+        /** add failure. no-op if no items. */
+        public void addVerificationFailure(String message, Collection<String> items) {
+            if (items.isEmpty()) return;
+            addVerificationFailure(composeMessage(message, items));
+        }
+
+        /** add warning. no-op if no items. */
+        public void addVerificationWarning(String message, Collection<String> items) {
+            if (items.isEmpty()) return;
+            addVerificationWarning(composeMessage(message, items));
+        }
+
+        private static final String composeMessage(final String message, Collection<String> items) {
+            return message + ": " + items.stream().sorted().collect(Collectors.joining(" "));
         }
     }
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/SpecialLocales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/SpecialLocales.txt
@@ -16,6 +16,9 @@
 # Note: Also, see CLDRFileTransformer.java which has the algorithmic locales defined
 # such as sr_Latn, etc. Those are no longer listed here.
 #
+# Programmatically, use the SpecialLocales.java class to get the list. Do NOT read this file
+# directly.
+#
 
 root       ;  readonly  ; The Root locale is maintained by the CLDR-TC and may not be modified in the SurveyTool. Please file a ticket to make changes.
 en         ;  readonly  ; The English locale is maintained by the CLDR-TC and may not be modified in the SurveyTool. Please file a ticket to make changes.


### PR DESCRIPTION
all with a view towards even more automation
- redo OFM error messages, what's an error and what's not
- update VxmlQueue api to simplify call site
- add a comment in SpecialLocales pointing developers at the java
- only handle 'scratch' locales specially.  Readonly locales, we just read/write them from STFactory.

With this update, no longer errors out, or omits .xml files that are needed in common/main (root, en, etc) so vxml update is much easier.

Let me translate this.

This means that, when generating vxml, the vxml subdirectories:

- vxml/common/main
- vxml/common/annotations
- vxml/common/dtd

… now contain _exactly_ the files they ought to in the repository (common/main, common/annotations, common/dtd) and can be dropped into place there.

CLDR-14953

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
