### PR TITLE
CLDR-19476 root search: no context for middle dot

### DIFF
--- a/common/collation/root.xml
+++ b/common/collation/root.xml
@@ -23,6 +23,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					# root search, suppress contractions for Thai, Lao, Tai Viet, New Tai Lue
 					# same as UCD property Logical_Order_Exception
 					[suppressContractions [เ-ไ ເ-ໄ ꪵ ꪶ ꪹ ꪻ ꪼ\u19B5-\u19B7\u19BA]]
+					# CLDR-19476: Suppress L/l + middle dot prefix so a standalone
+					# MIDDLE DOT (U+00B7) or GREEK ANO TELEIA (U+0387)
+					# is findable in any context.
+					[suppressContractions [··]]
 					# root search rules for Symbols
 					&'='<'≠'
 					# root search rules for Arabic, Thai


### PR DESCRIPTION
Root search tailoring:
Suppress context-sensitive matching for middle dot, and the canonically equivalent ano teleia, so that they are always findable on their own.

CLDR-19476

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
