### PR TITLE
CLDR-19143 Omit non-Basic non-ICU locales in production

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -61,6 +61,7 @@ public class GenerateProductionData {
     private static boolean ADD_SIDEWAYS = false;
     private static boolean ADD_ROOT = false;
     private static boolean INCLUDE_COMPREHENSIVE = false;
+    private static boolean KEEP_PRE_BASIC = false;
     private static boolean CONSTRAINED_RESTORATION = false;
 
     private static final Set<String> NON_XML =
@@ -71,6 +72,7 @@ public class GenerateProductionData {
                     "collation"); // don't want to "clean up", makes format difficult to use
     private static final SupplementalDataInfo SDI =
             CLDRConfig.getInstance().getSupplementalDataInfo();
+    private static Set<String> skippedPreBasicLocales = new TreeSet<>();
 
     enum MyOptions {
         sourceDirectory(
@@ -112,6 +114,12 @@ public class GenerateProductionData {
                 new Params()
                         .setHelp("exclude comprehensive paths — otherwise just to modern level")
                         .setDefault("true")
+                        .setMatch("true|false")),
+        keepPreBasic(
+                new Params()
+                        .setHelp(
+                                "keep non-ICU locales below Basic coverage — otherwise they are skipped")
+                        .setDefault("false")
                         .setMatch("true|false")),
         verbose(new Params().setHelp("verbose debugging messages")),
         Debug(new Params().setHelp("debug")),
@@ -162,6 +170,7 @@ public class GenerateProductionData {
         // constraints
         INCLUDE_COMPREHENSIVE =
                 "true".equalsIgnoreCase(MyOptions.includeComprehensive.option.getValue());
+        KEEP_PRE_BASIC = "true".equalsIgnoreCase(MyOptions.keepPreBasic.option.getValue());
         CONSTRAINED_RESTORATION =
                 "true".equalsIgnoreCase(MyOptions.constrainedRestoration.option.getValue());
 
@@ -196,6 +205,11 @@ public class GenerateProductionData {
         for (File source : specialDirectories.keySet()) {
             File dest = specialDirectories.get(source);
             doubleCheckSpecialPaths(source, dest);
+        }
+        if (!skippedPreBasicLocales.isEmpty()) {
+            System.out.println(
+                    "The following non-ICU pre-Basic locales were skipped: "
+                            + skippedPreBasicLocales);
         }
     }
 
@@ -254,7 +268,8 @@ public class GenerateProductionData {
             if (FILE_MATCH != null && !FILE_MATCH.reset(localeId).matches()) {
                 return false;
             }
-            if (localeShouldBeSkipped(localeId)) {
+            if (!KEEP_PRE_BASIC && localeIsPreBasicNonIcu(localeId)) {
+                skippedPreBasicLocales.add(localeId);
                 return false;
             }
             return copyOneFileAndReturnIsEmpty(
@@ -278,8 +293,9 @@ public class GenerateProductionData {
     private static final Set<ULocale> ICU_Locales =
             ImmutableSet.copyOf(ULocale.getAvailableLocales());
 
-    private static boolean localeShouldBeSkipped(String localeId) {
-        return !ICU_Locales.contains(new ULocale(localeId))
+    private static boolean localeIsPreBasicNonIcu(String localeId) {
+        return !localeId.equals(LocaleNames.ROOT)
+                && !ICU_Locales.contains(new ULocale(localeId))
                 && !CalculatedCoverageLevels.getInstance().isLocaleAtLeastBasic(localeId);
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -296,7 +296,7 @@ public class GenerateProductionData {
     private static boolean localeIsPreBasicNonIcu(String localeId) {
         return !localeId.equals(LocaleNames.ROOT)
                 && !ICU_Locales.contains(new ULocale(localeId))
-                && !CalculatedCoverageLevels.getInstance().isLocaleAtLeastBasic(localeId);
+                && !CalculatedCoverageLevels.getInstance().isLocaleReallyAtLeastBasic(localeId);
     }
 
     private static void copyDirectory(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.ibm.icu.util.ICUUncheckedIOException;
 import com.ibm.icu.util.Output;
+import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -31,6 +32,7 @@ import org.unicode.cldr.util.AnnotationUtil;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CalculatedCoverageLevels;
 import org.unicode.cldr.util.CldrNumberingSystem;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.DtdType;
@@ -252,6 +254,9 @@ public class GenerateProductionData {
             if (FILE_MATCH != null && !FILE_MATCH.reset(localeId).matches()) {
                 return false;
             }
+            if (localeShouldBeSkipped(localeId)) {
+                return false;
+            }
             return copyOneFileAndReturnIsEmpty(
                     localeId, sourceFile, destinationFile, factory, stats);
         } else {
@@ -268,6 +273,14 @@ public class GenerateProductionData {
             copyFiles(sourceFile, destinationFile);
             return false;
         }
+    }
+
+    private static final Set<ULocale> ICU_Locales =
+            ImmutableSet.copyOf(ULocale.getAvailableLocales());
+
+    private static boolean localeShouldBeSkipped(String localeId) {
+        return !ICU_Locales.contains(new ULocale(localeId))
+                && !CalculatedCoverageLevels.getInstance().isLocaleAtLeastBasic(localeId);
     }
 
     private static void copyDirectory(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CalculatedCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CalculatedCoverageLevels.java
@@ -62,6 +62,15 @@ public class CalculatedCoverageLevels {
      */
     public boolean isLocaleAtLeastBasic(String locale) {
         return levels.containsKey(locale);
+        // return isLocaleReallyAtLeastBasic(locale);
+        // TODO: fix this function and/or its callers and/or the data. If this function
+        // is made the same as isLocaleReallyAtLeastBasic, four tests fail with current data.
+        // Reference: https://unicode-org.atlassian.net/browse/CLDR-19722
+    }
+
+    public boolean isLocaleReallyAtLeastBasic(String localeId) {
+        Level level = getEffectiveCoverageLevel(localeId);
+        return level != null && level.isAtLeast(Level.BASIC);
     }
 
     /** Read the coverage levels from the standard file */


### PR DESCRIPTION
-New GenerateProductionData.localeIsPreBasicNonIcu

-Skip if not in ICU, not root, and !isLocaleReallyAtLeastBasic

-Add option -k: keep non-ICU locales below Basic coverage — otherwise they are skipped

-Report locales that were skipped (The following non-ICU pre-Basic locales were skipped: ...)

-New function CalculatedCoverageLevels.isLocaleReallyAtLeastBasic, TODO comment linking new ticket for isLocaleAtLeastBasic

CLDR-19143

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
