### PR TITLE
CLDR-19649 Clarify in UTS #35 Part 3 that explicit ISO 4217 currency code formatting uses `<currencyFormat>`

### DIFF
--- a/docs/ldml/tr35-modifications.md
+++ b/docs/ldml/tr35-modifications.md
@@ -48,6 +48,9 @@ This is a partial document, describing only the changes to the LDML since the pr
 * [`numberFormat`](tr35-numbers.md#Number_Formats) Revise numberFormat description
 <!-- CLDR-18963 -->
 
+* [`currencyFormats`](tr35-numbers.md#Currency_Formats) Clarified that formatting ISO 4217 currency codes uses the standard `<currencyFormat>` pattern (`alt="alphaNextToNumber"` if present)
+<!-- CLDR-19649 -->
+
 * [`dateTime`](tr35-dates.md#Time_Zone_Names) Removed `gmtZeroOffset` item
 
 

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -538,6 +538,8 @@ In addition to a standard currency format, in which negative currency amounts mi
 
 The `alt="alphaNextToNumber"` pattern, if available, should be used instead of the standard pattern when the currency symbol character closest to the numeric value has Unicode General Category L (letter). The `alt="alphaNextToNumber"` pattern is typically provided when the standard currency pattern does not have a space between currency symbol and numeric value; the alphaNextToNumber variant adds a non-breaking space if appropriate for the locale.
 
+When formatting a currency using its ISO 4217 code, implementations should use the standard `<currencyFormat>` pattern, specifically selecting the `alt="alphaNextToNumber"` pattern variant if it exists.
+
 The `alt="noCurrency"` pattern can be used when a currency-style format is desired but without the currency symbol. This sort of display may be used when formatting a large column of values all in the same currency, for example. For compact currency formats (`<currencyFormatLength type="short">`), the compact decimal format (`<decimalFormatLength type="short">`) should be used if no `alt="noCurrency"` pattern is present (so the `alt="noCurrency"` pattern is typically not needed for compact currency formats).
 
 ```xml


### PR DESCRIPTION
Adds a dedicated paragraph in Section 2.4.2 (`#Currency_Formats`) of UTS #35 Part 3 (Numbers) clarifying that when formatting a currency using its ISO 4217 code, implementations should use the standard `<currencyFormat>` pattern, specifically selecting the `alt="alphaNextToNumber"` pattern variant if it exists.

See: https://unicode-org.atlassian.net/browse/CLDR-19649?focusedCommentId=212032