### PR TITLE
CLDR-19616 update TestExampleGenerator for lv

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/dev/test/TestFmwk.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/dev/test/TestFmwk.java
@@ -2161,28 +2161,33 @@ public class TestFmwk extends AbstractTestLog {
             String source = st.getFileName();
             if (source == null || source.equals("TestShim.java")) {
                 return new SourceLocation(); // hit the end of helpful stack traces
-            } else if (source != null
-                    // exclude locations here that are 'not useful'.
-                    // That is, we want to have throws happen in the test code,
-                    // not in the 'framework'
-                    && (st.getLineNumber() != 1) // exclude line 1!
-                    && !source.equals("TestFmwk.java")
-                    && !source.equals("TestFmwkForChecks.java")
-                    // exclude utility functions in TestFmwkPlus, but not its TestTest!
-                    && !(source.equals("TestFmwkPlus.java")
-                            && !st.getMethodName().equals("TestTest"))
-                    && !source.equals("AbstractTestLog.java")) {
+            } else {
                 String methodName = st.getMethodName();
-                if (methodName != null && methodName.startsWith("lambda$")) { // unpack inner lambda
-                    methodName =
-                            methodName.substring(
-                                    "lambda$".length()); // lambda$TestValid$0 -> TestValid$0
+                if (source != null
+                        // exclude locations here that are 'not useful'.
+                        // That is, we want to have throws happen in the test code,
+                        // not in the 'framework'
+                        // TODO CLDR-19672 to automate this
+                        && (st.getLineNumber() != 1) // exclude line 1!
+                        && !source.equals("TestFmwk.java")
+                        && !source.equals("TestFmwkForChecks.java")
+                        // exclude utility functions in TestFmwkPlus, but not its TestTest!
+                        && !(source.equals("TestFmwkPlus.java") && !methodName.equals("TestTest"))
+                        && !(source.equals("TestExampleGenerator.java")
+                                && methodName.startsWith("checkValue"))
+                        && !source.equals("AbstractTestLog.java")) {
+                    if (methodName != null
+                            && methodName.startsWith("lambda$")) { // unpack inner lambda
+                        methodName =
+                                methodName.substring(
+                                        "lambda$".length()); // lambda$TestValid$0 -> TestValid$0
+                    }
+                    if (methodName != null
+                            && (methodName.startsWith("Test")
+                                    || methodName.startsWith("test")
+                                    || methodName.equals("main"))) {}
+                    return new SourceLocation(st.getLineNumber(), source, st);
                 }
-                if (methodName != null
-                        && (methodName.startsWith("Test")
-                                || methodName.startsWith("test")
-                                || methodName.equals("main"))) {}
-                return new SourceLocation(st.getLineNumber(), source, st);
             }
         }
         return new SourceLocation(); // not found

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -489,7 +489,7 @@ public class TestExampleGenerator extends TestFmwk {
         value = value != null ? value : cldrFile.getStringValue(path);
         String actual = exampleGenerator.getExampleHtml(path, value);
         assertEquals(
-                cldrFile.getLocaleID() + ": " + message,
+                cldrFile.getLocaleID() + ": " + message + " @ " + path,
                 expected,
                 ExampleGenerator.simplify(actual, false));
     }
@@ -1904,7 +1904,7 @@ public class TestExampleGenerator extends TestFmwk {
                 "//ldml/dates/fields/field[@type=\"hour\"]/relativeTime[@type=\"past\"]/relativeTimePattern[@count=\"many\"]");
         checkValue(
                 "lv relative month future-other",
-                "〖Set letter case for top example:〗〖1999. g. septembris (pēc ❬22❭ mēnešiem)〗〖pēc ❬22❭ mēnešiem (1999. g. septembris)〗〖See letter case instructions at right.〗",
+                "〖Set letter case for top example:〗〖1999. gada. septembris (pēc ❬22❭ mēnešiem)〗〖pēc ❬22❭ mēnešiem (1999. gada. septembris)〗〖See letter case instructions at right.〗",
                 exampleGeneratorLv,
                 "//ldml/dates/fields/field[@type=\"month\"]/relativeTime[@type=\"future\"]/relativeTimePattern[@count=\"other\"]");
     }


### PR DESCRIPTION
CLDR-19616

- the TestFmwk change is so that we get usable error messages (instead of a dead end), see https://unicode-org.atlassian.net/browse/CLDR-19672 for a general solution
- update TestExampleGenerator.java per vxml data change

this is the failure:

> `Error:  (TestExampleGenerator.java:491)  Error: : lv: lv relative month future-other: expected "〖Set letter case for top example:〗〖1999. g. septembris (pēc ❬22❭ mēnešiem)〗〖pēc ❬22❭ mēnešiem (1999. g. septembris)〗〖See letter case instructions at right.〗", got "〖Set letter case for top example:〗〖1999. gada. septembris (pēc ❬22❭ mēnešiem)〗〖pēc ❬22❭ mēnešiem (1999. gada. septembris)〗〖See letter case instructions at right.〗"`

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
