### PR TITLE
CLDR-19760 Exclude commits for reverted change

### DIFF
--- a/.github/COMMIT_METADATA.md
+++ b/.github/COMMIT_METADATA.md
@@ -68,3 +68,8 @@
 - 13db39076da1999260ad5ad85b6fc2bf8050756f CLDR-17141 kbd: fixed in 44
 - 09c8e1082808f97608c39062897a7b844d50c18e CLDR-17230 emoji: fixed in 44.1
 - 657e6e996b88b891132db29cc4fc61c36f174689 CLDR-17141 kbd: fixed in 44
+
+# SKIP v49
+
+- b4ab103ffb6baa02a6c970f04a237484d80ac19d CLDR-14086 Handle more raw quotes (change reverted)
+- 68b0098e39037a11b98be3feb7de280d27a00ff1 CLDR-14086 Handle more raw quotes (original change which was reverted)

--- a/docs/site/development/cldr-big-red-switch/commit-checker.md
+++ b/docs/site/development/cldr-big-red-switch/commit-checker.md
@@ -48,3 +48,7 @@ The Commit Checker report is separated into different categories. Commits can be
 2. Closed Issues with Commit Policy Problems, Commits without Jira Issue Tag, and Commits with Jira Issue Not Found (TBD)
 3. Tickets in **Commits with Open Jira Issue** only need to be actioned on near the end of the release, although it is better to close tickets out as soon as they're complete to make sure that tickets aren't split across releases unnecessarily.
 4. Tickets in **Issue is under Review** need to have review complete before the release is announced.
+
+### Excluding a commit
+
+You can exclude a commit by adding it to the .github/COMMIT_METADATA.md file in the CLDR repo. See file for instructions.


### PR DESCRIPTION
CLDR-19760

- Exclude commits for reverted change
- Update Commit Checker instructions for how to exclude a commit

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
