### PR TITLE
CLDR-17375 Add no as a macrolanguage

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -306,7 +306,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="him" replacement="srx" reason="macrolanguage"/> <!-- Himachali ⇒ Sirmauri (= Pahari, Himachali) -->
 			<languageAlias type="bh" replacement="bho" reason="macrolanguage"/> <!-- Bihari ⇒ Bhojpuri -->
 			<languageAlias type="cls" replacement="sa" reason="macrolanguage"/> <!-- Classical Sanskrit ⇒ Sanskrit -->
-			<!-- Special case <languageAlias type="nb" replacement="no" reason="macrolanguage"/> <! - - Norwegian Bokmål ⇒ Norwegian -->
+			<languageAlias type="nb" replacement="no" reason="macrolanguage"/> <!-- Norwegian Bokmål ⇒ Norwegian -->
 			<!-- Special case <languageAlias type="sr" replacement="sh" reason="macrolanguage"/> <! - - Serbian ⇒ Serbo-Croatian -->
 
 			<languageAlias type="prs" replacement="fa_AF" reason="overlong"/> <!-- Dari ⇒ Farsi (Afganistan) -->


### PR DESCRIPTION
Add no as a macrolanguage where the encompassed language is nb

Check test failures

CLDR-_____

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
