### PR TITLE
CLDR-13465 fix typo in test runner that was producing corrupt PR summaries

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/dev/test/TestFmwk.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/dev/test/TestFmwk.java
@@ -646,7 +646,7 @@ public class TestFmwk extends AbstractTestLog {
             localParams.log.println("\n<< " + errorCount + " TEST(S) FAILED >>");
         } else if (params.testCount > 0) {
             localParams.log.println("\n<< ALL " + params.testCount + " TESTS PASSED >>");
-            writeStepSummary("- :white_check_mark: ALL \" + params.testCount + \" TESTS PASSED");
+            writeStepSummary("- :white_check_mark: ALL " + params.testCount + " TESTS PASSED");
         } else if (params.listlevel == 0) {
             // unless in list mode
             final String ALL_TESTS_SKIPPED =


### PR DESCRIPTION
CLDR-13465

- [X] This PR completes the ticket.


After:

> - :white_check_mark: ALL 1 TESTS PASSED

Before, literally:

> … `" + params.testCount + "`


<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
