### PR TITLE
CLDR-19627 drop bulgarian many

### DIFF
--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -1403,7 +1403,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dayOfMonths>
 					<dayOfMonthContext type="format">
 						<dayOfMonthWidth type="abbreviated">
-							<dayOfMonth ordinal="zero">{0}</dayOfMonth>
 							<dayOfMonth ordinal="one">{0}</dayOfMonth>
 							<dayOfMonth ordinal="two">{0}</dayOfMonth>
 							<dayOfMonth ordinal="few">{0}</dayOfMonth>
@@ -1814,7 +1813,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dayOfMonths>
 					<dayOfMonthContext type="format">
 						<dayOfMonthWidth type="abbreviated">
-							<dayOfMonth ordinal="zero">{0}</dayOfMonth>
 							<dayOfMonth ordinal="one">{0}</dayOfMonth>
 							<dayOfMonth ordinal="two">{0}</dayOfMonth>
 							<dayOfMonth ordinal="few">{0}</dayOfMonth>
@@ -7127,7 +7125,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} ден</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">{0} дена</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="zero">Завийте надясно по {0}-тната пресечка.</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="one">Завийте надясно по {0}-вата пресечка.</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="two">Завийте надясно по {0}-рата пресечка.</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="few">Завийте надясно по {0}-тата пресечка.</ordinalMinimalPairs>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -1407,7 +1407,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayOfMonth ordinal="one">{0}</dayOfMonth>
 							<dayOfMonth ordinal="two">{0}</dayOfMonth>
 							<dayOfMonth ordinal="few">{0}</dayOfMonth>
-							<dayOfMonth ordinal="many">{0}</dayOfMonth>
 							<dayOfMonth ordinal="other">{0}</dayOfMonth>
 						</dayOfMonthWidth>
 					</dayOfMonthContext>
@@ -1819,7 +1818,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayOfMonth ordinal="one">{0}</dayOfMonth>
 							<dayOfMonth ordinal="two">{0}</dayOfMonth>
 							<dayOfMonth ordinal="few">{0}</dayOfMonth>
-							<dayOfMonth ordinal="many">{0}</dayOfMonth>
 							<dayOfMonth ordinal="other">{0}</dayOfMonth>
 						</dayOfMonthWidth>
 					</dayOfMonthContext>
@@ -7133,7 +7131,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<ordinalMinimalPairs ordinal="one">Завийте надясно по {0}-вата пресечка.</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="two">Завийте надясно по {0}-рата пресечка.</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="few">Завийте надясно по {0}-тата пресечка.</ordinalMinimalPairs>
-			<ordinalMinimalPairs ordinal="many">Завийте надясно по {0}-ата пресечка</ordinalMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">Завийте надясно по {0}-ата пресечка.</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>


### PR DESCRIPTION
Per Update Bulgarian ordinals rules (#5884) the 'many' was removed

remove this data because it was causing conflicts

CLDR-19627

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
