### PR TITLE
CLDR-19653 fix extraPaths script

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -151,6 +151,7 @@ public class ExtraPaths {
                 case SCRIPT:
                     addAltPath("Hans", "stand-alone", nameType);
                     addAltPath("Hant", "stand-alone", nameType);
+                    break;
                 case TERRITORY:
                     addAltPath("GB", "short", nameType);
                     addAltPath("HK", "short", nameType);
@@ -169,6 +170,7 @@ public class ExtraPaths {
                     // new alternate name
                     addAltPath("NZ", "variant", nameType);
                     addAltPath("TR", "variant", nameType);
+                    break;
             }
         }
 


### PR DESCRIPTION
switch statement passthrough allowed irregular script codes

CLDR-19653

- [ ] This PR completes the ticket.

I think we need to revisit why illegal extraPaths were allowed, all extraPaths ought to be valid in PathHeader and Coverage.

In this case, PathHeader has a wildcard (`.*`) matcher (%A) for the script type here!

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
