### PR TITLE
CLDR-19616 vxml update - including CLDR-19622 npe fix

### DIFF
--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -9886,9 +9886,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<long>
 					<standard>Hawaiiko ordua</standard>
 				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
-				</short>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
@@ -9896,11 +9893,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Hawaii-Aleutiar uharteetako ordu estandarra</standard>
 					<daylight>Hawaii-Aleutiar uharteetako udako ordua</daylight>
 				</long>
-				<short>
-					<generic draft="contributed">HAT</generic>
-					<standard draft="contributed">HAST</standard>
-					<daylight draft="contributed">HADT</daylight>
-				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
 				<long>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -4092,6 +4092,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="British">
 				<long>
+					<generic>Bretsk tíð</generic>
 					<daylight>Bretsk summartíð</daylight>
 				</long>
 			</metazone>
@@ -4294,7 +4295,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Hawaii">
 				<long>
-					<standard>Hawaii-Aleutian vanlig tíð</standard>
+					<standard>Hawaii tíð</standard>
 				</long>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
@@ -4357,6 +4358,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Irish">
 				<long>
+					<generic>Írsk tíð</generic>
 					<daylight>Írsk vanlig tíð</daylight>
 				</long>
 			</metazone>

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -2600,6 +2600,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yMMMd">d MMM y</dateFormatItem>
 						<dateFormatItem id="yMMMEd">E d MMM y</dateFormatItem>
 						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yMMMMd">d MMMM y</dateFormatItem>
+						<dateFormatItem id="yMMMMEd">E d MMMM y</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
 						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
 						<dateFormatItem id="yw" count="one">↑↑↑</dateFormatItem>
@@ -4004,15 +4006,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</fields>
 		<timeZoneNames>
 			<hourFormat draft="contributed">↑↑↑</hourFormat>
-			<gmtFormat draft="contributed">↑↑↑</gmtFormat>
+			<gmtFormat>↑↑↑</gmtFormat>
+			<gmtFormat alt="utc">↑↑↑</gmtFormat>
 			<regionFormat draft="contributed">{0}-tiid</regionFormat>
 			<regionFormat type="daylight" draft="contributed">Zomertiid {0}</regionFormat>
 			<regionFormat type="standard" draft="contributed">Standaardtiid {0}</regionFormat>
 			<fallbackFormat draft="contributed">↑↑↑</fallbackFormat>
 			<zone type="Etc/UTC">
 				<long>
-					<standard draft="unconfirmed">koördinearre wrâldtiid</standard>
+					<standard>Koördinearre Wrâldtiid</standard>
 				</long>
+				<short>
+					<standard>↑↑↑</standard>
+				</short>
 			</zone>
 			<zone type="Etc/Unknown">
 				<exemplarCity draft="contributed">Unbekende stêd</exemplarCity>
@@ -5129,6 +5135,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="British">
 				<long>
+					<generic>Britse tiid</generic>
 					<daylight draft="contributed">Britse simmertiid</daylight>
 				</long>
 			</metazone>
@@ -5346,7 +5353,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Hawaii">
 				<long>
-					<standard draft="contributed">Hawaii-Aleoetyske standerttiid</standard>
+					<standard>Hawaii tiid</standard>
 				</long>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
@@ -5409,6 +5416,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Irish">
 				<long>
+					<generic>Ierse tiid</generic>
 					<daylight draft="contributed">Ierse simmertiid</daylight>
 				</long>
 			</metazone>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -6504,9 +6504,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<long>
 					<standard>Bun-àm nan Eileanan Hawai’i ’s Aleutach</standard>
 				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
-				</short>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
@@ -6516,7 +6513,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</long>
 				<short>
 					<generic draft="contributed">HAT</generic>
-					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
 				</short>
 			</metazone>

--- a/common/main/kk_KZ.xml
+++ b/common/main/kk_KZ.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2026 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="kk"/>
+		<territory type="KZ"/>
+	</identity>
+</ldml>

--- a/common/main/ku_TR.xml
+++ b/common/main/ku_TR.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2026 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ku"/>
+		<territory type="TR"/>
+	</identity>
+</ldml>

--- a/common/main/om.xml
+++ b/common/main/om.xml
@@ -3740,9 +3740,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<long>
 					<standard>Sa’aatii Istaandardii Hawaayi</standard>
 				</long>
-				<short>
-					<standard draft="contributed">HAS</standard>
-				</short>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
@@ -3750,11 +3747,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Sa’aatii Istaandardii Hawaayi-Alushiyaa</standard>
 					<daylight>Sa’aatii Guyyaa Haawayi-Alewutiyan</daylight>
 				</long>
-				<short>
-					<generic draft="contributed">HAT</generic>
-					<standard draft="contributed">HAS</standard>
-					<daylight draft="contributed">HADT</daylight>
-				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
 				<long>

--- a/common/main/pms.xml
+++ b/common/main/pms.xml
@@ -26,7 +26,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Latn">latin</script>
 		</scripts>
 		<territories>
+			<territory type="AT">Àustria</territory>
+			<territory type="CH">Svìssera</territory>
+			<territory type="FR">Fransa</territory>
 			<territory type="IT">Italia</territory>
+			<territory type="SI">Slovenia</territory>
+			<territory type="SM">Repùblica ëd San Marin</territory>
 		</territories>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrico</measurementSystemName>
@@ -41,7 +46,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[aà b c {cc} {ch} d eéèë {eu} f g {gg} {gh} iì j l m n {n\-} oò p q r s {s\-c} {ss} t uù v z]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[h]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[h w]</exemplarCharacters>
 		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‑ — , ; \: ! ? . … '’ &quot;“” « » ( ) \[ \] \{ \} @ /]</exemplarCharacters>
 	</characters>
@@ -56,6 +61,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="gregorian">
 				<months>
 					<monthContext type="format">
+						<monthWidth type="narrow">
+							<month type="1">g</month>
+							<month type="2">f</month>
+							<month type="3">m</month>
+							<month type="4">a</month>
+							<month type="5">m</month>
+							<month type="6">g</month>
+							<month type="7">l</month>
+							<month type="8">a</month>
+							<month type="9">s</month>
+							<month type="10">u</month>
+							<month type="11">n</month>
+							<month type="12">d</month>
+						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">gené</month>
 							<month type="2">fërvé</month>
@@ -112,6 +131,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</dateTimeFormats>
 			</calendar>
 		</calendars>
+		<fields>
+			<field type="year">
+				<displayName>Ann</displayName>
+			</field>
+			<field type="month">
+				<displayName>Mèis</displayName>
+			</field>
+			<field type="day">
+				<displayName>Di</displayName>
+			</field>
+			<field type="hour">
+				<displayName>Ora</displayName>
+			</field>
+			<field type="minute">
+				<displayName>Minuta</displayName>
+			</field>
+			<field type="second">
+				<displayName>↑↑↑</displayName>
+			</field>
+		</fields>
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
@@ -121,8 +160,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<regionFormat type="standard">Ora stàndar: {0}</regionFormat>
 			<fallbackFormat>↑↑↑</fallbackFormat>
 			<zone type="Etc/UTC">
+				<long>
+					<standard>Temp Universal Coordinà</standard>
+				</long>
 				<short>
-					<standard>↑↑↑</standard>
+					<standard>TUC</standard>
 				</short>
 			</zone>
 			<metazone type="GMT">

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -8308,9 +8308,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<long>
 					<standard>Waqtiga Caadiga Ah ee Hawaay-Alutiyaan</standard>
 				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
-				</short>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
@@ -8320,7 +8317,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</long>
 				<short>
 					<generic draft="contributed">HAT</generic>
-					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
 				</short>
 			</metazone>


### PR DESCRIPTION
CLDR-19616


- includes [CLDR-19622](https://unicode-org.atlassian.net/browse/CLDR-19622) [npe fix](https://github.com/unicode-org/cldr/commit/9ee47b64a9aa2659d5405873562cf1b4318799fb)
- includes CLDR-19453 vxml fixes (restoring 

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true


[CLDR-19622]: https://unicode-org.atlassian.net/browse/CLDR-19622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ