### PR TITLE
CLDR-19628 Align ta tamldec currency patterns (`#,##,##0`) with decimal grouping

### DIFF
--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -5994,9 +5994,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
-					<pattern alt="noCurrency">#,##0.00</pattern>
+					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>


### PR DESCRIPTION
CLDR-19628

### Description of Changes
In `common/main/ta.xml`, updated `<currencyFormats numberSystem="tamldec">` (`type="standard"`) to replace hardcoded Western 3-digit grouping (`¤#,##0.00`) with explicit South Asian Lakh grouping patterns:
- `<pattern>¤#,##,##0.00</pattern>`
- `<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>`
- `<pattern alt="noCurrency">#,##,##0.00</pattern>`

### Rationale & AI Linguistic Investigation
1. **Decimal vs Currency Grouping Mismatch**: In `ta.xml`, `decimalFormats numberSystem="latn"` (and inherited by `"tamldec"`) defines South Asian Lakh grouping (`#,##,##0.###`). However, `<currencyFormats numberSystem="tamldec">` retained legacy Western 3-digit grouping (`¤#,##0.00`).
2. **Integer Part Symmetry (CLDR-19628)**: Ordinary numbers and standard currency amounts in Tamil must share identical integer grouping structures (`#,##,##0`).
3. **Linguistic Alignment**: Tamil (`ta`) natively utilizes Lakh ($10^5$) and Crore ($10^7$) grouping across both Tamil decimal numerals (`tamldec`) and Latin numerals (`latn`). Explicitly setting `"tamldec"` currency patterns to `#,##,##0.00` ensures it matches native grouping, aligning perfectly with `decimalFormats` and fulfilling CLDR-19628 without relying on upward inheritance shortcuts in standard templates.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15