### PR TITLE
CLDR-19628 Align gu gujr currency patterns (`#,##,##0`) with decimal grouping

### DIFF
--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -5827,9 +5827,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
-					<pattern alt="noCurrency">#,##0.00</pattern>
+					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>


### PR DESCRIPTION
CLDR-19628

### Description of Changes
In `common/main/gu.xml`, updated `<currencyFormats numberSystem="gujr">` (`type="standard"`) to replace hardcoded Western 3-digit grouping (`¤#,##0.00`) with explicit South Asian Lakh grouping patterns:
- `<pattern>¤#,##,##0.00</pattern>`
- `<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>`
- `<pattern alt="noCurrency">#,##,##0.00</pattern>`

### Rationale & AI Linguistic Investigation
1. **Decimal vs Currency Grouping Mismatch**: In `gu.xml`, `decimalFormats numberSystem="latn"` (and inherited by `"gujr"`) defines South Asian Lakh grouping (`#,##,##0.###`). However, `<currencyFormats numberSystem="gujr">` retained legacy Western 3-digit grouping (`¤#,##0.00`).
2. **Integer Part Symmetry (CLDR-19628)**: Ordinary numbers and standard currency amounts in Gujarati must share identical integer grouping structures (`#,##,##0`).
3. **Linguistic Alignment**: Gujarati natively utilizes Lakh ($10^5$) and Crore ($10^7$) grouping. Explicitly defining `"gujr"` standard currency patterns as `#,##,##0.00` aligns Gujarati across numerals with its decimal formatting structure per CLDR-19628.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15