### PR TITLE
CLDR-19720 Akan (ak) should only have one encompassed language

### DIFF
--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -134,7 +134,7 @@
 			<variable id='$internet' type='regex'>[A-Z]+|XN--[A-Z0-9]+([-][A-Z0-9]+)*</variable>
 			<variable id='$coverageSpecial' type='choice'>* Cldr:modern</variable>
 			<variable id='$collationPrivate' type='choice'>digits-after private-unihan private-kana private-pinyin</variable>
-			<variable id='$languageDeprecated' type='choice'>sh tw tl fat in mo ji iw jw</variable>
+			<variable id='$languageDeprecated' type='choice'>sh tw tl in mo ji iw jw</variable>
 			<variable id='$localeOrDeprecated'>$locale|$languageDeprecated</variable>
 			<variable id='$name' type='regex'>[a-zA-Z]+([-_][a-zA-Z]+)*[.]?|\d+|\([A-Z][a-z]+\)</variable>
 			<variable id='$defaultCurrencyInfo' type='choice'>DEFAULT</variable>

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -263,7 +263,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="ekk" replacement="et" reason="macrolanguage"/> <!-- Standard Estonian ⇒ Estonian -->
 			<languageAlias type="emk" replacement="man" reason="macrolanguage"/> <!-- Maninkakan, Eastern ⇒ Mandingo -->
 			<languageAlias type="esk" replacement="ik" reason="macrolanguage"/> <!-- Northwest Alaska Inupiatun ⇒ Inupiaq -->
-			<languageAlias type="fat" replacement="ak" reason="macrolanguage"/> <!-- Fanti ⇒ Akan -->
 			<languageAlias type="fuc" replacement="ff" reason="macrolanguage"/> <!-- Pular ⇒ Fulah -->
 			<languageAlias type="gaz" replacement="om" reason="macrolanguage"/> <!-- Oromo, West Central ⇒ Oromo -->
 			<languageAlias type="gbo" replacement="grb" reason="macrolanguage"/> <!-- Northern Grebo ⇒ Grebo -->

--- a/common/validity/language.xml
+++ b/common/validity/language.xml
@@ -12,7 +12,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<idValidity>
-		<id type='language' idStatus='regular'>		<!-- 7971 items -->
+		<id type='language' idStatus='regular'>		<!-- 7972 items -->
 			aa aaa~i aak~l aan~q aas~x aaz
 			ab aba~j abl~z
 			aca~b acd~f ach~i ack~n acp~z
@@ -138,7 +138,7 @@
 			ext
 			eya eyo
 			eza eze
-			fa faa~b fad faf~n fap far fau fax~z
+			fa faa~b fad faf~n fap far fat~u fax~z
 			fbl
 			fcs
 			fer
@@ -625,13 +625,13 @@
 			mis mul
 			zxx
 		</id>
-		<id type='language' idStatus='deprecated'>		<!-- 300 items -->
+		<id type='language' idStatus='deprecated'>		<!-- 299 items -->
 			aam adp agp ais ajp ajt~u als aoh arb asd aue ayr ayx~y azj
 			baz bbz bcc bcl bgm bh bhk bic bih bij bjd bjq bkb blg bmy bpb btb btl bxk bxr bxx byy
 			cbe cbh cca ccq cdg cjr cka cld cls cmk cmn cnr coy cqu cug cum cwd
 			daf dap dek dgo dgu dha dhd dik diq dit djl dkl drh drr drw dud duj dwl
 			ekc ekk elp emk emo esk
-			fat fuc
+			fuc
 			gav gaz gbc gbo gfx ggn~o ggr gio gji gli gno gom gti gug guv gya
 			hdn hea him hrr
 			iap ibi ike ill ilw ime in iw izi

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -143,7 +143,9 @@ public class TestValidity extends TestFmwkPlus {
                     "dzd",
                     "knn",
                     // 2025
-                    "mnk");
+                    "mnk",
+                    // 2026
+                    "fat");
     static final Set<String> ALLOWED_MISSING =
             ImmutableSet.of(LocaleNames.ROOT, "POSIX", "REVISED", "SAAHO", "CNX");
     static final Set<String> ALLOWED_REGULAR_TO_SPECIAL = ImmutableSet.of("Zanb", "Zinh", "Zyyy");


### PR DESCRIPTION
Removed Fanti (fat) language alias mapping to macrolanguage Akan (ak).

CLDR-19720

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
