### PR TITLE
CLDR-19629 Align brx deva/latn accounting currency patterns (`#,##,##0`) with standard currency

### DIFF
--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -4979,7 +4979,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00;(¤ #,##,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4991,9 +4991,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern>¤#,##,##0.00;(¤#,##,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00;(¤ #,##,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##,##0.00;(#,##,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">


### PR DESCRIPTION
CLDR-19629

### Description of Changes
In `common/main/brx.xml`, updated `<currencyFormats numberSystem="latn">` and `<currencyFormats numberSystem="deva">` (`type="accounting"`) to replace Western 3-digit accounting grouping (`¤#,##0.00;(¤#,##0.00)`) with explicit South Asian Lakh grouping (`¤#,##,##0.00;(¤#,##,##0.00)`).

### Rationale & AI Linguistic Investigation
1. **Standard vs Accounting Currency Grouping Mismatch**: In `brx.xml`, standard currency across `latn` and `deva` defines South Asian Lakh grouping (`#,##,##0.00`). However, accounting currency retained unadjusted Western 3-digit grouping (`#,##0.00`).
2. **Number Part Uniformity (CLDR-19629)**: Standard currency and accounting currency formatting for Bodo (`brx`) must share identical integer grouping structures (`#,##,##0`).
3. **Linguistic Alignment**: Bodo natively employs Lakh ($10^5$) and Crore ($10^7$) grouping. Explicitly setting accounting currency patterns to `#,##,##0.00` harmonizes `brx.xml` across all currency variations per CLDR-19629.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15