### PR TITLE
CLDR-19600 add more tools to CLDRModify action

### DIFF
--- a/.github/workflows/cldr-modify.yml
+++ b/.github/workflows/cldr-modify.yml
@@ -94,6 +94,9 @@ jobs:
 
           cldr-tool GeneratePluralRanges
           cldr-tool GeneratedPluralSamples
+          cldr-tool GenerateDtd
+          cldr-tool GenerateValidityXml
+
           # update common/properties/coverageLevels.txt
           # this will also generate charts, but that can be ignored
           cldr-tool ShowLocaleCoverage

--- a/.github/workflows/cldr-modify.yml
+++ b/.github/workflows/cldr-modify.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
-          fetch-depth: 1
+          fetch-depth: 0  # Needed for cldr-archive
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -91,7 +91,8 @@ jobs:
             echo "::endgroup::"
           }
           ## OK, now run the actual tools
-
+          mkdir -vp ../cldr-archive
+          cldr-tool CheckoutArchive
           cldr-tool GeneratePluralRanges
           cldr-tool GeneratedPluralSamples
           cldr-tool GenerateDtd

--- a/.github/workflows/cldr-modify.yml
+++ b/.github/workflows/cldr-modify.yml
@@ -92,6 +92,8 @@ jobs:
           }
           ## OK, now run the actual tools
 
+          cldr-tool GeneratePluralRanges
+          cldr-tool GeneratedPluralSamples
           # update common/properties/coverageLevels.txt
           # this will also generate charts, but that can be ignored
           cldr-tool ShowLocaleCoverage
@@ -138,7 +140,7 @@ jobs:
         run: |
           set -euxo pipefail
           ( gh pr create \
-            --title $(git log --pretty=%s HEAD | head -1 | cut -d' ' -f1)" auto: ${GITHUB_REF_NAME} CLDRModify" \
+            --title $(git log --pretty=%s HEAD | head -1 | cut -d' ' -f1)" auto: ${GITHUB_REF_NAME} ${GITHUB_WORKFLOW}" \
             --body  $(git log --pretty=%s HEAD | head -1 | cut -d' ' -f1)" Automatically created, see <https://cldr.unicode.org/development/auto-pr>" \
             --base  ${GITHUB_REF_NAME} \
             --label 'automatic' \
@@ -146,4 +148,6 @@ jobs:
             | tee -a $GITHUB_STEP_SUMMARY ) || ( echo "# Could not create PR - may already exist" | tee -a $GITHUB_STEP_SUMMARY )
         env:
           GH_TOKEN: ${{ github.token }}
-
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true

--- a/docs/site/development/auto-pr.md
+++ b/docs/site/development/auto-pr.md
@@ -49,6 +49,8 @@ Source: <https://github.com/unicode-org/cldr/blob/main/.github/workflows/cldr-mo
 This process runs CLDRModify against several directories.
 Search for "CLDRModify passes here" in the .yml file to update.
 
+Several other CLDR tools are also run by this action.
+
 ### SpecFix
 
 Source: <https://github.com/unicode-org/cldr/blob/main/.github/workflows/spec.yml>


### PR DESCRIPTION
For the CldrModify / tools github action :

- adds GeneratePluralRanges and GeneratedPluralSamples
- also, make sure that the CLDRModify action interrupts an earlier run if a later run gets started.
- adds GenerateDtd
- adds GenerateValidityXml

CLDR-19600

- [X] This PR completes the ticket.

See this commit for an example run against current main: https://github.com/srl295/cldr/pull/30/changes/9829dd257d2d0d41d7bd17adb4a187da2e72c48a



<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
