### PR TITLE
CLDR-19629 Align sa deva/latn accounting currency patterns (`#,##,##0`) with standard currency

### DIFF
--- a/common/main/sa.xml
+++ b/common/main/sa.xml
@@ -965,8 +965,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
-					<pattern alt="noCurrency">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -978,9 +978,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>¤ #,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
-					<pattern alt="noCurrency">#,##0.00</pattern>
+					<pattern>¤ #,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">↑↑↑</unitPattern>


### PR DESCRIPTION
CLDR-19629

### Description of Changes
In `common/main/sa.xml`, updated `<currencyFormats numberSystem="deva">` and `<currencyFormats numberSystem="latn">` (`type="accounting"`) to replace Western 3-digit accounting grouping (`#,##0.00`) with explicit South Asian Lakh grouping (`#,##,##0.00`).

### Rationale & AI Linguistic Investigation
1. **Standard vs Accounting Currency Grouping Mismatch**: In `sa.xml`, standard currency defines South Asian Lakh grouping (`#,##,##0.00`). However, accounting currency retained unadjusted Western 3-digit grouping (`#,##0.00`).
2. **Number Part Uniformity (CLDR-19629)**: Standard currency and accounting currency formatting for Sanskrit (`sa`) must share identical integer grouping structures (`#,##,##0`).
3. **Linguistic Alignment**: Sanskrit natively employs Lakh ($10^5$) and Crore ($10^7$) grouping across numerals. Explicitly setting accounting currency patterns to `#,##,##0.00` harmonizes `sa.xml` across all currency variations per CLDR-19629.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15