### PR TITLE
CLDR-18781 Draw lines joining Info Panel items to Winning/Others

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrCanvas.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrCanvas.mjs
@@ -1,0 +1,68 @@
+/*
+ * cldrCanvas: encapsulate Survey Tool functions related to canvas, for
+ * graphical display, such as a line joining a candidate item in the Info Panel
+ * to the corresponding item in the Winning or Others column
+ */
+
+import * as cldrGui from "./cldrGui.mjs";
+
+const DEFAULT_CANVAS_ID = "cldrCanvas";
+
+function clear() {
+  const ctx = getContext();
+  if (ctx) {
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  }
+}
+
+function connectElements(elTo, elFrom) {
+  const ctx = getContext();
+  if (ctx) {
+    ctx.beginPath();
+    ctx.lineWidth = "2";
+    ctx.strokeStyle = "rgba(0,0,0,0.5)";
+    const canvasRect = ctx.canvas.getBoundingClientRect();
+    const fromRect = elFrom.getBoundingClientRect();
+    const toRect = elTo.getBoundingClientRect();
+    const xa = (fromRect.left + fromRect.right) / 2 - canvasRect.left;
+    const ya = (fromRect.top + fromRect.bottom) / 2 - canvasRect.top;
+    const xz = (toRect.left + toRect.right) / 2 - canvasRect.left;
+    const yz = (toRect.top + toRect.bottom) / 2 - canvasRect.top;
+    ctx.moveTo(xa, ya);
+    ctx.lineTo(xz, yz);
+    ctx.stroke();
+  }
+}
+
+function getContext() {
+  const canvas = getCanvas();
+  return canvas?.getContext ? canvas.getContext("2d") : null;
+}
+
+function getCanvas() {
+  const parent = document.getElementById(cldrGui.MAIN_ID);
+  if (!parent) {
+    return null;
+  }
+  const parentRect = parent.getBoundingClientRect();
+  let canvas = document.getElementById(DEFAULT_CANVAS_ID);
+  if (!canvas) {
+    canvas = parent.appendChild(document.createElement("canvas"));
+    if (canvas) {
+      canvas.id = DEFAULT_CANVAS_ID;
+      canvas.width = parentRect.width;
+      canvas.height = parentRect.height;
+      canvas.style = "position:absolute; pointer-events: none; z-index: 1000";
+    }
+  } else if (
+    canvas.width != parentRect.width ||
+    canvas.height != parentRect.height
+  ) {
+    // Resize if needed to match parent
+    canvas.width = parentRect.width;
+    canvas.height = parentRect.height;
+  }
+  return canvas;
+}
+
+export { clear, connectElements };

--- a/tools/cldr-apps/js/src/esm/cldrForum.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForum.mjs
@@ -13,6 +13,7 @@ import * as cldrLoad from "./cldrLoad.mjs";
 import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
+import * as cldrTable from "./cldrTable.mjs";
 import * as cldrText from "./cldrText.mjs";
 import * as cldrVue from "./cldrVue.mjs";
 
@@ -31,6 +32,7 @@ class PostInfo {
     this.locale = null;
     this.xpstrid = null;
     this.value = null;
+    this.valueHash = null;
     this.subject = "";
     this.willFlag = false;
     this.replyTo = -1;
@@ -53,14 +55,16 @@ class PostInfo {
       rootPost.locale,
       rootPost.xpath,
       rootPost.value,
+      rootPost.valueHash,
       rootPost.subject
     );
   }
 
-  setLocalePathValueSubject(locale, xpstrid, value, subject) {
+  setLocalePathValueSubject(locale, xpstrid, value, valueHash, subject) {
     this.locale = locale;
     this.xpstrid = xpstrid;
     this.value = value;
+    this.valueHash = valueHash;
     this.subject = subject;
   }
 
@@ -388,6 +392,14 @@ function parseContent(posts, context) {
             "postTopicInfo"
           );
           topicDiv.appendChild(requestInfo);
+          // If this is displayed in the Info Panel, add a hover to this item, so that it
+          // points (maybe draws a line) to the corresponding item in the vetting table
+          // "Winning" or "Others" column if present.
+          cldrTable.pointToCandidateAddListener(
+            requestInfo,
+            post.xpath,
+            rootPost.valueHash
+          );
         }
       }
       topicDivs[post.threadId] = topicDiv;
@@ -695,8 +707,17 @@ function addReplyButtonsToEachTopic(topicDivs) {
  * @param xpstrid the xpath string id
  * @param code the "code" for the xpath
  * @param value the value the current user voted for, or null
+ * @param valueHash the hash of the value the current user voted for, or null
  */
-function addNewPostButtons(el, locale, couldFlag, xpstrid, code, value) {
+function addNewPostButtons(
+  el,
+  locale,
+  couldFlag,
+  xpstrid,
+  code,
+  value,
+  valueHash
+) {
   if (!userCanPost) {
     return;
   }
@@ -730,7 +751,13 @@ function addNewPostButtons(el, locale, couldFlag, xpstrid, code, value) {
       },
       function (o) {
         const subject = makeSubject(code, xpstrid, o, xpathMap, willFlag);
-        pi.setLocalePathValueSubject(locale, xpstrid, value, subject);
+        pi.setLocalePathValueSubject(
+          locale,
+          xpstrid,
+          value,
+          valueHash,
+          subject
+        );
         if (willFlag) {
           pi.setWillFlagTrue();
         }

--- a/tools/cldr-apps/js/src/esm/cldrForumPanel.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForumPanel.mjs
@@ -97,7 +97,8 @@ function addTopButtons(theRow, frag) {
     couldFlag,
     theRow.xpstrid,
     theRow.code,
-    myValue
+    myValue,
+    theRow.voteVhash
   );
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -266,6 +266,8 @@ const topTitle =
   </header>
 `;
 
+const MAIN_ID = "main-row"; // must match the "main" element below
+
 const sideBySide = `
   <main id="main-row" class="sidebyside beware-left-sidebar">
     <div id="MainContentPane" class="sidebyside-column sidebyside-wide">
@@ -443,6 +445,7 @@ function refreshCounterVetting() {
 }
 
 export {
+  MAIN_ID,
   refreshCounterVetting,
   run,
   setToptitleVisibility,

--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -331,7 +331,12 @@ function addSelectedItem(theRow) {
   const item = findSelectedItem(theRow);
 
   const { displayValue, valueClass } = getValueAndClass(theRow, item);
-  selectedItemWrapper.setValueAndClass(displayValue, valueClass);
+  selectedItemWrapper.setPathValueClass(
+    theRow?.xpstrid,
+    displayValue,
+    item?.valueHash,
+    valueClass
+  );
 
   const { language, direction } = getLanguageAndDirection();
   selectedItemWrapper.setLanguageAndDirection(language, direction);
@@ -500,6 +505,7 @@ function updateRowVoteInfo(theRow) {
       isBaselineValue: Boolean(item.isBaselineValue),
       vote: vote,
       voteTableData: voteTableData,
+      valueHash: item.valueHash,
     };
     if (value === cldrSurvey.INHERITANCE_MARKER) {
       candidateItem.displayValue = theRow.inheritedDisplayValue;
@@ -526,6 +532,7 @@ function updateRowVoteInfo(theRow) {
   const { language, direction } = getLanguageAndDirection();
   data.language = language;
   data.direction = direction;
+  data.xpstrid = theRow.xpstrid;
   candidateItemsWrapper.setData(data);
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -11,6 +11,7 @@
 import * as cldrAddAlt from "./cldrAddAlt.mjs";
 import * as cldrAddValue from "./cldrAddValue.mjs";
 import * as cldrAjax from "./cldrAjax.mjs";
+import * as cldrCanvas from "./cldrCanvas.mjs";
 import * as cldrChar from "./cldrChar.mjs";
 import { VOTE_FOR_MISSING } from "./cldrConstants.mjs";
 import * as cldrCoverage from "./cldrCoverage.mjs";
@@ -1461,6 +1462,41 @@ function mutateCodeString(code) {
   }
 }
 
+function pointToCandidateAddListener(element, xpstrid, valueHash) {
+  element.addEventListener("mouseover", (event) =>
+    pointToCandidate(event, xpstrid, valueHash)
+  );
+  element.addEventListener("mouseleave", (event) =>
+    pointToCandidateStop(event)
+  );
+}
+
+function pointToCandidate(event, xpstrid, valueHash) {
+  const theRow = rowFromPath(xpstrid);
+  if (theRow) {
+    const id = makeCandidateItemId(xpstrid, valueHash);
+    const elTo = document.getElementById(id);
+    if (elTo) {
+      cldrCanvas.connectElements(elTo, event.target);
+    }
+  }
+}
+
+function pointToCandidateStop(event) {
+  cldrCanvas.clear();
+}
+
+function rowFromPath(xpstrid) {
+  const rowId = makeRowId(xpstrid);
+  if (rowId) {
+    const tr = document.getElementById(rowId);
+    if (tr) {
+      return tr.theRow;
+    }
+  }
+  return null;
+}
+
 export {
   NO_WINNING_VALUE,
   findItemByProcessedValue,
@@ -1473,9 +1509,13 @@ export {
   insertRows,
   listen,
   makeRowId,
+  pointToCandidate,
+  pointToCandidateAddListener,
+  pointToCandidateStop,
   refreshSingleRow,
   resetLastShown,
   setDivClassSelected,
+
   /*
    * The following are meant to be accessible for unit testing only:
    */

--- a/tools/cldr-apps/js/src/esm/cldrVoteTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVoteTable.mjs
@@ -5,7 +5,6 @@ import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrSurvey from "../esm/cldrSurvey.mjs";
 import * as cldrText from "../esm/cldrText.mjs";
 import * as cldrUserLevels from "./cldrUserLevels.mjs";
-import * as cldrVue from "./cldrVue.mjs";
 
 function construct(votingResults, item, value, totalVoteCount) {
   try {

--- a/tools/cldr-apps/js/src/views/InfoCandidateItems.vue
+++ b/tools/cldr-apps/js/src/views/InfoCandidateItems.vue
@@ -11,9 +11,14 @@
           {{ valueTooltip }}
         </div></template
       >
-      <span :class="getItemClass(item)" :lang="language" :dir="direction">{{
-        item.displayValue
-      }}</span>
+      <span
+        :class="getItemClass(item)"
+        :lang="language"
+        :dir="direction"
+        @mouseover="(event) => valMouseover(event, item)"
+        @mouseleave="(event) => valMouseleave(event)"
+        >{{ item.displayValue }}</span
+      >
     </a-popover>
     <span v-if="item.isBaselineValue" class="baseline-value">
       <a-popover overlayClassName="overlay-style">
@@ -67,6 +72,7 @@ import { ref } from "vue";
 
 import InfoVoteTable from "./InfoVoteTable.vue";
 
+import * as cldrTable from "../esm/cldrTable.mjs";
 import * as cldrText from "../esm/cldrText.mjs";
 
 const valueTooltip = ref(cldrText.get("voteInfo_candidate_item_desc"));
@@ -80,6 +86,7 @@ const flagURL = ref(cldrText.get("flagURL"));
 const flagLinkText = ref(cldrText.get("flagLinkText"));
 const flagExplanationEnd = ref(cldrText.get("flagExplanationEnd"));
 
+const xpstrid = ref(null);
 const candidateItems = ref(null);
 const reqVoteMessage = ref(null);
 const language = ref(null);
@@ -93,6 +100,7 @@ const rowFlaggedMessage = ref(null);
 const isLocked = ref(false);
 
 function setData(data) {
+  xpstrid.value = data.xpstrid;
   candidateItems.value = data.candidateItems;
   reqVoteMessage.value = data.reqVoteMessage;
   transcript.value = data.transcript;
@@ -132,6 +140,14 @@ function getBaileyClass(item) {
 
 function toggleTranscript() {
   transcriptVisible.value = !transcriptVisible.value;
+}
+
+function valMouseover(event, item) {
+  cldrTable.pointToCandidate(event, xpstrid.value, item.valueHash);
+}
+
+function valMouseleave(event) {
+  cldrTable.pointToCandidateStop(event);
 }
 
 defineExpose({

--- a/tools/cldr-apps/js/src/views/InfoSelectedItem.vue
+++ b/tools/cldr-apps/js/src/views/InfoSelectedItem.vue
@@ -9,9 +9,14 @@
     <div class="info-selected-item" v-if="valueClass && description">
       <div>
         Value:
-        <span :class="valueClass" :lang="language" :dir="direction">{{
-          displayValue
-        }}</span>
+        <span
+          :class="valueClass"
+          :lang="language"
+          :dir="direction"
+          @mouseover="valMouseover"
+          @mouseleave="valMouseleave"
+          >{{ displayValue }}</span
+        >
         <br />
         <span class="value-description">{{ description }}</span>
         <template v-if="linkUrl">
@@ -34,6 +39,7 @@
 </template>
 
 <script>
+import * as cldrTable from "../esm/cldrTable.mjs";
 import * as cldrText from "../esm/cldrText.mjs";
 
 export default {
@@ -48,6 +54,8 @@ export default {
       linkText: null,
       testHtml: null,
       exampleHtml: null,
+      valueHash: null,
+      xpstrid: null,
     };
   },
 
@@ -56,8 +64,10 @@ export default {
       return cldrText.get("info_panel_selected");
     },
 
-    setValueAndClass(displayValue, valueClass) {
+    setPathValueClass(xpstrid, displayValue, valueHash, valueClass) {
+      this.xpstrid = xpstrid;
       this.displayValue = displayValue;
+      this.valueHash = valueHash;
       this.valueClass = valueClass;
     },
 
@@ -81,6 +91,14 @@ export default {
 
     setExampleHtml(exampleHtml) {
       this.exampleHtml = exampleHtml;
+    },
+
+    valMouseover(event) {
+      cldrTable.pointToCandidate(event, this.xpstrid, this.valueHash);
+    },
+
+    valMouseleave(event) {
+      cldrTable.pointToCandidateStop(event);
     },
   },
 };

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
@@ -791,6 +791,7 @@ public class SurveyForum {
                         }
                         if (value != null) {
                             post.put("value", value);
+                            post.put("valueHash", DataPage.getValueHash(value));
                         }
                         post.put("open", open);
                         post.put("root", root);


### PR DESCRIPTION
-While the user hovers over a candidate item (including Forum requested/flagged item) in the Info Panel, draw a line joining it to the corresponding item in the Winning or Others column

-New cldrCanvas.mjs for drawing lines

-Enhance cldrForum.mjs, cldrTable.mjs, cldrGui.mjs, InfoCandidateItems.vue, InfoSelectedItem.vue, SurveyForum.java to support the new functionality, such as using valueHash to identify the item

CLDR-18781

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
