### PR TITLE
CLDR-19382 Remove short names for British/Irish metazone

### DIFF
--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -5830,6 +5830,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>↑↑↑</daylight>
 				</long>
 				<short>
+					<standard>GMT</standard>
 					<daylight>BST</daylight>
 				</short>
 			</metazone>

--- a/common/main/en_IE.xml
+++ b/common/main/en_IE.xml
@@ -121,6 +121,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<timeZoneNames>
 			<metazone type="Irish">
 				<short>
+					<standard>GMT</standard>
 					<daylight>IST</daylight>
 				</short>
 			</metazone>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -2957,10 +2957,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>Wallis &amp; Futuna</exemplarCity>
 			</zone>
 			<metazone type="British">
-				<alias source="locale" path="../metazone[@type='GMT']"/>
+			<long>
+				<alias source="locale" path="../../metazone[@type='GMT']/long"/>
+			</long>
 			</metazone>
 			<metazone type="Irish">
-				<alias source="locale" path="../metazone[@type='GMT']"/>
+				<long>
+					<alias source="locale" path="../../metazone[@type='GMT']/long"/>
+				</long>
 			</metazone>
 		</timeZoneNames>
 	</dates>


### PR DESCRIPTION
CLDR-19382

- [ ] This PR completes the ticket.

The alias we currently have in root is too broad; it adds the short standard name "GMT" to all locales. However, we only want it in locales that also set the short daylight name ("BST"/"IST"), as otherwise this looks like a standard-only zone.

ALLOW_MANY_COMMITS=true
