### PR TITLE
CLDR-13978 VerifyJson tool to verify cldr-json has everything

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -79,17 +79,17 @@ import org.unicode.cldr.util.XPathParts;
 @CLDRTool(alias = "ldml2json", description = "Convert CLDR data to JSON")
 public class Ldml2JsonConverter {
     // Icons
-    private static final String DONE_ICON = "✅";
-    private static final String GEAR_ICON = "⚙️";
-    private static final String NONE_ICON = "∅";
+    static final String DONE_ICON = "✅";
+    static final String GEAR_ICON = "⚙️";
+    static final String NONE_ICON = "∅";
     private static final String PACKAGE_ICON = "📦";
     private static final String SECTION_ICON = "📍";
-    private static final String TYPE_ICON = "📂";
+    static final String TYPE_ICON = "📂";
     private static final String WARN_ICON = "⚠️";
 
     // File prefix
-    private static final String CLDR_PKG_PREFIX = "cldr-";
-    private static final String FULL_TIER_SUFFIX = "-full";
+    static final String CLDR_PKG_PREFIX = "cldr-";
+    static final String FULL_TIER_SUFFIX = "-full";
     private static final String MODERN_TIER_SUFFIX = "-modern";
     private static final String EXTERNAL_RAW_SUFFIX = ".txt";
     private static Logger logger = Logger.getLogger(Ldml2JsonConverter.class.getName());
@@ -535,6 +535,37 @@ public class Ldml2JsonConverter {
         return result;
     }
 
+    public static Set<String> getActiveNumberingSystems(CLDRFile file) {
+        Set<String> activeNumberingSystems = new TreeSet<>();
+        activeNumberingSystems.add("latn"); // Always include latin script numbers
+        for (String np : LdmlConvertRules.ACTIVE_NUMBERING_SYSTEM_XPATHS) {
+            String ns = file.getWinningValue(np);
+            if (ns != null && ns.length() > 0) {
+                activeNumberingSystems.add(ns);
+            }
+        }
+        return activeNumberingSystems;
+    }
+
+    public static String getNumberingSystem(final String fullPath) {
+        XPathParts xpp = XPathParts.getFrozenInstance(fullPath);
+        String currentNS = xpp.getAttributeValue(2, "numberSystem");
+        return currentNS;
+    }
+
+    public static boolean isFallbackValue(CLDRFile file, String path) {
+        final CLDRFile.Status status = new CLDRFile.Status();
+        final String localeWhereFound = file.getSourceLocaleID(path, status);
+
+        // language[@type="apc"] = apc : missing
+        if (localeWhereFound.equals(XMLSource.CODE_FALLBACK_ID)) return true;
+
+        // language[@type="fa_AF"] = fa (AF)
+        // or Farsi (Afghanistan) : missing
+        if (status.pathWhereFound.equals(GlossonymConstructor.PSEUDO_PATH)) return true;
+        return false;
+    }
+
     /** Read all paths in the file, and assign each to a JSONSection. Return the map. */
     private Map<JSONSection, List<CldrItem>> mapPathsToSections(
             AtomicInteger readCount,
@@ -544,24 +575,17 @@ public class Ldml2JsonConverter {
             SupplementalDataInfo sdi)
             throws IOException, ParseException {
         final Map<JSONSection, List<CldrItem>> sectionItems = new TreeMap<>();
-
+        final Set<String> activeNumberingSystems = getActiveNumberingSystems(file);
         String locID = file.getLocaleID();
         Matcher noNumberingSystemMatcher = LdmlConvertRules.NO_NUMBERING_SYSTEM_PATTERN.matcher("");
         Matcher numberingSystemMatcher = LdmlConvertRules.NUMBERING_SYSTEM_PATTERN.matcher("");
         Matcher rootIdentityMatcher = LdmlConvertRules.ROOT_IDENTITY_PATTERN.matcher("");
         Matcher versionMatcher = LdmlConvertRules.VERSION_PATTERN.matcher("");
-        Set<String> activeNumberingSystems = new TreeSet<>();
-        activeNumberingSystems.add("latn"); // Always include latin script numbers
-        for (String np : LdmlConvertRules.ACTIVE_NUMBERING_SYSTEM_XPATHS) {
-            String ns = file.getWinningValue(np);
-            if (ns != null && ns.length() > 0) {
-                activeNumberingSystems.add(ns);
-            }
-        }
+
         final DtdType fileDtdType = file.getDtdType();
         CoverageInfo covInfo = CLDRConfig.getInstance().getCoverageInfo();
         // read paths in DTD order. The order is critical for JSON processing.
-        final CLDRFile.Status status = new CLDRFile.Status();
+
         for (Iterator<String> it =
                         file.iteratorWithoutExtras(
                                 "", DtdData.getInstance(fileDtdType).getDtdComparator(null));
@@ -570,15 +594,7 @@ public class Ldml2JsonConverter {
             final String path = it.next();
 
             // Check for code-fallback and constructed first, even before fullpath and value
-            final String localeWhereFound = file.getSourceLocaleID(path, status);
-            if (!includeRedundant
-                    && (localeWhereFound.equals(XMLSource.CODE_FALLBACK_ID)
-                            || // language[@type="apc"] = apc : missing
-                            status.pathWhereFound.equals(
-                                    GlossonymConstructor
-                                            .PSEUDO_PATH))) { // language[@type="fa_AF"] = fa (AF)
-                // or Farsi (Afghanistan) : missing
-                // Don't include these paths.
+            if (!includeRedundant && isFallbackValue(file, path)) {
                 continue;
             }
 
@@ -621,8 +637,7 @@ public class Ldml2JsonConverter {
             // Filter out non-active numbering systems data unless fullNumbers is specified.
             numberingSystemMatcher.reset(fullPath);
             if (numberingSystemMatcher.matches() && !fullNumbers) {
-                XPathParts xpp = XPathParts.getFrozenInstance(fullPath);
-                String currentNS = xpp.getAttributeValue(2, "numberSystem");
+                final String currentNS = getNumberingSystem(fullPath);
                 if (currentNS != null && !activeNumberingSystems.contains(currentNS)) {
                     continue;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConfigFileReader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConfigFileReader.java
@@ -1,11 +1,16 @@
 package org.unicode.cldr.json;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
 import org.unicode.cldr.json.Ldml2JsonConverter.JSONSection;
 import org.unicode.cldr.json.Ldml2JsonConverter.RunType;
 import org.unicode.cldr.util.FileProcessor;
@@ -122,5 +127,23 @@ public class LdmlConfigFileReader {
         j.section = "other";
         j.pattern = PatternCache.get(".*");
         sections.add(j);
+    }
+
+    static LoadingCache<RunType, LdmlConfigFileReader> allConfigs =
+            CacheBuilder.newBuilder()
+                    .build(
+                            new CacheLoader<RunType, LdmlConfigFileReader>() {
+
+                                @Override
+                                public LdmlConfigFileReader load(@Nonnull RunType key)
+                                        throws Exception {
+                                    LdmlConfigFileReader r = new LdmlConfigFileReader();
+                                    r.read(null, key);
+                                    return r;
+                                }
+                            });
+
+    public static LdmlConfigFileReader getInstance(RunType t) throws ExecutionException {
+        return allConfigs.get(t);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/VerifyJson.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/VerifyJson.java
@@ -1,0 +1,404 @@
+package org.unicode.cldr.json;
+
+import static org.unicode.cldr.json.Ldml2JsonConverter.*;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.unicode.cldr.json.Ldml2JsonConverter.JSONSection;
+import org.unicode.cldr.json.Ldml2JsonConverter.RunType;
+import org.unicode.cldr.tool.Option.Options;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CLDRTool;
+import org.unicode.cldr.util.CalculatedCoverageLevels;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.Timer;
+
+@CLDRTool(alias = "verifyjson", description = "Verify JSON matches XML")
+public class VerifyJson {
+    private Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+    private CLDRConfig config = CLDRConfig.getInstance();
+    private CalculatedCoverageLevels coverage = CalculatedCoverageLevels.getInstance();
+    private Options options;
+
+    public VerifyJson(Options options) {
+        this.options = options;
+    }
+
+    public static class NestedJsonPath {
+        final String leaf;
+        final NestedJsonPath parent;
+        final int n;
+
+        // root
+        private NestedJsonPath(final NestedJsonPath parent, final String child, final int n) {
+            this.parent = parent;
+            this.leaf = child;
+            this.n = n;
+        }
+
+        static NestedJsonPath root() {
+            return new NestedJsonPath(null, ".", 0);
+        }
+
+        NestedJsonPath of(final String child) {
+            return new NestedJsonPath(this, child, n + 1);
+        }
+
+        @Override
+        public final String toString() {
+            if (parent == null) return leaf;
+            final String parStr = parent.toString();
+            if (parStr.equals(".")) return leaf;
+            return parent.toString() + "." + leaf;
+        }
+
+        public NestedJsonPath of(int i) {
+            return of("[" + Integer.toString(i) + "]");
+        }
+
+        /** Get leaf name of element n from the top. get(0) gets the root item, always null */
+        public String get(int i) {
+            if (i > n) return null; // out of range
+            if (i == n) return leaf;
+            return parent.get(i);
+        }
+
+        public int size() {
+            return n + 1;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println(GEAR_ICON + " " + Ldml2JsonConverter.class.getName() + " options:");
+        final Options options =
+                new Options(
+                                "Usage: VerifyJson [OPTIONS]\n"
+                                        + "This program validates that JSON data contains everything that is in XML.\n")
+                        .add(
+                                "destdir",
+                                'd',
+                                ".*",
+                                CLDRPaths.GEN_DIRECTORY,
+                                "Destination directory for json files to check, defaults to CldrUtility.GEN_DIRECTORY")
+                        .add(
+                                "match",
+                                'm',
+                                ".*",
+                                ".*",
+                                "Regular expression to define only specific locales or files to be generated")
+                        .add(
+                                "type",
+                                't',
+                                "(" + Ldml2JsonConverter.RunType.valueList() + ")",
+                                "all",
+                                "Type of CLDR data being tested, such as main, supplemental, or segments. All gets all.")
+                        .add(
+                                "draftstatus",
+                                's',
+                                "(approved|contributed|provisional|unconfirmed)",
+                                "unconfirmed",
+                                "The minimum draft status of the output data")
+                        .add(
+                                "coverage",
+                                'l',
+                                "(minimal|basic|moderate|modern|comprehensive|optional)",
+                                "optional",
+                                "The maximum coverage level of the output data")
+                        .add(
+                                "fullnumbers",
+                                'n',
+                                "(true|false)",
+                                "false",
+                                "Whether the output JSON should output data for all numbering systems, even those not used in the locale");
+
+        options.parse(args, true);
+
+        VerifyJson v = new VerifyJson(options);
+
+        Timer overallTimer = new Timer();
+        overallTimer.start();
+        final String rawType = options.get("type").getValue();
+
+        if (RunType.all.name().equals(rawType)) {
+            // Running all types
+            for (final RunType t : RunType.values()) {
+                if (t == RunType.all) continue;
+                System.out.println();
+                System.out.println(
+                        TYPE_ICON + "#######################  " + t + " #######################");
+                Timer subTimer = new Timer();
+                subTimer.start();
+                v.processType(t.name());
+                System.out.println(
+                        TYPE_ICON + " " + t + "\tFinished in " + subTimer.toMeasureString());
+                System.out.println();
+            }
+        } else {
+            v.processType(rawType);
+        }
+
+        System.out.println(
+                "\n\n###\n\n"
+                        + DONE_ICON
+                        + " Finished everything in "
+                        + overallTimer.toMeasureString());
+    }
+
+    private void processType(String type) {
+        processType(RunType.valueOf(type));
+    }
+
+    private void processType(RunType type) {
+        if (type != RunType.main) {
+            System.out.println(NONE_ICON + " - skipping unsupported " + type);
+        }
+        System.out.println("Locale: " + " - " + type);
+        processMain();
+    }
+
+    private void processMain() {
+        final Pattern p = Pattern.compile(options.get("match").getValue());
+        for (final CLDRLocale l : config.getCldrFactory().getAvailableCLDRLocales()) {
+            if (!coverage.isLocaleReallyAtLeastBasic(l.getBaseName())) {
+                continue; // skip sub-basic
+            }
+            if (!p.matcher(l.getBaseName()).matches()) {
+                continue;
+            }
+            try {
+                processMainLocale(l);
+            } catch (Throwable t) {
+                System.err.println("FAIL: " + t + " for " + l);
+            }
+        }
+    }
+
+    // TODO: print these on exit.
+    private Set<String> missingDirs = new HashSet<>();
+    // TODO: fail if this is an empty set (i.e. nothing read)
+    private Set<String> foundDirs = new HashSet<>();
+
+    private void processMainLocale(CLDRLocale l) throws Throwable {
+        // todo: param
+        final RunType type = RunType.main;
+        final LdmlConfigFileReader configFile = LdmlConfigFileReader.getInstance(type);
+        final Collection<String> packages = configFile.getPackages();
+        final Collection<JSONSection> sections = configFile.getSections();
+        System.out.println(" " + l);
+        final CLDRFile f = config.getCldrFactory().make(l.getBaseName(), true);
+        // values we've already seen
+        final Set<String> seenValues = new HashSet<>();
+        for (final String p : packages) {
+            String n = p;
+            if (RunType.main.tiered()) {
+                n = CLDR_PKG_PREFIX + n + FULL_TIER_SUFFIX;
+            }
+            final String dirName =
+                    options.get("destdir").getValue()
+                            + "/cldr-json/"
+                            + n
+                            + "/"
+                            + type.name()
+                            + "/"
+                            + l.toLanguageTag()
+                            + "/";
+            if (!Files.isDirectory(Path.of(dirName))) {
+                missingDirs.add(dirName);
+                continue;
+            } else {
+                foundDirs.add(dirName);
+            }
+            for (final JSONSection s : sections) {
+                // not every section is in every package. so just try them all
+                // TODO: try s.package
+                final String jsonName = dirName + s.section + ".json";
+                try (JsonReader json = new JsonReader(new FileReader(jsonName)); ) {
+                    extractJsonDocument(json, seenValues);
+                } catch (FileNotFoundException fnf) {
+                    // ... ignored, just skip a missing file
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    System.err.println("Some other error on " + jsonName);
+                }
+            }
+        }
+
+        Set<String> missingValues = new HashSet<>();
+        Set<String> activeNumberingSystems = Ldml2JsonConverter.getActiveNumberingSystems(f);
+        // COPYPASTA from Ldml2JsonConverter
+        Matcher noNumberingSystemMatcher = LdmlConvertRules.NO_NUMBERING_SYSTEM_PATTERN.matcher("");
+        Matcher numberingSystemMatcher = LdmlConvertRules.NUMBERING_SYSTEM_PATTERN.matcher("");
+        Matcher rootIdentityMatcher = LdmlConvertRules.ROOT_IDENTITY_PATTERN.matcher("");
+        Matcher versionMatcher = LdmlConvertRules.VERSION_PATTERN.matcher("");
+
+        for (final String xpath : f.iterableWithoutExtras()) {
+            final String fullPath = f.getFullXPath(xpath);
+
+            final CLDRFile file = f;
+            final boolean resolve = true;
+            final boolean fullNumbers = false;
+            // COPYPASTA from Ldml2JsonConverter
+
+            // TODO: CLDR-17790 known issue - //ldml/identity inherits when it shouldn't.
+            rootIdentityMatcher.reset(fullPath);
+            if (rootIdentityMatcher.matches() && !file.isHere(fullPath)) {
+                continue;
+            }
+
+            // discard version stuff
+            versionMatcher.reset(fullPath);
+            if (versionMatcher.matches()) {
+                // drop //ldml/identity/version entirely.
+                continue;
+            }
+
+            // automatically filter out number symbols and formats without a numbering system
+            noNumberingSystemMatcher.reset(fullPath);
+            if (noNumberingSystemMatcher.matches()) {
+                continue;
+            }
+
+            // Filter out non-active numbering systems data unless fullNumbers is specified.
+            numberingSystemMatcher.reset(fullPath);
+            if (numberingSystemMatcher.matches() && !fullNumbers) {
+                final String currentNS = getNumberingSystem(fullPath);
+                if (currentNS != null && !activeNumberingSystems.contains(currentNS)) {
+                    continue;
+                }
+            }
+
+            if (xpath.endsWith("/alias")) continue;
+            if (Ldml2JsonConverter.isFallbackValue(f, xpath)) continue;
+            final String v = f.getStringValue(xpath);
+
+            // Handle the no inheritance marker.
+            if (resolve && CldrUtility.NO_INHERITANCE_MARKER.equals(v)) {
+                continue;
+            }
+            if (seenValues.contains(v)) continue; // already processed
+            if (missingValues.contains(v)) continue; // already complained
+            System.err.println(xpath + " = " + v + " - missing");
+            missingValues.add(v);
+        }
+        if (!missingValues.isEmpty()) {
+            System.err.println("Missing value count: " + missingValues.size());
+        }
+    }
+
+    void extractJsonDocument(JsonReader json, Set<String> seenValues) throws IOException {
+        extractJsonObject(json, seenValues, NestedJsonPath.root());
+    }
+
+    void extractJsonObject(JsonReader json, Set<String> seenValues, final NestedJsonPath parentKey)
+            throws IOException {
+        json.beginObject();
+
+        String key = null;
+        while (json.hasNext()) {
+
+            switch (json.peek()) {
+                case JsonToken.NAME:
+                    key = json.nextName();
+                    break;
+
+                case JsonToken.END_OBJECT:
+                    json.endObject();
+                    key = null;
+                    /* NOTREACHED */
+                    return;
+
+                case JsonToken.BEGIN_OBJECT:
+                    // it's a sub object.
+                    extractJsonObject(json, seenValues, parentKey.of(key));
+                    key = null;
+                    break;
+                case JsonToken.BEGIN_ARRAY:
+                    // it's a sub array.
+                    extractJsonArray(json, seenValues, parentKey.of(key));
+                    key = null;
+                    break;
+
+                case JsonToken.STRING:
+                    extractJsonString(json, seenValues, parentKey.of(key));
+                    key = null;
+                    break;
+
+                default:
+                case JsonToken.NULL:
+                case JsonToken.NUMBER:
+                case JsonToken.BOOLEAN:
+                    // skip all of these.
+                    json.skipValue();
+                    key = null;
+            }
+        }
+        json.endObject();
+    }
+
+    void extractJsonArray(JsonReader json, Set<String> seenValues, NestedJsonPath parentKey)
+            throws IOException {
+        json.beginArray();
+        int n = 0;
+        while (json.hasNext()) {
+            switch (json.peek()) {
+                case JsonToken.NAME:
+                    // shouldn't happen, this is an array
+                    json.nextName();
+                    break;
+
+                case JsonToken.END_ARRAY:
+                    json.endArray();
+                    /* NOTREACHED */
+                    return;
+
+                case JsonToken.BEGIN_OBJECT:
+                    // it's a sub object.
+                    extractJsonObject(json, seenValues, parentKey.of(n++));
+                    break;
+                case JsonToken.BEGIN_ARRAY:
+                    // it's a sub array.
+                    extractJsonArray(json, seenValues, parentKey.of(n++));
+                    break;
+
+                case JsonToken.STRING:
+                    extractJsonString(json, seenValues, parentKey.of(n++));
+                    break;
+
+                default:
+                case JsonToken.NULL:
+                case JsonToken.NUMBER:
+                case JsonToken.BOOLEAN:
+                    n++;
+                    // skip all of these.
+                    json.skipValue();
+            }
+        }
+        json.endArray();
+    }
+
+    void extractJsonString(JsonReader json, Set<String> seenValues, NestedJsonPath parentKey)
+            throws IOException {
+        // read nextstr
+        final String str = json.nextString();
+
+        // skip if in identity
+        if ("identity".equals(parentKey.get(3))) return; // main.mt.identity = skip.
+
+        seenValues.add(str);
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/VerifyJson.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/VerifyJson.java
@@ -6,6 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.unicode.cldr.json.Ldml2JsonConverter.JSONSection;
@@ -26,6 +28,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CLDRTool;
 import org.unicode.cldr.util.CalculatedCoverageLevels;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.TempPrintWriter;
 import org.unicode.cldr.util.Timer;
 
 @CLDRTool(alias = "verifyjson", description = "Verify JSON matches XML")
@@ -34,9 +37,13 @@ public class VerifyJson {
     private CLDRConfig config = CLDRConfig.getInstance();
     private CalculatedCoverageLevels coverage = CalculatedCoverageLevels.getInstance();
     private Options options;
+    private final boolean VERBOSE = false;
+    private final String DESTDIR;
 
     public VerifyJson(Options options) {
         this.options = options;
+        // TODO CLDR-13978: verbose as an option
+        this.DESTDIR = options.get("destdir").getValue();
     }
 
     public static class NestedJsonPath {
@@ -164,11 +171,12 @@ public class VerifyJson {
     }
 
     private void processType(RunType type) {
-        if (type != RunType.main) {
+        if (type == RunType.main) {
+            System.out.println("Locale: " + " - " + type);
+            processMain();
+        } else {
             System.out.println(NONE_ICON + " - skipping unsupported " + type);
         }
-        System.out.println("Locale: " + " - " + type);
-        processMain();
     }
 
     private void processMain() {
@@ -188,13 +196,13 @@ public class VerifyJson {
         }
     }
 
-    // TODO: print these on exit.
+    // TODO CLDR-13978: print these on exit.
     private Set<String> missingDirs = new HashSet<>();
-    // TODO: fail if this is an empty set (i.e. nothing read)
+    // TODO CLDR-13978: fail if this is an empty set (i.e. nothing read)
     private Set<String> foundDirs = new HashSet<>();
 
     private void processMainLocale(CLDRLocale l) throws Throwable {
-        // todo: param
+        // TODO CLDR-13978:type could be a param
         final RunType type = RunType.main;
         final LdmlConfigFileReader configFile = LdmlConfigFileReader.getInstance(type);
         final Collection<String> packages = configFile.getPackages();
@@ -203,20 +211,14 @@ public class VerifyJson {
         final CLDRFile f = config.getCldrFactory().make(l.getBaseName(), true);
         // values we've already seen
         final Set<String> seenValues = new HashSet<>();
+        final Set<String> readFiles = new TreeSet<>();
         for (final String p : packages) {
             String n = p;
             if (RunType.main.tiered()) {
                 n = CLDR_PKG_PREFIX + n + FULL_TIER_SUFFIX;
             }
             final String dirName =
-                    options.get("destdir").getValue()
-                            + "/cldr-json/"
-                            + n
-                            + "/"
-                            + type.name()
-                            + "/"
-                            + l.toLanguageTag()
-                            + "/";
+                    DESTDIR + "/cldr-json/" + n + "/" + type.name() + "/" + l.toLanguageTag() + "/";
             if (!Files.isDirectory(Path.of(dirName))) {
                 missingDirs.add(dirName);
                 continue;
@@ -225,9 +227,10 @@ public class VerifyJson {
             }
             for (final JSONSection s : sections) {
                 // not every section is in every package. so just try them all
-                // TODO: try s.package
+                // TODO CLDR-13978: try s.package as a filter
                 final String jsonName = dirName + s.section + ".json";
                 try (JsonReader json = new JsonReader(new FileReader(jsonName)); ) {
+                    readFiles.add(jsonName);
                     extractJsonDocument(json, seenValues);
                 } catch (FileNotFoundException fnf) {
                     // ... ignored, just skip a missing file
@@ -238,13 +241,31 @@ public class VerifyJson {
             }
         }
 
+        if (foundDirs.isEmpty() || readFiles.isEmpty()) {
+            System.err.println("Did not read any files. Check paths: " + missingDirs.toString());
+            System.exit(1); // TODO CLDR-13978: improve failure
+        }
+
+        System.err.println(
+                "# for "
+                        + type
+                        + " / "
+                        + l
+                        + " Read dirs: "
+                        + foundDirs.size()
+                        + ", Read files: "
+                        + readFiles.size());
+
         Set<String> missingValues = new HashSet<>();
         Set<String> activeNumberingSystems = Ldml2JsonConverter.getActiveNumberingSystems(f);
-        // COPYPASTA from Ldml2JsonConverter
+        // TODO CLDR-13978: COPYPASTA from Ldml2JsonConverter
         Matcher noNumberingSystemMatcher = LdmlConvertRules.NO_NUMBERING_SYSTEM_PATTERN.matcher("");
         Matcher numberingSystemMatcher = LdmlConvertRules.NUMBERING_SYSTEM_PATTERN.matcher("");
         Matcher rootIdentityMatcher = LdmlConvertRules.ROOT_IDENTITY_PATTERN.matcher("");
         Matcher versionMatcher = LdmlConvertRules.VERSION_PATTERN.matcher("");
+
+        // collect missing paths in order, so we can report them.
+        Set<String> missingXpaths = new TreeSet<>();
 
         for (final String xpath : f.iterableWithoutExtras()) {
             final String fullPath = f.getFullXPath(xpath);
@@ -252,11 +273,13 @@ public class VerifyJson {
             final CLDRFile file = f;
             final boolean resolve = true;
             final boolean fullNumbers = false;
-            // COPYPASTA from Ldml2JsonConverter
 
-            // TODO: CLDR-17790 known issue - //ldml/identity inherits when it shouldn't.
+            // TODO CLDR-13978: COPYPASTA from Ldml2JsonConverter
+
+            // TODO: CLDR-17790 known issue
+            // ldml/identity inherits when it shouldn't.
             rootIdentityMatcher.reset(fullPath);
-            if (rootIdentityMatcher.matches() && !file.isHere(fullPath)) {
+            if (rootIdentityMatcher.matches() /* && !file.isHere(fullPath) */) {
                 continue;
             }
 
@@ -292,12 +315,55 @@ public class VerifyJson {
             }
             if (seenValues.contains(v)) continue; // already processed
             if (missingValues.contains(v)) continue; // already complained
-            System.err.println(xpath + " = " + v + " - missing");
+            if (VERBOSE) System.err.println(xpath + " = " + v + " - missing");
             missingValues.add(v);
+            missingXpaths.add(xpath);
         }
         if (!missingValues.isEmpty()) {
-            System.err.println("Missing value count: " + missingValues.size());
+            System.err.println(" Missing value count: " + missingValues.size());
+        } else {
+            System.out.println(" - no missing values");
         }
+        writeMissingReport(type, l, f, missingXpaths, missingValues);
+    }
+
+    void writeMissingReport(
+            RunType type,
+            CLDRLocale locale,
+            CLDRFile file,
+            Collection<String> missingXpaths,
+            Collection<String> missingValues) {
+        File chartDir = new File(DESTDIR + "/missing");
+        chartDir.mkdirs();
+
+        File outFile =
+                new File(
+                        chartDir,
+                        String.format("missing-%s-%s.md", type.name(), locale.getBaseName()));
+
+        try (TempPrintWriter out = new TempPrintWriter(outFile)) {
+            out.println(
+                    String.format(
+                            "# Missing XPath report — %s / %s (%s)",
+                            type.name(), locale.getBaseName(), locale.getDisplayName()));
+            out.println("");
+            out.println("## Statistics");
+            out.println("");
+            out.println(String.format("- Missing values: %d", missingValues.size()));
+            // TODO CLDR-13978: include other params such as draftStatus
+            out.println("");
+            out.println("## Missing values");
+            out.println("");
+            out.println("_Sorted by example XPath. Only one XPath is shown per value._");
+            out.println("");
+            for (final String xpath : missingXpaths) {
+                final String v = file.getStringValue(xpath);
+                out.println(String.format(" - **%s**", v));
+                out.println(String.format("   `%s`", xpath));
+                out.println();
+            }
+        }
+        System.out.println("# Wrote: " + outFile);
     }
 
     void extractJsonDocument(JsonReader json, Set<String> seenValues) throws IOException {


### PR DESCRIPTION
CLDR-13978

### Review Notes

#### Sample output files: https://gist.github.com/srl295/e00694807b586db378047f0dff4ef39a

- This is definitely confirming https://unicode-org.atlassian.net/browse/CLDR-19774 for example.
- There are also person names examples, and perhaps some other items that either are missing or should be ignored


#### Sample run:

```shell
$ cldr-tool  org.unicode.cldr.json.VerifyJson '-d /home/srl295/src/cldr-json -t main -m en'

?? org.unicode.cldr.json.Ldml2JsonConverter options:
[-d, /home/srl295/src/cldr-json, -t, main, -m, en]
#-d     destdir ?       /home/srl295/src/cldr-json
#-m     match   ?       en
#-t     type    ?       main
#-s     draftstatus     ?       unconfirmed
#-l     coverage        ?       optional
#-n     fullnumbers     ?       false
Locale:  - main
 en
# for main / en Read dirs: 17, Read files: 38
 Missing value count: 67
# Wrote: /home/srl295/src/cldr-json/missing/missing-main-en.md
```

ALLOW_MANY_COMMITS=true