### PR TITLE
CLDR-19628 Align az arab/arabext decimal pattern with standard currency (`#,##0`)

### DIFF
--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -5247,14 +5247,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>standart onluq kəsr0.###</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>standart onluq kəsr0.###</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>


### PR DESCRIPTION
CLDR-19628

### Description of Changes
In `common/main/az.xml`, updated `<decimalFormats numberSystem="arab">` and `<decimalFormats numberSystem="arabext">` (`type="standard"`) to replace `<pattern>standart onluq kəsr0.###</pattern>` with explicit standard 3-digit grouping `<pattern>#,##0.###</pattern>`.

### Rationale & AI Linguistic Investigation
1. **Bogus Text String in Numeric Pattern**: The existing pattern `standart onluq kəsr0.###` contains the literal Azerbaijani words "standart onluq kəsr" (meaning "standard decimal fraction"). This was an accidental legacy XML import/translation error where the placeholder description text was pasted directly into the numeric `<pattern>` element.
2. **Integer Part Symmetry (CLDR-19628)**: Because the decimal pattern contained this bogus string, its integer part evaluated to `0` (or `standart onluq kəsr0`), creating a false mismatch against `az` currency formats (`#,##0.00 ¤`).
3. **Linguistic Alignment**: In Iranian Azerbaijani (`az_IR` / `az/arab`), ordinary numbers follow standard Middle Eastern / Western 3-digit grouping (`#,##0`). Explicitly setting the pattern to `#,##0.###` ensures the decimal number structure perfectly matches the currency integer structure (`#,##0`), fulfilling CLDR-19628 with clean, self-contained pattern definitions.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15