### PR TITLE
CLDR-19513 Add 'tg' locales to OTHER_ONLY_HACK set

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -4088,7 +4088,7 @@ public class SupplementalDataInfo {
             public static final List<Count> VALUES =
                     Collections.unmodifiableList(Arrays.asList(values()));
             public static final Set<Count> OTHER_ONLY = Set.of(Count.other);
-            public static final Set<String> LOCALES_USING_OTHER_ONLY_HACK = Set.of("vi", "vi_VN");
+            public static final Set<String> LOCALES_USING_OTHER_ONLY_HACK = Set.of("vi", "vi_VN","tg","tg_TJ");
         }
 
         static final Pattern pluralPaths = PatternCache.get(".*pluralRule.*");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -4088,7 +4088,8 @@ public class SupplementalDataInfo {
             public static final List<Count> VALUES =
                     Collections.unmodifiableList(Arrays.asList(values()));
             public static final Set<Count> OTHER_ONLY = Set.of(Count.other);
-            public static final Set<String> LOCALES_USING_OTHER_ONLY_HACK = Set.of("vi", "vi_VN", "tg", "tg_TJ");
+            public static final Set<String> LOCALES_USING_OTHER_ONLY_HACK =
+                    Set.of("vi", "vi_VN", "tg", "tg_TJ");
         }
 
         static final Pattern pluralPaths = PatternCache.get(".*pluralRule.*");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -4088,7 +4088,7 @@ public class SupplementalDataInfo {
             public static final List<Count> VALUES =
                     Collections.unmodifiableList(Arrays.asList(values()));
             public static final Set<Count> OTHER_ONLY = Set.of(Count.other);
-            public static final Set<String> LOCALES_USING_OTHER_ONLY_HACK = Set.of("vi", "vi_VN","tg","tg_TJ");
+            public static final Set<String> LOCALES_USING_OTHER_ONLY_HACK = Set.of("vi", "vi_VN", "tg", "tg_TJ");
         }
 
         static final Pattern pluralPaths = PatternCache.get(".*pluralRule.*");


### PR DESCRIPTION
CLDR-19513

Per [PR#5765#issuecomment-4866854692](https://github.com/unicode-org/cldr/pull/5765#issuecomment-4866854692) 

"One thing that should make this lighter than it looks: in Tajik (as in Persian) the counted noun isn't inflected after a numeral, so for most unit and currency patterns the one form is textually identical to other. I expect a large share of the now-missing values can simply mirror fa rather than needing fresh translation."

CLDR TC had agreed to hide the unnecessary plural form per meeting on 2026-07-08 until a longer term solution is developed as discussed in CLDR-15634

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
