### PR TITLE
CLDR-19629 Align te latn accounting currency patterns (`#,##,##0`) with standard currency

### DIFF
--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -5861,9 +5861,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern>¤#,##,##0.00;(¤#,##,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00;(¤ #,##,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##,##0.00;(#,##,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">


### PR DESCRIPTION
CLDR-19629

### Description of Changes
In `common/main/te.xml`, updated `<currencyFormats numberSystem="latn">` (`type="accounting"`) to replace Western 3-digit accounting grouping (`¤#,##0.00;(¤#,##0.00)`) with explicit South Asian Lakh grouping (`¤#,##,##0.00;(¤#,##,##0.00)`).

### Rationale & AI Linguistic Investigation
1. **Standard vs Accounting Currency Grouping Mismatch**: In `te.xml`, standard currency defines South Asian Lakh grouping (`#,##,##0.00`). However, accounting currency retained unadjusted Western 3-digit grouping (`#,##0.00`).
2. **Number Part Uniformity (CLDR-19629)**: Standard currency and accounting currency formatting for Telugu (`te`) must share identical integer grouping structures (`#,##,##0`).
3. **Linguistic Alignment**: Telugu natively employs Lakh ($10^5$) and Crore ($10^7$) grouping across numerals. Explicitly setting accounting currency patterns to `#,##,##0.00` harmonizes `te.xml` across all currency variations per CLDR-19629.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15