### PR TITLE
CLDR-19616 restore pluralMinimalPairs for ga/cy

### DIFF
--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -8632,12 +8632,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="zero" draft="contributed">{0}</pluralMinimalPairs>
-			<pluralMinimalPairs count="one" draft="contributed">{0} diwrnod</pluralMinimalPairs>
-			<pluralMinimalPairs count="two" draft="contributed">dau</pluralMinimalPairs>
-			<pluralMinimalPairs count="few" draft="contributed">ychydig</pluralMinimalPairs>
-			<pluralMinimalPairs count="many" draft="contributed">llawer</pluralMinimalPairs>
-			<pluralMinimalPairs count="other" draft="contributed">{0} o ddiwrnodau</pluralMinimalPairs>
+			<pluralMinimalPairs count="zero">{0} cŵn, {0} cathod</pluralMinimalPairs>
+			<pluralMinimalPairs count="one">{0} ci, {0} gath</pluralMinimalPairs>
+			<pluralMinimalPairs count="two">{0} gi, {0} gath</pluralMinimalPairs>
+			<pluralMinimalPairs count="few">{0} chi, {0} cath</pluralMinimalPairs>
+			<pluralMinimalPairs count="many">{0} chi, {0} chath</pluralMinimalPairs>
+			<pluralMinimalPairs count="other">{0} ci, {0} cath</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="zero">{0}fed ci</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="one">Cymerwch y troad {0}af ar y dde.</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="two">Cymerwch yr {0}il droad ar y dde</ordinalMinimalPairs>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -9005,11 +9005,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="one" draft="contributed">{0} cheann, {0} uair, {0} chat, {0} éan, {0} bhróg</pluralMinimalPairs>
-			<pluralMinimalPairs count="two" draft="contributed">{0} cheann, {0} uair, {0} chat, {0} éan, {0} bhróig</pluralMinimalPairs>
-			<pluralMinimalPairs count="few" draft="contributed">{0} cinn, {0} huaire, {0} chat, {0} éan, {0} bhróg</pluralMinimalPairs>
-			<pluralMinimalPairs count="many" draft="contributed">{0} gcinn, {0} n-uaire, {0} gcat, {0} n-éan, {0} mbróg</pluralMinimalPairs>
-			<pluralMinimalPairs count="other" draft="contributed">{0} ceann, {0} uair, {0} cat, {0} éan, {0} bróg</pluralMinimalPairs>
+			<pluralMinimalPairs count="one">{0} cheann, {0} uair, {0} chat, {0} éan, {0} bhróg</pluralMinimalPairs>
+			<pluralMinimalPairs count="two">{0} cheann, {0} uair, {0} chat, {0} éan, {0} bhróig</pluralMinimalPairs>
+			<pluralMinimalPairs count="few">{0} cinn, {0} huaire, {0} chat, {0} éan, {0} bhróg</pluralMinimalPairs>
+			<pluralMinimalPairs count="many">{0} gcinn, {0} n-uaire, {0} gcat, {0} n-éan, {0} mbróg</pluralMinimalPairs>
+			<pluralMinimalPairs count="other">{0} ceann, {0} uair, {0} cat, {0} éan, {0} bróg</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="one">Glac an {0}ú chasadh ar dheis.</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">Glac an {0}ú casadh ar dheis.</ordinalMinimalPairs>
 		</minimalPairs>


### PR DESCRIPTION
from 48

CLDR-19616


were removed in https://github.com/unicode-org/cldr/pull/5757

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
