### PR TITLE
CLDR-19616 consolidate known issues for basic locales

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
@@ -37,7 +37,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 
 public class XLocaleDistance {
 
-    static final boolean PRINT_OVERRIDES = true;
+    static final boolean PRINT_OVERRIDES = false;
 
     public static final int ABOVE_THRESHOLD = 100;
 
@@ -67,15 +67,16 @@ public class XLocaleDistance {
         CONTAINER_TO_CONTAINED = ImmutableMultimap.copyOf(containerToContainedTemp);
         // get hard-coded data because ICU fails to copy information
 
-        for (String container : SDI.getContainers()) {
-            Set<String> contained = SDI.getContained(container);
-            System.out.println(
-                    ".putAll(\""
-                            + container
-                            + "\", \""
-                            + Joiner.on("\", \"").join(contained)
-                            + "\")");
-        }
+        if (PRINT_OVERRIDES)
+            for (String container : SDI.getContainers()) {
+                Set<String> contained = SDI.getContained(container);
+                System.out.println(
+                        ".putAll(\""
+                                + container
+                                + "\", \""
+                                + Joiner.on("\", \"").join(contained)
+                                + "\")");
+            }
 
         ImmutableMultimap.Builder<String, String> containerToFinalContainedBuilder =
                 new ImmutableMultimap.Builder<>();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -37,6 +37,7 @@ import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
+import org.unicode.cldr.util.TestCoverageLevel2; // test function
 import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
 import org.unicode.cldr.util.VoteResolver;
@@ -119,8 +120,6 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                         localesForNames,
                         coverageLocales);
 
-        final int currentMajorVersion = SDI.getCldrVersion().getMajor();
-
         // Updating coverageLevels.txt
         //
         // Languages that reach basic need to be added to coverage locales in the next release.
@@ -128,21 +127,15 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         // the end of a release.
         // Follow the instructions below.
 
-        // Set the version number to the current release number
-        final int exceptionMajorVersion = 49;
-
         // Include all and only the locales that newly reached Basic coverage.
-        // (until the next version that has a SurveyTool phase)
-        Set<String> exceptionsForCurrentVersion =
-                ImmutableSet.of("ba", "bua", "pms", "scn", "shn", "tyv");
+        // (until the next version that has a SurveyTool phase).
+        // the known issue part is managed by TestCoverageLevel2.
+        Set<String> exceptionsForCurrentVersion = TestCoverageLevel2.getAllKnownExceptions();
 
         showRegex |=
                 !assertContains(
                         "coverageLocales.containsAll(localesForNames) - add to %language80 or lower under coverageLevels.xml?",
-                        currentMajorVersion != exceptionMajorVersion
-                                ? coverageLocales
-                                : Sets.union(coverageLocales, exceptionsForCurrentVersion),
-                        localesForNames);
+                        Sets.union(coverageLocales, exceptionsForCurrentVersion), localesForNames);
 
         if (showRegex) {
             String simplePattern = MinimizeRegex.simplePattern(localesForNames);
@@ -167,7 +160,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                         "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromIdentifier(locale));
             }
         }
-        if (!official1MSetNames.isEmpty()) {
+        if (isVerbose() && !official1MSetNames.isEmpty()) {
             logln(
                     "Official with 1M+ speakers, need investigation of literacy:\n\t"
                             + Joiner.on("\n\t").join(official1MSetNames.entrySet()));
@@ -181,15 +174,19 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         coverageLocales.removeAll(mainLocales);
         coverageLocales.removeAll(additionsToTranslate);
 
-        for (String locale : localesForNames) {
-            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getNameFromIdentifier(locale));
-        }
+        if (isVerbose()) {
+            for (String locale : localesForNames) {
+                logln("\n" + locale + "\t" + ENGLISH.nameGetter().getNameFromIdentifier(locale));
+            }
 
-        logln("\nmainLocales:" + composeList(mainLocales, "\n\t", new StringBuilder()));
-        logln(
-                "\nadditionsToTranslate:"
-                        + composeList(additionsToTranslate, "\n\t", new StringBuilder()));
-        logln("\noldModernLocales:" + composeList(coverageLocales, "\n\t", new StringBuilder()));
+            logln("\nmainLocales:" + composeList(mainLocales, "\n\t", new StringBuilder()));
+            logln(
+                    "\nadditionsToTranslate:"
+                            + composeList(additionsToTranslate, "\n\t", new StringBuilder()));
+            logln(
+                    "\noldModernLocales:"
+                            + composeList(coverageLocales, "\n\t", new StringBuilder()));
+        }
     }
 
     private Map<String, Integer> getOfficial1M() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
@@ -6,15 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.google.common.collect.ImmutableSet;
+import com.ibm.icu.util.Output;
 import com.ibm.icu.util.VersionInfo;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.MultipleFailuresError;
 import org.unicode.cldr.icu.LDMLConstants;
@@ -26,6 +29,7 @@ public class TestCoverageLevel2 extends TestWithKnownIssues {
 
     final int ITERATIONS = 100000; // keep this low for normal testing
 
+    @Disabled("Perf test: leave disabled normally.")
     @Test
     public void TestCoveragePerf() {
         final SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
@@ -237,6 +241,18 @@ public class TestCoverageLevel2 extends TestWithKnownIssues {
         return false; // no changes
     }
 
+    boolean removeIfKnownIssue(final Set<String> remainingNotInCoverage, final String message) {
+        final Output<Boolean> didRemove = new Output<>(false);
+        deferLocalesReachingBasic(
+                (final String ticket, final Set<String> set) -> {
+                    if (removeIfKnownIssue(ticket, remainingNotInCoverage, message, set)) {
+                        didRemove.value = true;
+                    }
+                });
+
+        return didRemove.value;
+    }
+
     /** Bring the bad news (if any). Reporting factored out here. */
     private void assertMissingCoverage(
             final Level failIfAbove,
@@ -256,7 +272,7 @@ public class TestCoverageLevel2 extends TestWithKnownIssues {
                                             plural, notInEnglish.toString()));
                 },
                 () -> {
-                    // make a modifyable copy here so we can exclude some due to logKnownIssues
+                    // make a modifiable copy here so we can exclude some due to logKnownIssues
                     Set<String> remainingNotInCoverage = new TreeSet<>(notInCoverage);
                     final Supplier<String> formatter =
                             () ->
@@ -274,16 +290,55 @@ public class TestCoverageLevel2 extends TestWithKnownIssues {
                             //
                             //   removeIfKnownIssue("CLDR-00000", remainingNotInCoverage, message,
                             //       ImmutableSet.of("es","tlh","zxx"));
-
-                            removeIfKnownIssue(
-                                    "CLDR-18972",
-                                    remainingNotInCoverage,
-                                    formatter.get(),
-                                    ImmutableSet.of("ba", "bua", "pms", "scn", "shn", "tyv"));
+                            removeIfKnownIssue(remainingNotInCoverage, formatter.get());
                         }
                         // do the assertion.
                         assertTrue(remainingNotInCoverage.isEmpty(), formatter);
                     }
+                });
+    }
+
+    public static Set<String> getAllKnownExceptions() {
+        final Set<String> r = new TreeSet<>();
+        // just get the locales, don't care about the known issues here.
+        deferLocalesReachingBasic((final String ticket, final Set<String> set) -> r.addAll(set));
+        return r;
+    }
+
+    /**
+     * Bottleneck function with all of the knowledge of known issues for locales reaching basic
+     *
+     * @param consumer consumer for pairs of: known issue, set
+     */
+    private static void deferLocalesReachingBasic(BiConsumer<String, Set<String>> consumer) {
+        // CLDR 48 list (CLDR 50 ticket)
+        consumer.accept("CLDR-18972", ImmutableSet.of("ba", "bua", "pms", "scn", "shn", "tyv"));
+        // CLDR 49 list (CLDR 50 ticket)
+        consumer.accept(
+                "CLDR-18972",
+                ImmutableSet.of(
+                        "ady", // 	Adyghe
+                        "cop", // 	Coptic
+                        "kbd", // 	Kabardian
+                        "kek", // 	Qʼeqchiʼ
+                        "ki", // Kikuyu
+                        "lld", // 	Ladin
+                        "quc" // 	Kʼicheʼ
+                        ));
+    }
+
+    @Test
+    public void testShowDeferred() {
+        deferLocalesReachingBasic(
+                (ticket, set) -> {
+                    if (logKnownIssue(
+                            ticket,
+                            "Deferred locales (check deferLocalesReachingBasic()): " + set)) {
+                        return;
+                    }
+                    assertTrue(
+                            set.isEmpty(),
+                            "Expected to have no deferred locales: " + ticket + " : " + set);
                 });
     }
 }


### PR DESCRIPTION
- improve the logKnownIssues mechanism for excluding locales-going-to-basic since we'll need it every year
- update logKnownIssues for this year's vxml (add v49 locales to those already in CLDR-18972 )
- quell a bunch of noise in XLocaleDistance and TestCLDRLocaleCoverage

CLDR-19616

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
