### PR TITLE
CLDR-19713 fix a known issue and bump another

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
@@ -287,7 +287,7 @@ public class TestAnnotations extends TestFmwkPlus {
 
     // TODO CLDR-16947 - this test should migrate into
     // CheckDisplayCollisions-run-against-derived-annotations (see isuse)
-    // TODO CLDR-19189
+    // TODO CLDR-19714 formerly CLDR-19189
     public void TestUniqueness() {
         Set<String> locales = new TreeSet<>();
         locales.add("en");
@@ -305,7 +305,7 @@ public class TestAnnotations extends TestFmwkPlus {
                         .collect(Collectors.toCollection(() -> new TreeSet<>()));
         if (!problems.isEmpty()) {
             if (logKnownIssue(
-                    "CLDR-19189",
+                    "CLDR-19714", // formerly: CLDR-19189
                     "cased collision in annotations:\n" + String.join("\n", problems))) {
                 return;
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -111,12 +111,12 @@ public class TestExampleGenerator extends TestFmwk {
                 "〖❬2,34 ❭value-other〗〖❬3,45 ❭value-other〗",
                 "〖❬2,34❭_❬dollars des États-Unis❭〗〖❬2,34❭_❬euros❭〗〖❬3,45❭_❬dollars des États-Unis❭〗〖❬3,45❭_❬euros❭〗"
             },
-            {"en", "one", "〖❬1 ❭Bermudan dollar〗", "〖❬1❭ ❬US dollar❭〗〖❬1❭ ❬euro❭〗"},
+            {"en", "one", "〖❬1 ❭value-one〗", "〖❬1❭_❬US dollar❭〗〖❬1❭_❬euro❭〗"},
             {
                 "en",
                 "other",
-                "〖❬1.23 ❭Bermudan dollars〗〖❬0.00 ❭Bermudan dollars〗",
-                "〖❬1.23❭ ❬US dollars❭〗〖❬1.23❭ ❬euros❭〗〖❬0.00❭ ❬US dollars❭〗〖❬0.00❭ ❬euros❭〗"
+                "〖❬1.23 ❭value-other〗〖❬0.00 ❭value-other〗",
+                "〖❬1.23❭_❬US dollars❭〗〖❬1.23❭_❬euros❭〗〖❬0.00❭_❬US dollars❭〗〖❬0.00❭_❬euros❭〗"
             },
         };
         String sampleCurrencyPatternPrefix =


### PR DESCRIPTION
CLDR-19713

### CLDR-19409
- fix TestExampleGenerator
- this was just a bug, the prior caching was broken (see CLDR-19409), just forgot to update the test For 

### CLDR-19189
- dup annotations 
- kick the can along and bump to [CLDR-19714](https://unicode-org.atlassian.net/browse/CLDR-19714)


- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true


[CLDR-19714]: https://unicode-org.atlassian.net/browse/CLDR-19714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ