### PR TITLE
CLDR-17854 Multiple numbering systems follow-up

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -115,11 +115,8 @@ public class ShowPlurals {
     }
 
     public void printPluralTable(
-            CLDRFile english, String localeFilter, Appendable appendable, Factory factory)
+            CLDRFile cldrFile, String localeFilter, Appendable appendable, Factory factory)
             throws IOException {
-        // TODO: clarify why the CLDRFile parameter is named "english", and its purpose.
-        // As actually used by VerifyCompactNumbers, english.getLocaleID() is NOT generally "en".
-        // Reference: https://unicode-org.atlassian.net/browse/CLDR-17854
         final TablePrinter tablePrinter =
                 new TablePrinter()
                         .setTableAttributes("class='dtf-table'")
@@ -164,7 +161,9 @@ public class ShowPlurals {
             if (localeFilter != null && !localeFilter.equals(locale) || locale.equals("root")) {
                 continue;
             }
-            final String name = english.nameGetter().getNameFromIdentifier(locale);
+            // The cldrFile may be for English or for another locale (such as the one being
+            // described), so name may get either "French" or "français" if locale is "fr".
+            final String name = cldrFile.nameGetter().getNameFromIdentifier(locale);
             String canonicalLocale = canonicalizer.transform(locale);
             if (!locale.equals(canonicalLocale)) {
                 String redirect =
@@ -203,10 +202,9 @@ public class ShowPlurals {
                 Set<Count> counts = plurals.getCounts();
                 for (PluralInfo.Count count : counts) {
                     String keyword = count.toString();
-                    // Seemingly this code can only produce examples using Latin digits, even if the
-                    // default numbering system for the locale is not "latn". This limitation
-                    // affects the "Examples" column of the "Plural Rules" table in the "Numbers"
-                    // report.
+                    // For the "Examples" column of the "Plural Rules" table in the "Numbers"
+                    // report/chart, by design, this code only produce examples using Latin digits,
+                    // regardless of the locale.
                     DecimalQuantitySamples exampleList =
                             pluralRules.getDecimalSamples(keyword, PluralRules.SampleType.INTEGER);
                     DecimalQuantitySamples exampleList2 =
@@ -305,12 +303,9 @@ public class ShowPlurals {
     }
 
     private String getExamples(DecimalQuantitySamples exampleList) {
-        // Seemingly this code only produces examples using Latin digits, even if the
-        // default numbering system for the locale is not "latn". This limitation affects
-        // the "Examples" column of the "Plural Rules" table in the "Numbers" report.
+        // This code only produces examples using Latin digits, by design.
         // Joiner.join() forces conversion by PluralRules.DecimalQuantitySamplesRange.toString,
         // which in turn calls com.ibm.icu.impl.number.DecimalQuantity.toExponentString.
-        // Maybe there is a way to make that produce non-Latin digits.
         return Joiner.on(", ").join(exampleList.getSamples()) + (exampleList.bounded ? "" : ", …");
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrNumberingSystem.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrNumberingSystem.java
@@ -29,7 +29,7 @@ public enum CldrNumberingSystem {
      * @param cldrFile the file for a locale
      * @return the map
      */
-    public static LinkedHashMap<String, String> getMap(CLDRFile cldrFile) {
+    public static LinkedHashMap<String, String> getSystemToUsageMap(CLDRFile cldrFile) {
 
         LinkedHashMap<String, String> kindToPath = new LinkedHashMap<>();
         LinkedHashMap<String, String> systemToKind = new LinkedHashMap<>();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1468,7 +1468,8 @@ public class DateTimeFormats {
             DateTimeFormats formats,
             Writer out)
             throws IOException {
-        final LinkedHashMap<String, String> numSysMap = CldrNumberingSystem.getMap(nativeFile);
+        final LinkedHashMap<String, String> numSysMap =
+                CldrNumberingSystem.getSystemToUsageMap(nativeFile);
         final Set<String> systems = numSysMap.keySet();
         if (systems.size() > 1) {
             CldrNumberingSystem.writeLinks(out, numSysMap);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -4119,7 +4119,7 @@ public class SupplementalDataInfo {
             this.countToRule = Collections.unmodifiableMap(tempCountToRule);
 
             // Now build rules.
-            // There should be a comment here explaining why ULocale.ENGLISH is hard-wired.
+            // Output in en-US format (ULocale.ENGLISH) as that's what the rule needs.
             NumberFormat nf = NumberFormat.getNumberInstance(ULocale.ENGLISH);
             nf.setMaximumFractionDigits(2);
             StringBuilder pluralRuleBuilder = new StringBuilder();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
@@ -153,8 +153,10 @@ public class VerifyCompactNumbers {
         final boolean isRTL = cldrFile.isRTL();
         final Set<String> debugCreationErrors = new LinkedHashSet<>();
         final Set<String> errors = new LinkedHashSet<>();
-        final LinkedHashMap<String, String> numSysMap = CldrNumberingSystem.getMap(cldrFile);
+        final LinkedHashMap<String, String> numSysMap =
+                CldrNumberingSystem.getSystemToUsageMap(cldrFile);
         final Set<String> systems = numSysMap.keySet();
+        boolean showPluralRules = true; // first/default system only
         try {
             if (systems.size() > 1) {
                 CldrNumberingSystem.writeLinks(out, numSysMap);
@@ -203,7 +205,15 @@ public class VerifyCompactNumbers {
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-                writeTables(tablePrinter, cldrFile, localeID, numberingSystem, out, factory);
+                writeTables(
+                        tablePrinter,
+                        cldrFile,
+                        localeID,
+                        numberingSystem,
+                        out,
+                        factory,
+                        showPluralRules);
+                showPluralRules = false;
             }
             showErrors(errors, out);
             showErrors(debugCreationErrors, out);
@@ -272,7 +282,8 @@ public class VerifyCompactNumbers {
             String localeID,
             String numberingSystem,
             Appendable out,
-            Factory factory)
+            Factory factory,
+            boolean showPluralRules)
             throws IOException {
         out.append(
                         "<p>To correct problems in compact numbers below, please go to "
@@ -282,6 +293,9 @@ public class VerifyCompactNumbers {
                 .append(String.valueOf(PageId.Compact_Decimal_Formatting))
                 .append("</em></a>.</p>");
         out.append(tablePrinter.toString()).append("\n");
+        if (!showPluralRules) {
+            return;
+        }
         out.append("<h3>Plural Rules</h3>");
         out.append(
                 "<p>Look over the Minimal Pairs to make sure they are OK. "


### PR DESCRIPTION
-In printPluralTable rename english to cldrFile, add explanatory comment

-Other explanatory comments

-Rename CldrNumberingSystem.getMap to getSystemToUsageMap

-Show Plural Rules table for the first/default numbering system only

CLDR-17854

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
