### PR TITLE
CLDR-19694 Add alt name for Nauru: Naoero 

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1173,6 +1173,7 @@ annotations.
 			<territory type="NO">Norway</territory>
 			<territory type="NP">Nepal</territory>
 			<territory type="NR">Nauru</territory>
+			<territory type="NR" alt="variant">Naoero</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">New Zealand</territory>
 			<territory type="NZ" alt="variant">Aotearoa New Zealand</territory>


### PR DESCRIPTION
Naoero is the official name now, but (for now at least) Nauru remains the most common.

CLDR-19694

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
