### PR TITLE
CLDR-19626 move 5 items out of basic to moderate

### DIFF
--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -1488,9 +1488,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yMMMEd">y MMM d, E</dateFormatItem>
 						<dateFormatItem id="yMMMEddd">y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="yMMMM">y MMMM</dateFormatItem>
-						<dateFormatItem id="yMMMMd">y MMMM d</dateFormatItem>
 						<dateFormatItem id="yMMMMddd">y MMMM ddd</dateFormatItem>
-						<dateFormatItem id="yMMMMEd">y MMMM d, E</dateFormatItem>
 						<dateFormatItem id="yMMMMEddd">y MMMM ddd, E</dateFormatItem>
 						<dateFormatItem id="yQQQ">y QQQ</dateFormatItem>
 						<dateFormatItem id="yQQQQ">y QQQQ</dateFormatItem>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -226,8 +226,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<!-- Additional variables for the restructuring -->
 
-		<coverageVariable key="%basicDateSkeletons" value="(yMMMMEd|yMMMMd|yMMMd|yMd|Hmsv|hmsv|Hms|hms|Hm|hm)"/>
-
+		<coverageVariable key="%basicDateSkeletons" value="(yMMMd|yMd|Hmsv|hmsv|Hms|hms|Hm|hm)"/>
+		<coverageVariable key="%moderateDateSkeletons" value="(yMMMMEd|yMMMMd)" />
 		<!-- -->
 		<!-- Coverage levels begin here -->
 		<!-- -->
@@ -434,6 +434,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type='%A']"/>
 
 		<coverageLevel	value="basic"	 	    match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%basicDateSkeletons']"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%moderateDateSkeletons']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>
 
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/eras/eraAbbr/era[@type='(0|1)']"/>
@@ -457,11 +458,11 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/regionFormat[@type='%regionFormatTypes']"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/fallbackFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtFormat"/>
-		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtFormat[@alt='utc']"/>
+		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/gmtFormat[@alt='utc']"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/hourFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/metazone[@type='GMT']/long/standard"/>
-		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/long/standard"/>
-		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/short/standard"/>
+		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/long/standard"/>
+		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/short/standard"/>
 
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/gmtUnknownFormat"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/gmtUnknownFormat[@alt='utc']"/>
@@ -1564,7 +1565,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/displayName"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/gender"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsJapanese']/perUnitPattern"/>
-		
+
 		<!-- Other Units, all locales -->
 
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -76,7 +76,9 @@ public class ExtraPaths {
                             "//ldml/localeDisplayNames/languages/language[@type=\"ku\"][@menu=\"core\"]",
                             "//ldml/localeDisplayNames/languages/language[@type=\"ku\"][@menu=\"extension\"]",
                             "//ldml/localeDisplayNames/typeValues/typeValue[@type=\"yes\"]",
-                            "//ldml/localeDisplayNames/typeValues/typeValue[@type=\"no\"]"));
+                            "//ldml/localeDisplayNames/typeValues/typeValue[@type=\"no\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"yMMMMd\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"yMMMMEd\"]"));
 
     public static void addConstant(Collection<String> toAddTo) {
         toAddTo.addAll(SingletonHelper.INSTANCE.paths);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -835,6 +835,16 @@ public class TestPaths extends TestFmwkPlus {
         }
     }
 
+    private final boolean isLogKnownIssueCldr19647(final String id, final String related) {
+        if (!id.equals("yMMMEd") && !id.equals("yMMMd")) {
+            return false; // not an input id of interest.
+        }
+        if (!related.equals(id.replaceFirst("MMM", "MMMM"))) {
+            return false; // not a related id of interest
+        }
+        return logKnownIssue("CLDR-19647", String.format("condition %s => %s", id, related));
+    }
+
     private void checkCondition(
             Set<String> calendarIds,
             String id,
@@ -842,6 +852,9 @@ public class TestPaths extends TestFmwkPlus {
             Function<String, String> alter) {
         if (test.test(id)) {
             String related = alter.apply(id);
+            if (isLogKnownIssueCldr19647(id, related)) {
+                return; // skip
+            }
             assertTrue(id + " => " + related, calendarIds.contains(related));
         }
     }


### PR DESCRIPTION
CLDR-19626

- move 5 items from basic to moderate
- remove two MMMM patterns from root (per Design WG) - partial revert of b9e2136245bcffd0a16f56f8af64384546dfadb8

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
