### PR TITLE
CLDR-19643 Upgrade ko/KR and fa/SA short region names to basic coverage level

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -284,6 +284,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/territories/territory[@type='${Target-Territories}']"/>
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/territories/territory[@type='${Target-Territories}'][@alt='(%anyAttribute)']"/>
+		<coverageLevel	value="basic"	inLanguage="ko"	match="localeDisplayNames/territories/territory[@type='KR'][@alt='short']"/>
+		<coverageLevel	value="basic"	inLanguage="fa"	match="localeDisplayNames/territories/territory[@type='SA'][@alt='short']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/territories/territory[@type='%territory30']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/territories/territory[@type='%territory30'][@alt='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/territories/territory[@type='%territory40']"/>


### PR DESCRIPTION
Issue: https://unicode-org.atlassian.net/browse/CLDR-19643

### Current `CoverageLevel2` Resolution:
- `ko/KR` (`alt="short"` $\rightarrow$ "한국"): Returns **`basic`** (already matched via `${Target-Territories}` with `alt` wildcard at line 286).
- `fa/SA` (`alt="short"` $\rightarrow$ "عربستان"): Returns **`moderate`** (matched via `%territory60` wildcard at line 1071).

### Summary of Changes
Explicitly assigns `basic` coverage level in `common/supplemental/coverageLevels.xml` to:
- `territory[@type="SA"][@alt="short"]` in `fa` locale ("عربستان") — promoting it from `moderate` to `basic`.
- `territory[@type="KR"][@alt="short"]` in `ko` locale ("한국") — adding explicit coverage assignment for consistency.

🤖 This pull request was created by an AI agent working with @sffc.