### PR TITLE
CLDR-19100 Fix Hungarian GMT

### DIFF
--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -5331,7 +5331,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="GMT">
 				<long>
-					<standard>greenwichi középidő, téli idő</standard>
+					<standard>greenwichi középidő</standard>
 				</long>
 				<short>
 					<standard>GMT</standard>


### PR DESCRIPTION
CLDR-19100

This translation erroneously includes "winter time".

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
