### PR TITLE
CLDR-19616 skip /alias paths in metazone logical grouping

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/LogicalGroupChecker.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/LogicalGroupChecker.java
@@ -57,7 +57,11 @@ public class LogicalGroupChecker {
         this.result = result;
         pathType = new Output<>();
         cldrFile = checkLogicalGroupings.getCldrFileToCheck();
-        paths = LogicalGrouping.getPaths(cldrFile, path, pathType);
+        try {
+            paths = LogicalGrouping.getPaths(cldrFile, path, pathType);
+        } catch (Throwable t) {
+            throw new RuntimeException("Illegal xpath on logical group for " + path, t);
+        }
         coverageLevel =
                 CoverageLevel2.getInstance(
                         SupplementalDataInfo.getInstance(), cldrFile.getLocaleID());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LogicalGrouping.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LogicalGrouping.java
@@ -164,6 +164,16 @@ public class LogicalGrouping {
     private static final boolean GET_TYPE_FROM_PARTS = false;
 
     /**
+     * Bottleneck to validate that a path parses.
+     *
+     * @return a copy of the string
+     */
+    private static final String validatePath(final String path) {
+        /* ignored */ XPathParts.getFrozenInstance(path);
+        return path;
+    }
+
+    /**
      * Return a sorted set of paths that are in the same logical set as the given path
      *
      * @param cldrFile the CLDRFile
@@ -210,9 +220,7 @@ public class LogicalGrouping {
             /*
              * Skip cache for PathType.SINGLETON and simply return a set of one.
              */
-            Set<String> set = new TreeSet<>();
-            set.add(path);
-            return set;
+            return Collections.singleton(validatePath(path));
         }
 
         if (!GET_TYPE_FROM_PARTS) {
@@ -351,6 +359,8 @@ public class LogicalGrouping {
             @Override
             @SuppressWarnings("unused")
             void addPaths(Set<String> set, CLDRFile cldrFile, String path, XPathParts parts) {
+                if (path.contains("/alias"))
+                    return; // TODO CLDR-19671 alias paths shouldn't get here.
                 String metazoneName = parts.getAttributeValue(3, "type");
                 if (metazonesDSTSet.contains(metazoneName)) {
                     for (String str : ImmutableSet.of("generic", "standard", "daylight")) {
@@ -359,7 +369,9 @@ public class LogicalGrouping {
                             // Skip standard path for metazones that inherit GMT standard name
                             continue;
                         }
-                        set.add(path.substring(0, path.lastIndexOf('/') + 1) + str);
+                        final String mutatedPath =
+                                path.substring(0, path.lastIndexOf('/') + 1) + str;
+                        set.add(validatePath(mutatedPath));
                     }
                 }
             }
@@ -373,7 +385,7 @@ public class LogicalGrouping {
                 if (dayName != null && days.contains(dayName)) {
                     for (String str : days) {
                         parts.setAttribute("day", "type", str);
-                        set.add(parts.toString());
+                        set.add(validatePath(parts.toString()));
                     }
                 }
             }
@@ -382,13 +394,13 @@ public class LogicalGrouping {
             @Override
             void addPaths(Set<String> set, CLDRFile cldrFile, String path, XPathParts parts) {
                 if (parts.containsElement("alias")) {
-                    set.add(path);
+                    set.add(validatePath(path));
                 } else {
                     String dayPeriodType = parts.findAttributeValue("dayPeriod", "type");
                     if (ampm.contains(dayPeriodType)) {
                         for (String s : ampm) {
                             parts.setAttribute("dayPeriod", "type", s);
-                            set.add(parts.toString());
+                            set.add(validatePath(parts.toString()));
                         }
                     } else {
                         DayPeriodInfo.Type dayPeriodContext =
@@ -402,7 +414,7 @@ public class LogicalGrouping {
                         if (dayPeriods.contains(thisDayPeriod)) {
                             for (DayPeriod d : dayPeriods) {
                                 parts.setAttribute("dayPeriod", "type", d.name());
-                                set.add(parts.toString());
+                                set.add(validatePath(parts.toString()));
                             }
                         }
                     }
@@ -420,7 +432,7 @@ public class LogicalGrouping {
                                 <= 4) { // This is just a quick check to make sure the path is good.
                     for (Integer i = 1; i <= 4; i++) {
                         parts.setAttribute("quarter", "type", i.toString());
-                        set.add(parts.toString());
+                        set.add(validatePath(parts.toString()));
                     }
                 }
             }
@@ -441,12 +453,12 @@ public class LogicalGrouping {
                         if ("hebrew".equals(calType)) {
                             parts.removeAttribute("month", "yeartype");
                         }
-                        set.add(parts.toString());
+                        set.add(validatePath(parts.toString()));
                     }
                     if ("hebrew".equals(calType)) { // Add extra hebrew calendar leap month
                         parts.setAttribute("month", "type", Integer.toString(7));
                         parts.setAttribute("month", "yeartype", "leap");
-                        set.add(parts.toString());
+                        set.add(validatePath(parts.toString()));
                     }
                 }
             }
@@ -470,7 +482,7 @@ public class LogicalGrouping {
                         }
                         for (Integer i = -1 * limit; i <= limit; i++) {
                             parts.setAttribute("relative", "type", i.toString());
-                            set.add(parts.toString());
+                            set.add(validatePath(parts.toString()));
                         }
                     }
                 }
@@ -498,7 +510,7 @@ public class LogicalGrouping {
                         parts.setAttribute(5, "type", patType);
                         for (Count count : pluralTypes) {
                             parts.setAttribute(5, "count", count.toString());
-                            set.add(parts.toString());
+                            set.add(validatePath(parts.toString()));
                         }
                     }
                 }
@@ -569,7 +581,7 @@ public class LogicalGrouping {
             void addPaths(Set<String> set, CLDRFile cldrFile, String path, XPathParts parts) {
                 for (String str : YES_NO) {
                     parts.setAttribute("typeValue", "type", str);
-                    set.add(parts.toString());
+                    set.add(validatePath(parts.toString()));
                 }
             }
         },
@@ -579,7 +591,7 @@ public class LogicalGrouping {
             void addPaths(Set<String> set, CLDRFile cldrFile, String path, XPathParts parts) {
                 for (String str : CORE_EXTENSION) {
                     parts.setAttribute("language", "menu", str);
-                    set.add(parts.toString());
+                    set.add(validatePath(parts.toString()));
                 }
             }
         };
@@ -590,7 +602,7 @@ public class LogicalGrouping {
             Set<Count> pluralTypes = getCounts(cldrFile);
             for (Count count : pluralTypes) {
                 parts.setAttribute(-1, "count", count.toString());
-                set.add(parts.toString());
+                set.add(validatePath(parts.toString()));
             }
         }
 
@@ -622,7 +634,7 @@ public class LogicalGrouping {
                         parts.setAttribute(-1, "gender", gender);
                         parts.setAttribute(-1, "count", count.toString());
                         parts.setAttribute(-1, "case", case1);
-                        set.add(parts.toString());
+                        set.add(validatePath(parts.toString()));
                     }
                 }
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestCheckLogicalGroupings.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestCheckLogicalGroupings.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.test.CheckCLDR.Options;
 import org.unicode.cldr.test.CheckCLDR.Phase;
 import org.unicode.cldr.util.*;
@@ -240,5 +242,39 @@ public class TestCheckLogicalGroupings {
                                     + " for "
                                     + xpath);
         }
+    }
+
+    /**
+     * Test that no root paths have logical grouping invalid xpath issues Specifically,
+     * LogicalGrouping.validatePath() will throw at the point that an invalid XPath is generated.
+     */
+    @Test
+    public void testRootGroups() {
+        CLDRConfig config = CLDRConfig.getInstance();
+        Factory cldrFactory = config.getCldrFactory();
+        CheckLogicalGroupings clg = new CheckLogicalGroupings(cldrFactory);
+        final String localeID = "root";
+        final Options options =
+                new Options(
+                        CLDRLocale.getInstance(localeID),
+                        Phase.VETTING,
+                        Level.COMPREHENSIVE.getAltName(),
+                        "organization");
+        final CLDRFile f = cldrFactory.make(localeID, true);
+        // paths that fail
+        final Set<String> badPaths = new TreeSet<String>();
+        final List<CheckStatus> errs = new LinkedList<>();
+        clg.setCldrFileToCheck(f, options, errs);
+        assertTrue(errs.isEmpty(), () -> "whole-file errs" + errs.toString());
+        f.fullIterable()
+                .forEach(
+                        p -> {
+                            clg.check(p, p, f.getStringValue(p), options, errs);
+                            if (errs.stream()
+                                    .anyMatch(s -> s.getSubtype() == Subtype.internalError)) {
+                                badPaths.add(p);
+                            }
+                        });
+        assertTrue(badPaths.isEmpty(), () -> "Internal errors on paths: " + badPaths.toArray());
     }
 }


### PR DESCRIPTION
- also, rigorously check XPaths coming out of the logical group mechanism
- Adds a TODO to CLDR-19671, since /alias paths are showing up in fullIterable() (and they shouldn't be).

CLDR-19616

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
