### PR TITLE
CLDR-19616 vxml: drop colliding emoji in qu

### DIFF
--- a/common/annotations/qu.xml
+++ b/common/annotations/qu.xml
@@ -2557,8 +2557,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🛬" type="tts">lata pʼisqu chayana</annotation>
 		<annotation cp="🪂">paracaídas | pawaypaq</annotation>
 		<annotation cp="🪂" type="tts">paracaídas</annotation>
-		<annotation cp="💺">silla | tiyana</annotation>
-		<annotation cp="💺" type="tts">tiyana</annotation>
+		<!-- <annotation cp="💺">silla | tiyana</annotation>
+		<annotation cp="💺" type="tts">tiyana</annotation> -->
 		<annotation cp="🚁">carru | helicoptero</annotation>
 		<annotation cp="🚁" type="tts">helicoptero</annotation>
 		<annotation cp="🚟">ferrocarril | warkhusqa</annotation>
@@ -3199,8 +3199,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📤" type="tts">lluqsina wandiha</annotation>
 		<annotation cp="📥">bandeja | caja | carta | chaskiy | chusaq | correo | correo electrónico | inbox</annotation>
 		<annotation cp="📥" type="tts">bandeja de entrada</annotation>
-		<annotation cp="📦">apachiy | caja | entrega | paquete | parcela | willanakuy</annotation>
-		<annotation cp="📦" type="tts">qipi</annotation>
+		<!-- <annotation cp="📦">apachiy | caja | entrega | paquete | parcela | willanakuy</annotation>
+		<annotation cp="📦" type="tts">qipi</annotation> -->
 		<annotation cp="📫">bandera | caja de correo | correo | correo caja | wichasqa | willanakuy | wisqʼasqa</annotation>
 		<annotation cp="📫" type="tts">wisq’asqa correo caja hoqarisqa banderayuq</annotation>
 		<annotation cp="📪">bandera | caja de correo | correo | correo caja | uraykachisqa | wisqʼasqa</annotation>
@@ -3948,8 +3948,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🪋">apokalipsis | espacio | gravedad nisqa | nina bola | qaqa | quyllur | urmaykuspa</annotation>
 		<annotation cp="🪋" type="tts">meteoro nisqa</annotation>
 		<annotation cp="🪌">allichay | borrar | deshacer | frotar | hurquy | pantay | qillqay | siqʼi</annotation>
-		<annotation cp="🪌" type="tts">pichana</annotation>
-		<annotation cp="🪍">hapʼiy | huñuy | malla | tuqlla</annotation>
+		<!-- <annotation cp="🪌" type="tts">pichana</annotation>
+		<annotation cp="🪍">hapʼiy | huñuy | malla | tuqlla</annotation> -->
 		<annotation cp="🪍" type="tts">llika hapinayuq</annotation>
 		<annotation cp="🫌">frágil | kurucha | metamorfosis nisqamanta | migración | suyakuy | tikray | urucha</annotation>
 		<annotation cp="🫌" type="tts">monarca pillpintu</annotation>


### PR DESCRIPTION
- retained the 'older' translation, dropped the 'newer' one

CLDR-19616

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
