### PR TITLE
CLDR-18942 vxml: improved aleutian warning

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -16,6 +16,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.PathHeader;
@@ -327,6 +328,14 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
     public CheckDisplayCollisions(Factory factory) {
         super(factory);
     }
+
+    /** timezones to exclude */
+    private static final Set<String> KNOWNISSUE_CLDR_19685_ZONES =
+            ImmutableSet.of("Hawaii", "Hawaii_Aleutian");
+
+    /** locales to exclude (besides non-TC) */
+    private static final Set<String> KNOWNISSUE_CLDR_19685_LOCS =
+            ImmutableSet.of("ps_PK", "be_TARASK", "sr_Cyrl_BA");
 
     @Override
     @SuppressWarnings("unused")
@@ -792,7 +801,11 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
                         && collidingZoneTypes.contains("generic-short")) {
                     thisErrorType = CheckStatus.warningType;
                 }
-            } else if (thisZone.startsWith("Hawaii") && collidingZone.startsWith("Hawaii")) {
+            } else if (KNOWNISSUE_CLDR_19685_ZONES.contains(thisZone)
+                    && KNOWNISSUE_CLDR_19685_ZONES.contains(collidingZone)
+                    && !thisZone.equals(collidingZone)
+                    && (!SubmissionLocales.isTcLocale(CLDRLocale.getInstance(getLocaleID()))
+                            || KNOWNISSUE_CLDR_19685_LOCS.contains(getLocaleID()))) {
                 thisErrorType = CheckStatus.warningType;
                 message = "CLDR-19685: warning for v49:" + message;
             }


### PR DESCRIPTION
- restrict to non-TC locales OR a small exclusion list of sublocales
- clamp down the zone id specifically (set instead of a prefix)

CLDR-18942

- [ ] This PR completes the ticket.

@AEApple does this address your concerns in #5986 ?


<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
