### PR TITLE
CLDR-19628 Align mr latn/deva currency patterns (`#,##,##0`) with decimal grouping

### DIFF
--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -5853,14 +5853,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>¤#,##0.00</pattern>
+					<pattern>¤#,##,##0.00</pattern>
 					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern>¤#,##,##0.00;(¤#,##,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00;(¤ #,##,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##,##0.00;(#,##,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">


### PR DESCRIPTION
CLDR-19628

### Description of Changes
In `common/main/mr.xml`, updated `<currencyFormats numberSystem="latn">` (`standard` and `accounting`) to replace Western 3-digit grouping (`¤#,##0.00`) with explicit South Asian Lakh grouping (`¤#,##,##0.00`). Since `numberSystem="deva"` uses upward inheritance (`↑↑↑`) from `latn`, this synchronizes integer grouping symmetry across both numbering systems.

### Rationale & AI Linguistic Investigation
1. **Decimal vs Currency Grouping Mismatch**: In `mr.xml`, `decimalFormats numberSystem="latn"` (and inherited by `"deva"`) defines South Asian Lakh grouping (`#,##,##0.###`). However, `<currencyFormats numberSystem="latn">` retained legacy Western 3-digit grouping (`¤#,##0.00`).
2. **Integer Part Symmetry (CLDR-19628)**: Ordinary numbers and standard currency amounts in Marathi must share identical integer grouping structures (`#,##,##0`).
3. **Linguistic Alignment**: Marathi (`mr`) natively employs Lakh ($10^5$) and Crore ($10^7$) grouping across both Devanagari and Latin numerals. Explicitly updating `latn` currency formats to `¤#,##,##0.00` ensures Marathi currency expressions follow native grouping and align perfectly with `decimalFormats` per CLDR-19628.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15