### PR TITLE
CLDR-19622 re-fix NPE in BallotBox

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
@@ -81,7 +81,7 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
             // change, just as if the user had never voted.
             if (value == CldrUtility.INHERITANCE_MARKER && status == Status.missing) {
                 value = null;
-            } else if (value.equals(VoteResolver.NO_WINNING_VALUE)) {
+            } else if (value != null && value.equals(VoteResolver.NO_WINNING_VALUE)) {
                 // this is a non-value, there was an abstension. remove the path.
                 value = null;
             }


### PR DESCRIPTION
- partial revert of a63bdbbd17593f6a6496d3387e8d0aec6e8014fa #5880
- re-implementation of c8264332b43d317b98a3d05aaf86e5c18e37610e #5874 (In fact, it's exactly this commit!)

Not sure what happened here, but a regression leaked into #5880 - probably grabbed the wrong file.

This is needed for vxml gen.

CLDR-19622

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
