### PR TITLE
CLDR-19632 Fix dropped non-breaking space (`\u00A0`) in kok short compact `alphaNextToNumber` patterns

### DIFF
--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -4979,80 +4979,80 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="ahom">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="bhks">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="chis">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5070,168 +5070,168 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="diak">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gara">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gukh">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="hmng">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="hmnp">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="kawi">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="krai">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5307,368 +5307,368 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathbold">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathdbl">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathmono">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathsanb">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mathsans">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="modi">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mroo">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrepka">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrpao">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrtlng">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="nagm">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="newa">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="onao">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="outlined">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="segment">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="sind">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="sinh">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="sunu">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="tirh">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="tnsa">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="tols">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="wara">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="wcho">
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤000LCr</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000LCr</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000LCr</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000LCr</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>


### PR DESCRIPTION
CLDR-19632

### Description of Changes
In `common/main/kok.xml`, updated `<currencyFormatLength type="short">` (`alt="alphaNextToNumber"`) across all numbering systems (`adlm`, `ahom`, `deva`, `latn`, etc.) to replace unspaced currency token `¤000LCr` with explicit non-breaking spacing `¤ 000LCr` (`\u00A0`).

### Rationale & AI Linguistic Investigation
1. **Dropped Spacing Bug**: In `kok.xml`, standard `alphaNextToNumber` across numbering systems includes a non-breaking space after `¤` (`¤ #,##,##0.00`). However, when explicit short compact `alphaNextToNumber` patterns (`¤000LCr`) were entered across ~77 numbering systems, the non-breaking space was dropped.
2. **ISO Code Collisions (CLDR-19632)**: Omitting `\u00A0` in compact patterns (`¤000LCr`) causes unreadable collisions (`USD100LCr`) when formatting amounts with alphabetic ISO codes.
3. **TR35 Section 3.4 Alignment**: Correcting explicit compact patterns across `kok.xml` to inherit standard spacing (`¤ 000LCr`) resolves all 154 spacing mismatches in Konkani per CLDR-19632.

TAG=agy
CONV=d40cada6-48bf-4ae3-be3b-7a53f8978a15