### PR TITLE
CLDR-18980 quell noisy test

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
@@ -763,6 +763,7 @@ public class TestDateOrder extends TestFmwk {
 
     // This is temporary; it will be modified to be a real test once the new data is solid.
 
+    @Disabled
     public void testAddSeparators() {
         Collection<String> locales =
                 getInclusion() < 6 ? List.of("en", "ja", "de", "vo") : cldrFactory.getAvailable();


### PR DESCRIPTION
"temporary" test
outputs a long list of all locale ids
no actual asserts

CLDR-18980

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
