### PR TITLE
CLDR-19488 Fix typo

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -1798,7 +1798,7 @@ The directory [common/validity](https://github.com/unicode-org/cldr/blob/main/co
 * **private_use** — codes that, for CLDR, are considered private use. Note that some private-use codes in a source standard such as BCP 47 have defined CLDR semantics, and are considered regular codes. For more information, see _[Private Use Codes](#Private_Use_Codes)._
 * **reserved** — codes that are private use in a source standard, but are reserved for future use as regular codes by CLDR.
 
-The list of subtags for each idStatus use a compact format as a space-delimited list of StringRanges, as defined in [Section String Range](#String_Range)._ The separator for each StringRange is a "~".
+The list of subtags for each idStatus use a compact format as a space-delimited list of StringRanges, as defined in _[Section String Range](#String_Range)._ The separator for each StringRange is a "~".
 
 Each measure unit is a sequence of subtags, such as “angle-arc-minute”. The first subtag provides a general “category” of the unit.
 


### PR DESCRIPTION
CLDR-19488

#5849 left a dangling Markdown `_`. I suppose [CLDR-19488](https://unicode-org.atlassian.net/browse/CLDR-19488) should be reopened for this PR.

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true


[CLDR-19488]: https://unicode-org.atlassian.net/browse/CLDR-19488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ