### PR TITLE
CLDR-19616 vxml: fix quc

### DIFF
--- a/common/main/quc.xml
+++ b/common/main/quc.xml
@@ -44,7 +44,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</orientation>
 	</layout>
 	<characters>
-		<exemplarCharacters>[a {aa} {bʼ} {ch} {chʼ} e {ee} h i {ii} j k {kʼ} l m n o {oo} p q {qʼ} r s t {tz} {tzʼ} {tʼ} u {uu} w x y ʼ]</exemplarCharacters>
+		<exemplarCharacters>[a {aa} {bʼ} {ch} {chʼ} e {ee} i {ii} j k {kʼ} l m n o {oo} p q {qʼ} r s t {tz} {tzʼ} {tʼ} u {uu} w x y ʼ]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[c d f g h ñ z]</exemplarCharacters>
 		<exemplarCharacters type="index">[AÄ {Bʼ} {CH} {CHʼ} E I J K {Kʼ} L M N O P Q {Qʼ} R S T {TZ} {TZʼ} {Tʼ} U V W X Y]</exemplarCharacters>
 		<exemplarCharacters type="numbers" draft="contributed">↑↑↑</exemplarCharacters>


### PR DESCRIPTION
per feedback, 'h' should be in aux only

CLDR-19616

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
