### PR TITLE
CLDR-19641 Add JSON representation of XPath coverage levels to cldr-json

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -2,6 +2,8 @@ package org.unicode.cldr.json;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -42,6 +44,7 @@ import java.util.stream.Collectors;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.draft.ScriptMetadata;
 import org.unicode.cldr.draft.ScriptMetadata.Info;
+import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.util.Annotations;
 import org.unicode.cldr.util.CLDRConfig;
@@ -1726,6 +1729,105 @@ public class Ldml2JsonConverter {
             // resolved, including all available locales
             obj.add("effectiveCoverageLevels", gson.toJsonTree(effectiveCovlocs));
             outf.println(gson.toJson(obj));
+        }
+    }
+
+    public void writeCoverageLevelsByXPath(String outputDir) throws IOException {
+        SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
+        Factory factory = CLDRConfig.getInstance().getMainAndAnnotationsFactory();
+
+        CoverageLevel2 covRoot = sdi.getCoverageLevelInfo("root");
+        CLDRFile rootFile = factory.make("root", true);
+
+        Multimap<String, String> defaultCoverageToXpaths = TreeMultimap.create();
+        for (String x : rootFile.fullIterable()) {
+            Level l = covRoot.getLevel(x);
+            if (l == null || l == Level.UNDETERMINED) {
+                throw new IllegalStateException(
+                        "Unexpected coverage level " + l + " for XPath: " + x);
+            }
+            // Skip COMPREHENSIVE level as it represents the catch-all max coverage tier.
+            if (l == Level.COMPREHENSIVE) {
+                continue;
+            }
+            defaultCoverageToXpaths.put(l.name().toLowerCase(), x);
+        }
+
+        JsonObject rootCoverageObj = new JsonObject();
+        JsonObject rootInnerObj = new JsonObject();
+        JsonObject rootLevelMap = new JsonObject();
+        rootCoverageObj.add("coverageByXPath", rootInnerObj);
+        rootInnerObj.add("root", rootLevelMap);
+        for (String levelName : defaultCoverageToXpaths.keySet()) {
+            rootLevelMap.add(levelName, gson.toJsonTree(defaultCoverageToXpaths.get(levelName)));
+        }
+
+        File miscDir = new File(outputDir + "/cldr-misc-full");
+        miscDir.mkdirs();
+
+        try (PrintWriter outf =
+                FileUtilities.openUTF8Writer(miscDir.getAbsolutePath(), "coverageByXPath.json")) {
+            System.out.println(
+                    PACKAGE_ICON
+                            + " Creating packaging file => "
+                            + miscDir.getAbsolutePath()
+                            + File.separator
+                            + "coverageByXPath.json using CoverageLevel2 API");
+            outf.println(gson.toJson(rootCoverageObj));
+        }
+
+        File coverageByXPathDir = new File(miscDir, "coverageByXPath");
+        coverageByXPathDir.mkdirs();
+
+        for (String loc : avl.full) {
+            String uloc = ULocale.forLanguageTag(loc).toString();
+            String bcp47loc = unicodeLocaleToString(uloc);
+            CoverageLevel2 cov = sdi.getCoverageLevelInfo(uloc);
+            CLDRFile file = factory.make(uloc, true);
+
+            Multimap<String, String> overrideXpaths = TreeMultimap.create();
+            for (String x : file.fullIterable()) {
+                Level lLoc = cov.getLevel(x);
+                Level lRoot = covRoot.getLevel(x);
+                if (lLoc == null
+                        || lLoc == Level.UNDETERMINED
+                        || lRoot == null
+                        || lRoot == Level.UNDETERMINED) {
+                    throw new IllegalStateException("Unexpected coverage level for XPath: " + x);
+                }
+                // Skip COMPREHENSIVE level and paths that match the baseline default.
+                if (lLoc == Level.COMPREHENSIVE || lLoc == lRoot) {
+                    continue;
+                }
+                overrideXpaths.put(lLoc.name().toLowerCase(), x);
+            }
+
+            JsonObject locObj = new JsonObject();
+            JsonObject locInnerObj = new JsonObject();
+            locObj.add("coverageByXPath", locInnerObj);
+
+            JsonObject locLevelMap = new JsonObject();
+            for (String levelName : overrideXpaths.keySet()) {
+                locLevelMap.add(levelName, gson.toJsonTree(overrideXpaths.get(levelName)));
+            }
+            locInnerObj.add(bcp47loc, locLevelMap);
+
+            try (PrintWriter outf =
+                    FileUtilities.openUTF8Writer(
+                            coverageByXPathDir.getAbsolutePath(), bcp47loc + ".json")) {
+                outf.println(gson.toJson(locObj));
+            }
+        }
+
+        // Emit und.json with empty overrides map for undetermined locale
+        JsonObject undObj = new JsonObject();
+        JsonObject undInnerObj = new JsonObject();
+        undObj.add("coverageByXPath", undInnerObj);
+        undInnerObj.add("und", new JsonObject());
+
+        try (PrintWriter outf =
+                FileUtilities.openUTF8Writer(coverageByXPathDir.getAbsolutePath(), "und.json")) {
+            outf.println(gson.toJson(undObj));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -1737,17 +1737,25 @@ public class Ldml2JsonConverter {
         SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
         Factory factory = CLDRConfig.getInstance().getMainAndAnnotationsFactory();
 
-        CoverageLevel2 covRoot = sdi.getCoverageLevelInfo("root");
-        // Harvest standard LDML XPaths from main locale data using the "en" CLDRFile because
-        // "en.xml" contains the full inventory of main data paths (such as unit types and display
-        // names)
-        // that are absent from minimal fallback "root.xml". Each harvested XPath is evaluated
-        // against
-        // covRoot.getLevel(x) to compute the default baseline coverage level for "root".
-        CLDRFile enFile = factory.make("en", true);
+        // Get a union of all XPaths in all locales of CLDR in main and annotations.
+        // Then, use root to determine the baseline coverage level for each XPath.
+        // We can't pull XPaths from only root.xml since that file contains only a
+        // subset of all data.
+        Set<String> allXpaths = new TreeSet<>();
+        for (String loc : avl.full) {
+            try {
+                CLDRFile f = factory.make(loc, true);
+                for (String x : f.fullIterable()) {
+                    allXpaths.add(x);
+                }
+            } catch (NoSourceDirectoryException e) {
+                // Skip legacy metadata locale aliases that lack XML source files.
+            }
+        }
 
         Multimap<String, String> defaultCoverageToXpaths = TreeMultimap.create();
-        for (String x : enFile.fullIterable()) {
+        CoverageLevel2 covRoot = sdi.getCoverageLevelInfo("root");
+        for (String x : allXpaths) {
             Level l = covRoot.getLevel(x);
             if (l == null || l == Level.UNDETERMINED) {
                 throw new IllegalStateException(
@@ -2631,6 +2639,7 @@ public class Ldml2JsonConverter {
                 writeDefaultContent(outputDir);
                 writeAvailableLocales(outputDir);
                 writeCoverageLevels(outputDir);
+                writeCoverageLevelsByXPath(outputDir);
             } else if (type == RunType.supplemental) {
                 writeScriptMetadata(outputDir);
                 if (Boolean.parseBoolean(options.get("packagelist").getValue())) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -1735,9 +1735,9 @@ public class Ldml2JsonConverter {
 
     public void writeCoverageLevelsByXPath(String outputDir) throws IOException {
         SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
-        Factory factory = CLDRConfig.getInstance().getMainAndAnnotationsFactory();
+        Factory factory = CLDRConfig.getInstance().getCldrFactory();
 
-        // Get a union of all XPaths in all locales of CLDR in main and annotations.
+        // Get a union of all XPaths in all locales of CLDR in main.
         // Then, use root to determine the baseline coverage level for each XPath.
         // We can't pull XPaths from only root.xml since that file contains only a
         // subset of all data.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -1738,10 +1738,16 @@ public class Ldml2JsonConverter {
         Factory factory = CLDRConfig.getInstance().getMainAndAnnotationsFactory();
 
         CoverageLevel2 covRoot = sdi.getCoverageLevelInfo("root");
-        CLDRFile rootFile = factory.make("root", true);
+        // Harvest all standard LDML XPaths using the "en" CLDRFile because "en.xml" contains the
+        // complete inventory of CLDR data paths (such as subdivisions, unit types, and display
+        // names)
+        // that are absent from minimal fallback "root.xml". Each harvested XPath is evaluated
+        // against
+        // covRoot.getLevel(x) to compute the true default baseline coverage level for "root".
+        CLDRFile enFile = factory.make("en", true);
 
         Multimap<String, String> defaultCoverageToXpaths = TreeMultimap.create();
-        for (String x : rootFile.fullIterable()) {
+        for (String x : enFile.fullIterable()) {
             Level l = covRoot.getLevel(x);
             if (l == null || l == Level.UNDETERMINED) {
                 throw new IllegalStateException(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -1738,12 +1738,12 @@ public class Ldml2JsonConverter {
         Factory factory = CLDRConfig.getInstance().getMainAndAnnotationsFactory();
 
         CoverageLevel2 covRoot = sdi.getCoverageLevelInfo("root");
-        // Harvest all standard LDML XPaths using the "en" CLDRFile because "en.xml" contains the
-        // complete inventory of CLDR data paths (such as subdivisions, unit types, and display
+        // Harvest standard LDML XPaths from main locale data using the "en" CLDRFile because
+        // "en.xml" contains the full inventory of main data paths (such as unit types and display
         // names)
         // that are absent from minimal fallback "root.xml". Each harvested XPath is evaluated
         // against
-        // covRoot.getLevel(x) to compute the true default baseline coverage level for "root".
+        // covRoot.getLevel(x) to compute the default baseline coverage level for "root".
         CLDRFile enFile = factory.make("en", true);
 
         Multimap<String, String> defaultCoverageToXpaths = TreeMultimap.create();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -67,6 +67,7 @@ import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.SimpleFactory.NoSourceDirectoryException;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.RBNFGroup;
@@ -1779,11 +1780,26 @@ public class Ldml2JsonConverter {
         File coverageByXPathDir = new File(miscDir, "coverageByXPath");
         coverageByXPathDir.mkdirs();
 
+        if (avl.full.isEmpty()) {
+            throw new IllegalStateException(
+                    "avl.full is empty; writeCoverageLevelsByXPath must be called after locales are populated.");
+        }
+
         for (String loc : avl.full) {
+            if ("root".equals(loc)) {
+                continue;
+            }
             String uloc = ULocale.forLanguageTag(loc).toString();
             String bcp47loc = unicodeLocaleToString(uloc);
             CoverageLevel2 cov = sdi.getCoverageLevelInfo(uloc);
-            CLDRFile file = factory.make(uloc, true);
+            CLDRFile file = null;
+            try {
+                file = factory.make(uloc, true);
+            } catch (NoSourceDirectoryException e) {
+                // Skip legacy metadata locale aliases (e.g. be_TARASK, el_POLYTON) that lack XML
+                // source files.
+                continue;
+            }
 
             Multimap<String, String> overrideXpaths = TreeMultimap.create();
             for (String x : file.fullIterable()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -95,6 +95,10 @@ public class Ldml2JsonConverter {
     private static final String CLDR_PKG_PREFIX = "cldr-";
     private static final String FULL_TIER_SUFFIX = "-full";
     private static final String MODERN_TIER_SUFFIX = "-modern";
+    // Note: Package names are normally loaded dynamically from JSON_config.txt at runtime.
+    // "misc" is defined as a constant here because writeCoverageLevelsByXPath needs to target it
+    // directly.
+    private static final String MISC_PKG_NAME = "misc";
     private static final String EXTERNAL_RAW_SUFFIX = ".txt";
     private static Logger logger = Logger.getLogger(Ldml2JsonConverter.class.getName());
 
@@ -1777,8 +1781,9 @@ public class Ldml2JsonConverter {
             rootLevelMap.add(levelName, gson.toJsonTree(defaultCoverageToXpaths.get(levelName)));
         }
 
-        File miscDir = new File(outputDir + "/cldr-misc-full");
+        File miscDir = new File(outputDir, CLDR_PKG_PREFIX + MISC_PKG_NAME + FULL_TIER_SUFFIX);
         miscDir.mkdirs();
+        File mainDir = new File(miscDir, CLDRPaths.MAIN_SUBDIR);
 
         try (PrintWriter outf =
                 FileUtilities.openUTF8Writer(miscDir.getAbsolutePath(), "coverageByXPath.json")) {
@@ -1790,9 +1795,6 @@ public class Ldml2JsonConverter {
                             + "coverageByXPath.json using CoverageLevel2 API");
             outf.println(gson.toJson(rootCoverageObj));
         }
-
-        File coverageByXPathDir = new File(miscDir, "coverageByXPath");
-        coverageByXPathDir.mkdirs();
 
         if (avl.full.isEmpty()) {
             throw new IllegalStateException(
@@ -1810,6 +1812,9 @@ public class Ldml2JsonConverter {
             try {
                 file = factory.make(uloc, true);
             } catch (NoSourceDirectoryException e) {
+                // TODO: Investigate "Skip legacy metadata locale aliases that lack XML source files"
+                // by either improving the comment (giving examples of locales that hit it) or by
+                // removing the special case.
                 // Skip legacy metadata locale aliases (e.g. be_TARASK, el_POLYTON) that lack XML
                 // source files.
                 continue;
@@ -1832,31 +1837,47 @@ public class Ldml2JsonConverter {
                 overrideXpaths.put(lLoc.name().toLowerCase(), x);
             }
 
-            JsonObject locObj = new JsonObject();
-            JsonObject locInnerObj = new JsonObject();
-            locObj.add("coverageByXPath", locInnerObj);
-
             JsonObject locLevelMap = new JsonObject();
             for (String levelName : overrideXpaths.keySet()) {
                 locLevelMap.add(levelName, gson.toJsonTree(overrideXpaths.get(levelName)));
             }
-            locInnerObj.add(bcp47loc, locLevelMap);
+
+            JsonObject bcp47locObj = new JsonObject();
+            bcp47locObj.add("coverageByXPath", locLevelMap);
+
+            JsonObject mainObj = new JsonObject();
+            mainObj.add(bcp47loc, bcp47locObj);
+
+            JsonObject locObj = new JsonObject();
+            locObj.add("main", mainObj);
+
+            File mainLocDir = new File(mainDir, bcp47loc);
+            mainLocDir.mkdirs();
 
             try (PrintWriter outf =
                     FileUtilities.openUTF8Writer(
-                            coverageByXPathDir.getAbsolutePath(), bcp47loc + ".json")) {
+                            mainLocDir.getAbsolutePath(), "coverageByXPath.json")) {
                 outf.println(gson.toJson(locObj));
             }
         }
 
-        // Emit und.json with empty overrides map for undetermined locale
+        // TODO: Try to make writing the und locale not be a special case.
+        // Emit coverageByXPath.json with empty overrides map for undetermined locale
+        JsonObject undBcp47locObj = new JsonObject();
+        undBcp47locObj.add("coverageByXPath", new JsonObject());
+
+        JsonObject undMainObj = new JsonObject();
+        undMainObj.add("und", undBcp47locObj);
+
         JsonObject undObj = new JsonObject();
-        JsonObject undInnerObj = new JsonObject();
-        undObj.add("coverageByXPath", undInnerObj);
-        undInnerObj.add("und", new JsonObject());
+        undObj.add("main", undMainObj);
+
+        File undMainLocDir = new File(mainDir, "und");
+        undMainLocDir.mkdirs();
 
         try (PrintWriter outf =
-                FileUtilities.openUTF8Writer(coverageByXPathDir.getAbsolutePath(), "und.json")) {
+                FileUtilities.openUTF8Writer(
+                        undMainLocDir.getAbsolutePath(), "coverageByXPath.json")) {
             outf.println(gson.toJson(undObj));
         }
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -32,6 +32,7 @@ class LdmlConvertRules {
                     "languages:language:menu",
                     "monthWidth:month:yeartype",
                     "characters:parseLenients:scope",
+                    "characters:placeholderBoundarySpacing:type",
                     "dateFormat:pattern:numbers",
                     "characterLabelPatterns:characterLabelPattern:count", // originally under
                     // characterLabels

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -32,7 +32,6 @@ class LdmlConvertRules {
                     "languages:language:menu",
                     "monthWidth:month:yeartype",
                     "characters:parseLenients:scope",
-                    "characters:placeholderBoundarySpacing:type",
                     "dateFormat:pattern:numbers",
                     "characterLabelPatterns:characterLabelPattern:count", // originally under
                     // characterLabels


### PR DESCRIPTION
CLDR-19641

This PR adds a JSON representation of API-computed path-specific coverage levels to `cldr-json` tool output as `coverageByXPath.json` in `cldr-misc-full`.

As explained in the issue, this allows ICU4X and other consumers to inspect path-specific coverage requirements by region/locale for improved data slicing.

Here is `coverageByXPath.json` sample output generated from this PR: https://gist.github.com/sffc-bot/e1e2415c9ce1a35084cea1c0aed2d937

### Implementation

Instead of raw XML translation, this implementation uses the CLDR Java `CoverageLevel2` / `SupplementalDataInfo` APIs (`cov.getLevel(xpath)`) across locales to compute and serialize effective coverage levels (`core`, `basic`, `moderate`, `modern`) into `cldr-misc-full`.

Output layout:
- **Root Coverage Baseline**: `cldr-misc-full/coverageByXPath.json` (`{ "coverageByXPath": { "root": { ... } } }`)
- **Locale-Specific Overrides**: `cldr-misc-full/coverageByXPath/<bcp47loc>.json` (e.g., `it-CH.json`, `und.json` containing `{ "coverageByXPath": { "<bcp47loc>": { ... } } }`)

🤖 Antigravity helped generate this change.