### PR TITLE
CLDR-19632 Fix missing currency token (`¤`) in de_CH short compact `alphaNextToNumber` patterns (`100K`)

### DIFF
--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -5062,9 +5062,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000" count="other">↑↑↑</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">0</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 0</pattern>
 					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">0</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 0</pattern>
 					<pattern type="1000000" count="one">¤ 0 Mio'.'</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber" draft="contributed">¤ 0 Mio'.'</pattern>
 					<pattern type="1000000" count="other">¤ 0 Mio'.'</pattern>


### PR DESCRIPTION
CLDR-19632

### Description of Changes
In `common/main/de_CH.xml`, updated `<currencyFormatLength type="short">` (`alt="alphaNextToNumber"`) for `type="100000"` (`count="one"` and `"other"`) to replace pure placeholder `0` with explicit currency token `¤ 0`.

### Rationale & AI Linguistic Investigation
1. **Missing Currency Symbol / Pure Placeholder Bug**: In `de_CH.xml`, standard `alphaNextToNumber` defines `¤ #,##0.00`. However, short compact `alphaNextToNumber` for magnitude `100000` (`100 thousand`) was entered as literally `0` without the currency symbol (`¤`).
2. **Fatal Loss of Currency Information (CLDR-19632)**: Omitting `¤` in `currencyFormatLength` causes the currency code/symbol (`CHF`, `EUR`) to vanish entirely when formatting 100K (`100` instead of `CHF 100`).
3. **TR35 Structural Integrity**: Correcting these patterns to include `¤ 0` (`\u00A0` non-breaking space after `¤`) restores full currency information when formatting with alphabetic ISO codes per CLDR-19632.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15