### PR TITLE
CLDR-19600 auto cldr-modify should run additional tools

### DIFF
--- a/.github/workflows/cldr-modify.yml
+++ b/.github/workflows/cldr-modify.yml
@@ -4,13 +4,15 @@ name: CLDR Modify
 
 env:
   CLDR_DIR: ${{ github.workspace }}
-  AUTO_BRANCH: auto/cldrmodify/main
+  AUTO_BRANCH_BASE: auto/cldrmodify
   AUTO_REMOTE: origin
   JDK_VERSION: 21
+  JVM_OPTS: -Dfile.encoding=utf-8 -Dexec.cleanupDaemonThreads=false -DCLDR_GITHUB_ANNOTATIONS=true
 
 on:
   push:
     # only run this on certain branch(s)
+    # this can handle other branches, the auto branch will be auto/cldrmodify/some/branch etc
     branches:
       - 'main'
 jobs:
@@ -53,7 +55,7 @@ jobs:
           function cldrmodify() {
             echo "- :gear: Running CLDRModify " $1 >> $GITHUB_STEP_SUMMARY
             echo "::group::CLDRModify $1"
-            mvn -s .github/workflows/mvn-settings.xml -B "-DCLDR_DIR=${CLDR_DIR}" --file=tools/pom.xml -pl cldr-code -Dfile.encoding=utf-8 exec:java -Dexec.mainClass=org.unicode.cldr.tool.CLDRModify "-Dexec.args=-I -s$1"
+            mvn -s .github/workflows/mvn-settings.xml -B "-DCLDR_DIR=${CLDR_DIR}" --file=tools/pom.xml -pl cldr-code ${JVM_OPTS} exec:java -Dexec.mainClass=org.unicode.cldr.tool.CLDRModify "-Dexec.args=-I -s$1"
             echo "::endgroup::"
           }
           ## CLDRModify passes here.
@@ -70,12 +72,33 @@ jobs:
         env:
           CLDR_DIR: ${{ github.workspace }}
           LANG: en_US.UTF-8
-      - name: Run GenerateTestData
-        run: >
-          mvn -s .github/workflows/mvn-settings.xml -B --file tools/pom.xml -pl cldr-code
-          exec:java -Dexec.mainClass=org.unicode.cldr.tool.GenerateTestData
-          -Dexec.cleanupDaemonThreads=false
-          -DCLDR_DIR=$(pwd)
+      - name: Run other tools
+        run: |
+          # setup some scripts
+          # usage: cldr-tool class[.package] arg
+          function cldr-tool() {
+            mainClass=$1
+            shift
+            arg=$1
+            if [[ "" == $(echo "${mainClass}" | tr -c -d .) ]];
+            then
+              # no package given - use default package
+              mainClass=org.unicode.cldr.tool.${mainClass}
+            fi
+            echo "- :gear: Running ${mainClass}" ${arg} >> $GITHUB_STEP_SUMMARY
+            echo "::group::${mainClass}" ${arg}
+            mvn -s .github/workflows/mvn-settings.xml -B "-DCLDR_DIR=${CLDR_DIR}" --file=tools/pom.xml -pl cldr-code ${JVM_OPTS} exec:java -Dexec.mainClass=${mainClass} "-Dexec.args=${arg}"
+            echo "::endgroup::"
+          }
+          ## OK, now run the actual tools
+
+          # update common/properties/coverageLevels.txt
+          # this will also generate charts, but that can be ignored
+          cldr-tool ShowLocaleCoverage
+          # update other test data
+          cldr-tool GenerateTestData
+          cldr-tool GenerateLocaleIDTestData
+          cldr-tool GeneratePersonNameTestData
       - name: Verify git Changes
         id: gitstatus
         run: |
@@ -91,15 +114,23 @@ jobs:
         run: |
           set -euxo pipefail
           git config user.name 'cldr-modify.yml [bot]'
-          git config user.email 'unicode-org@users.noreply.github.com'
+          git config user.email "${GITHUB_REPOSITORY_OWNER}@users.noreply.github.com"
+          # add only certain directories.
+          # This is a failsafe to prevent any other changes.
+          # Update this if processes change.
+          git add common/annotations
           git add common/main
+          git add common/properties
+          git add common/subdivisions
           git add common/testData
           bash .github/workflows/cldr-modify-commit.sh cldr-modify.yml CLDRModify
-          git checkout -b ${AUTO_BRANCH}
+          git checkout -b ${AUTO_BRANCH_BASE}/${GITHUB_REF_NAME}
           # reset origin using token
-          git remote set-url ${AUTO_REMOTE} "https://unicode-org:${GH_TOKEN}@github.com/unicode-org/cldr.git"
+          git remote set-url ${AUTO_REMOTE} "https://${GITHUB_REPOSITORY_OWNER}:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           # push ONLY if files under common/ are out of date.
-          bash .github/workflows/cldr-modify-push-if-needed.sh ${AUTO_REMOTE} ${AUTO_BRANCH} common/
+          bash .github/workflows/cldr-modify-push-if-needed.sh ${AUTO_REMOTE} ${AUTO_BRANCH_BASE}/${GITHUB_REF_NAME} common/
+          echo "Note: If any stray files show up here, update cldr-modify.yml"
+          git status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Open PR
@@ -107,13 +138,12 @@ jobs:
         run: |
           set -euxo pipefail
           ( gh pr create \
-            --title $(git log --pretty=%s HEAD | head -1 | cut -d' ' -f1)" auto: CLDRModify" \
-            --body $(git log --pretty=%s HEAD | head -1 | cut -d' ' -f1)" Automatically created, see <https://cldr.unicode.org/development/auto-pr>" \
-            --base 'main' \
+            --title $(git log --pretty=%s HEAD | head -1 | cut -d' ' -f1)" auto: ${GITHUB_REF_NAME} CLDRModify" \
+            --body  $(git log --pretty=%s HEAD | head -1 | cut -d' ' -f1)" Automatically created, see <https://cldr.unicode.org/development/auto-pr>" \
+            --base  ${GITHUB_REF_NAME} \
             --label 'automatic' \
-            --head ${AUTO_BRANCH} \
+            --head  ${AUTO_BRANCH_BASE}/${GITHUB_REF_NAME} \
             | tee -a $GITHUB_STEP_SUMMARY ) || ( echo "# Could not create PR - may already exist" | tee -a $GITHUB_STEP_SUMMARY )
-#            --reviewer 'unicode-org/cldr-brs' \
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
CLDR-19600

- branch portable: can add another branch (such as vxml or even a feature branch) and it will run and keep the PR separate. 
- repo portable: I can push it to my test repo and it will run there. This lets me iterate without causing conflicts.

- sample run: https://github.com/srl295/cldr/pull/30
- runs additional tools:
  - ShowLocaleCoverage
  - GenerateTestData
  - GenerateLocaleIDTestData
  - GeneratePersonNameTestData

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
