### PR TITLE
CLDR-19628 Align te telu decimal pattern (`#,##,##0`) with standard currency

### DIFF
--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -5809,7 +5809,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>#,##0.###</pattern>
+					<pattern>#,##,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>


### PR DESCRIPTION
CLDR-19628

### Description of Changes
In `common/main/te.xml`, updated `<decimalFormats numberSystem="telu">` (`type="standard"`) to replace hardcoded Western 3-digit grouping (`#,##0.###`) with explicit South Asian Lakh grouping (`#,##,##0.###`).

### Rationale & AI Linguistic Investigation
1. **Decimal vs Currency Grouping Mismatch**: In `te.xml`, `<currencyFormats numberSystem="telu">` uses upward inheritance (`↑↑↑`), correctly inheriting South Asian Lakh grouping (`¤#,##,##0.00`) from `latn`. However, `<decimalFormats numberSystem="telu">` retained legacy Western 3-digit grouping (`#,##0.###`).
2. **Integer Part Symmetry (CLDR-19628)**: Ordinary numbers and standard currency amounts in Telugu must share identical integer grouping structures (`#,##,##0`).
3. **Linguistic Alignment**: Telugu (`te`) natively employs Lakh ($10^5$) and Crore ($10^7$) grouping across both Telugu numerals (`telu`) and Latin numerals (`latn`). Explicitly setting `decimalFormats` for `"telu"` to `#,##,##0.###` aligns perfectly with `currencyFormats` per CLDR-19628 without relying on upward inheritance shortcuts in standard templates.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15